### PR TITLE
Fix image-warn code so that it works with Sphinx 1.4+

### DIFF
--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -20,21 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -21,22 +21,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
-
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/common_conf.py
+++ b/common_conf.py
@@ -37,3 +37,22 @@ intersphinx_mapping = {'copter': (intersphinx_base_url % 'copter',
                        'ardupilot': (intersphinx_base_url % 'ardupilot',
                                   None),
                                   }
+
+############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
+### From:
+##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
+##  And https://github.com/sphinx-doc/sphinx/issues/2429
+
+#Set False to re-enable warnings for non-local images.
+disable_non_local_image_warnings=True
+
+if disable_non_local_image_warnings:
+    import sphinx.environment
+    from docutils.utils import get_source_line
+
+    def _warn_node(self, msg, node, **kwargs):
+        if not msg.startswith('nonlocal image URI found:'):
+            self._warnfunc(msg, '%s:%s' % get_source_line(node),**kwargs)
+
+    sphinx.environment.BuildEnvironment.warn_node = _warn_node
+############ ENDPATH

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -20,21 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -20,20 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -20,21 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -20,20 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -20,20 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -20,22 +20,6 @@ sys.path.insert(0,'../..')
 import common_conf
 
 
-############ PATCH REMOVE NON-LOCAL IMAGE WARNINGS
-### From:
-##  http://stackoverflow.com/questions/12772927/specifying-an-online-image-in-sphinx-restructuredtext-format
-
-if common_conf.disable_non_local_image_warnings:
-    import sphinx.environment
-    from docutils.utils import get_source_line
-
-    def _warn_node(self, msg, node):
-        if not msg.startswith('nonlocal image URI found:'):
-            self._warnfunc(msg, '%s:%s' % get_source_line(node))
-
-    sphinx.environment.BuildEnvironment.warn_node = _warn_node
-############ ENDPATH
-
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
The conf.py for each section had some code to disable warnings on non-local images. This was what was incompatible with Sphinx 1.4 (and why we've been forced to use 1.3). This change fixes that code, and moves it into a common location.