### PR TITLE
Autopilot boards: change wording

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -24,7 +24,7 @@ available if you're still working on those platforms:
 Current boards
 ==============
 
-Open solutions
+Open hardware 
 --------------
 
 .. toctree::
@@ -35,7 +35,7 @@ Open solutions
     Erle-Brain Linux Autopilot <common-erle-brain-linux-autopilot>
     PXFmini Autopilot Shield <common-pxfmini>
 
-Closed solutions
+Closed hardware
 -----------------
 
 .. toctree::


### PR DESCRIPTION
Closed solution might confuse users that software is closed. 