### PR TITLE
Update for rover wiring description

### DIFF
--- a/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
+++ b/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
@@ -118,6 +118,13 @@ signal pins:
 
 -  Pin 3 = Throttle
 -  Pin 1 = Steering
+
+The skid-steer parameters are used to configure vehicles that have fixed wheels and steer like
+tank tracks (do not use servos to steer the wheels but rather use differential speed between the
+left and right wheels). The parameters are: SKID_STEER_OUT and SKID_STEER_IN. When enabled, flight
+controller's ouput RC1 is used for the left track control, and ouput RC3 is used for right track
+control.
+
 [/site]
 
 Connect other peripherals


### PR DESCRIPTION
Update for rover description of its servo outputs wiring when using a tank track style vehicle (skid steering)