### PR TITLE
Add note about including libc6-i386 for px4 on 64 bit linux

### DIFF
--- a/dev/source/docs/building-px4-for-linux-with-make.rst
+++ b/dev/source/docs/building-px4-for-linux-with-make.rst
@@ -104,6 +104,7 @@ following tools and git repositories:
    `github.com/ArduPilot/ardupilot <https://github.com/ArduPilot/ardupilot>`__
 -  gnu make, gawk and associated standard Linux build tools
 -  On Ubuntu you will need to install the genromfs package.
+-  On a 64 bit system you will also need to have installed libc6-i386
 
 Permissions
 -----------

--- a/dev/source/docs/building-px4-for-linux-with-make.rst
+++ b/dev/source/docs/building-px4-for-linux-with-make.rst
@@ -104,7 +104,7 @@ following tools and git repositories:
    `github.com/ArduPilot/ardupilot <https://github.com/ArduPilot/ardupilot>`__
 -  gnu make, gawk and associated standard Linux build tools
 -  On Ubuntu you will need to install the genromfs package.
--  On a 64 bit system you will also need to have installed libc6-i386
+-  On a 64 bit system you will also need to have installed libc6-i386.
 
 Permissions
 -----------


### PR DESCRIPTION
See  https://github.com/ArduPilot/ardupilot/issues/3999