### PR TITLE
Remove ampersand from EKF/DCM failsafe page's title

### DIFF
--- a/copter/source/docs/ekf-inav-failsafe.rst
+++ b/copter/source/docs/ekf-inav-failsafe.rst
@@ -1,7 +1,7 @@
 .. _ekf-inav-failsafe:
 
 ==============================
-EKF / DCM Check &amp; Failsafe
+EKF / DCM Check Failsafe
 ==============================
 
 Copter 3.2 adds a DCM heading check and an :ref:`EKF (Extended Kalman Filter - Pixhawk only) <common-apm-navigation-extended-kalman-filter-overview>` check


### PR DESCRIPTION
Remove ampersand from EKF/DCM failsafe page