### PR TITLE
correcting typo in title

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -1,7 +1,7 @@
-.. _common-ads-b-reciever:
+.. _common-ads-b-receiver:
 
 ==============
-ADS-B Reciever
+ADS-B Receiver
 ==============
 
 This article shows the **experimental** integration of an `Automatic Dependent Surveillance Broadcast <https://en.wikipedia.org/wiki/Automatic_dependent_surveillance_%E2%80%93_broadcast>`__


### PR DESCRIPTION
just correcting a typo.  Reciever should be receiver.
Since the name of the page also has this typo, this might impact the links to the page.