### PR TITLE
add "python-wxtools"

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -69,7 +69,7 @@ this:
 
 ::
 
-    sudo apt-get install python-matplotlib python-serial python-wxgtk2.8 python-lxml
+    sudo apt-get install python-matplotlib python-serial python-wxgtk2.8 python-wxtools python-lxml
     sudo apt-get install python-scipy python-opencv ccache gawk git python-pip python-pexpect
     sudo pip install pymavlink MAVProxy
 


### PR DESCRIPTION
Because on the latest version of Ubuntu 16.04 ,you can no longer install 'python-wxgtk2.8' using apt-get command. And this will lead to a failure when you ues 'sim_vehicle.sh' to open the console and map window. Hence, use 'sudo apt-get install python-wxtools' will fix this problem.