### PR TITLE
Added Commercial Section to Geotagging wiki.

### DIFF
--- a/common/source/docs/common-geotagging-images-with-mission-planner.rst
+++ b/common/source/docs/common-geotagging-images-with-mission-planner.rst
@@ -311,22 +311,36 @@ Alternative Commercial Hardware Solutions
 DROTAG - Airborne Projects
 --------------------------
 
-The `DROTAG <https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/>`_ (airborneprojects.com) is a small board (55x27mm at 21g) that connects to an APM compatible Flight Controller (like Pixhawk) through the one of the any available TELEMETRY port and through a MicroUSB cable to the camera. That's it. Nothing more is needed. 
+With the appropriate mission from Mission Planner(or similar),
+`DROTAG <https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/>`_ (airborneprojects.com) enables APM compatible Flight Controllers (like Pixhawk)
+to *Configure, Trigger and Geo-Tag* your Digital Camera pictures in
+the air. It works through one of the available TELEMETRY ports and
+through a microUSB cable to the camera. That's it.
 
-With the appropriate mission planning you will have your taken pictures automatically geotagged by DROTAG in the MicroSD card at the time you land, with no need for any post-processing. DROTAG also has a way to configure most of your camera settings. This is specially important if you use your aerial camera for other earthly uses.
+You will have your taken pictures automatically Geo-Tagged by DROTAG in
+the microSD card at the time you land, with no need for any post-processing.
+DROTAG also has a way to configure most of your camera settings. This is
+specially important if you often change your camera settings manually for
+other uses.
 
-Airborne Project's also offers a comprehensive `DROTAG manual <https://www.airborneprojects.com/wp-content/uploads/2016/06/Manual.Gstreamer.Arietta.pdf>`_ (airborneprojects.com) with before flight checklists detailed explanations for diagnosis and other tips.
+Airborne Project's also provides a comprehensive
+`DROTAG manual <https://www.airborneprojects.com/wp-content/uploads/2016/06/Manual.Gstreamer.Arietta.pdf>`_ (airborneprojects.com)
+with before flight checklists, detailed explanations for diagnosis and
+other tips.
 
 
- .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/text_image_1-1200x548.jpg
+.. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/text_image_1-1200x548.jpg
     :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
     :width: 100%
- .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/3.jpg
+    :align: left
+.. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/3.jpg
     :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
     :width: 50%
- .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/2.jpg
+    :align: left
+.. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/2.jpg
     :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
     :width: 49%
+    :align: left
 
 
 Acknowledgements

--- a/common/source/docs/common-geotagging-images-with-mission-planner.rst
+++ b/common/source/docs/common-geotagging-images-with-mission-planner.rst
@@ -305,6 +305,30 @@ working with specific cameras:
 -  `Geotag GoPro Images with a Pixhawk Log File <http://tuffwing.com/support/geotag_gopro_images_with_pixhawk_log.html>`__
    (tuffwing.com)
 
+Alternative Commercial Hardware Solutions
+=========================================
+
+DROTAG - Airborne Projects
+--------------------------
+
+The `DROTAG <https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/>`_ (airborneprojects.com) is a small board (55x27mm at 21g) that connects to an APM compatible Flight Controller (like Pixhawk) through the one of the any available TELEMETRY port and through a MicroUSB cable to the camera. That's it. Nothing more is needed. 
+
+With the appropriate mission planning you will have your taken pictures automatically geotagged by DROTAG in the MicroSD card at the time you land, with no need for any post-processing. DROTAG also has a way to configure most of your camera settings. This is specially important if you use your aerial camera for other earthly uses.
+
+Airborne Project's also offers a comprehensive `DROTAG manual <https://www.airborneprojects.com/wp-content/uploads/2016/06/Manual.Gstreamer.Arietta.pdf>`_ (airborneprojects.com) with before flight checklists detailed explanations for diagnosis and other tips.
+
+
+ .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/text_image_1-1200x548.jpg
+    :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
+    :width: 100%
+ .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/3.jpg
+    :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
+    :width: 50%
+ .. image:: https://www.airborneprojects.com/wp-content/uploads/2016/06/2.jpg
+    :target: https://www.airborneprojects.com/product/drotag-onboard-image-tagging-computer/
+    :width: 49%
+
+
 Acknowledgements
 ================
 
@@ -313,3 +337,4 @@ from Sandro Benigno and Guto Santaella updated by Jesus Alvarez.
 
 
 [copywiki destination="copter,plane,rover,planner"]
+


### PR DESCRIPTION
Airborne Projects released a geotagging
solution which might be useful for some people.
The addition is a brief description of the
board, how it connects to the APM and 3 images.

The spirit of the section is similar to the
one found on http://ardupilot.org/copter/docs/common-frsky-telemetry.html#hardware-solutions
which encouraged people to add their own alternative solution.