### PR TITLE
Fix typo in building-px4-with-qtcreator.rst

### DIFF
--- a/dev/source/docs/building-px4-with-qtcreator.rst
+++ b/dev/source/docs/building-px4-with-qtcreator.rst
@@ -42,7 +42,7 @@ that are needed to build an ArduPilot project.
 	  cd /path-to-your-qt-creator-dir/bin
 	  qtcreator.exe
  
-#. Go to the *toolchain\msys\1.0* subdirectory of the PX4 toolchain directory and
+#. Go to the *toolchain\\msys\\1.0* subdirectory of the PX4 toolchain directory and
    make a copy of the file **px4_console.bat** , called **px4_qt_creator.bat**.
    Change this file in *:startsh* section, so that it becomes:
 


### PR DESCRIPTION
*toolchain\msys\1.0* was changed to *toolchain\\msys\\1.0* to show the backslash properly.