### PR TITLE
Correct references of sim_vehicle.sh to sim_vehicle.py

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -168,6 +168,8 @@ to set the ``SERIAL3_`` parameters:
    SERIAL3_PROTOCOL 1
    SERIAL3_BAUD 57600
 
+At the SITL console set the quantity of simulated aircraft to 5 with the command ``param set SIM_ADSB_COUNT 5``. Values 0 - 100 are available. You can also set the altitude ``SIM_ADSB_ALT`` and radius ``SIM_ADSB_RADIUS`` of the simulated aircraft
+
 TODO
 ====
 


### PR DESCRIPTION
Also sneaks in a fix for the way ADSB simulation is triggered.

@magicrub Do the fixes for simulating ADSB in SITL look correct to you?
