### PR TITLE
Enabling serial connection on Raspberry Pi

### DIFF
--- a/dev/source/docs/raspberry-pi-via-mavlink.rst
+++ b/dev/source/docs/raspberry-pi-via-mavlink.rst
@@ -163,6 +163,10 @@ RPi type:
 
     sudo -s
     mavproxy.py --master=/dev/ttyAMA0 --baudrate 57600 --aircraft MyCopter
+    
+.. note::
+    On newer versions of Raspberry Pi 3 the uart serial connection may be disable by default. In order to enable serial
+    connection on the Raspberry Pi edit /boot/config.txt and set enable_uart=1.
 
 Once MAVProxy has started you should be able to type in the following
 command to display the ``ARMING_CHECK`` parameters value


### PR DESCRIPTION
On newer versions of the Raspberry Pi, for some bizarre reason UART is disabled by default. This fix tells readers how to fix that in order for the RPi to talk to the Pixhawk.