### PR TITLE
remove redundant and older text

### DIFF
--- a/copter/source/docs/autotune.rst
+++ b/copter/source/docs/autotune.rst
@@ -104,18 +104,6 @@ Copter 3.3 adds some additional features:
    AutoTune flight mode responds in the same way as raising or lowering
    a ch7/ch8 aux switch high assigned the AutoTune function.
 -  Yaw axis is also autotuned
--  :ref:`AUTOTUNE_AXES <AUTOTUNE_AXES>` allows control of which axis are to be tuned
-   (useful if the vehicle's battery life is not long enough to complete
-   all 3-axis).  "1" = tune roll, "2" = tune pitch, "4" = tune yaw.  Add
-   these numbers together to tune multiple axis in a single session
-   (i.e. "7" = tune all axis)
--  :ref:`AUTOTUNE_AGGR <AUTOTUNE_AGGR>` : Should be in the range of 0.05 to 0.10. Controls the
-   threshold for D-term bounce back and P-term overshoot. This affects
-   the tuning noise immunity (a higher value is more tolerant to flex in
-   the frame or other disturbances that could trick the tuning
-   algorithm).  High values also leads to a tune that rejects external
-   disturbances better.  Lower values result in a tune that is more
-   responsive to pilot input.
 -  Upon a succesful tune these additional values are saved:
 
    -  roll and pitch axis rate feed-forward is enabled


### PR DESCRIPTION
comparing these two lines, I chose the top versions which seemed more verbose and therefore newer:

AUTOTUNE_AGGR...
 Higher values will produce a more aggressive tune but sometimes results in gains that are too high. More specifically this parameter controls the threshold for D-term bounce back and P-term overshoot. 
vs
Controls the threshold for D-term bounce back and P-term overshoot.

AUTOTUNE_AXES ..
This is useful if the vehicle’s battery life is not long enough to complete all 3-axis).
vs
(useful if the vehicle’s battery life is not long enough to complete all 3-axis).
