### PR TITLE
autotest.py parameter was changed.

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-windows.rst
+++ b/dev/source/docs/setting-up-sitl-on-windows.rst
@@ -181,7 +181,7 @@ terminal on the Ubuntu VM:
 
 ::
 
-    ./Tools/autotest/autotest.py build.Copter fly.Copter logs.Copter --map --viewerip=192.168.184.1
+    ./Tools/autotest/autotest.py build.ArduCopter fly.ArduCopter --map --viewerip=192.168.184.1
 
 Next connect with the mission planner after first setting the "COM Port"
 to "UDP".


### PR DESCRIPTION
In previous code, 
  ./Tools/autotest/autotest.py build.Copter fly.Copter logs.Copter --map --viewerip=192.168.184.1

build.Copter, fly.Copter, logs.Copter do not work anymore. 

So I tried to make autotest.py work. 
I think 
    ./Tools/autotest/autotest.py build.ArduCopter fly.ArduCopter --map --viewerip=192.168.184.1
works properly.