### PR TITLE
Update common-ublox-gps.rst

### DIFF
--- a/common/source/docs/common-ublox-gps.rst
+++ b/common/source/docs/common-ublox-gps.rst
@@ -7,7 +7,7 @@ UBlox GPS Configuration
 `3DR uBlox <https://store.3dr.com/products/3dr-gps-ublox-with-compass>`__
 modules are shipped with a `custom configuration <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_GPS/config>`__
 that is compatible with Copter, Rover and Plane.  This article explains
-how you can reprogram the custom configuration if needed (this is not
+how you can connect to u-center to change the onfiguration if needed (this is not
 expected to be necessary for normal users).
 
 .. image:: ../../../images/3DR-ublox.jpg
@@ -16,10 +16,10 @@ expected to be necessary for normal users).
 Connection Option #1 - Mission Planner and Pixhawk as Passthrough
 =================================================================
 
-The mission planner and pixhawk can pass through the communication
+Mission planner and pixhawk can pass through the communication
 between u-center and the GPS by doing the following:
 
--  Connect to Pixhawk to your PC and connect with the Mission Planner
+-  Connect Pixhawk to your PC and connect with the Mission Planner
 -  On the Flight Data screen press Ctrl-F and then select "MAVSerial
    pass"
 -  Open u-center and select Receiver, TCP Client and in the Network
@@ -44,64 +44,3 @@ the `Virtual COM port driver <http://www.ftdichip.com/Drivers/VCP.htm>`__.
 
 .. image:: ../../../images/ublox_gps_ftdi_connection.jpg
     :target: ../_images/ublox_gps_ftdi_connection.jpg
-
-Connection Option #3 - using the APM2 as a passthrough
-======================================================
-
--  Download the `APM / UBlox passthrough <http://download.ardupilot.org/downloads/wiki/advanced_user_tools/GPS_UBLOX_passthrough_APM2.hex>`__
-   binary to your computer
--  Load the binary onto your APM2 using the **Mission Planner's Initial
-   Setup \| Install Firmware \| Load custom firmware link**
-
-..  youtube:: JIgs3UCLfd0
-    :width: 100%
-
-Installing and Uploading the config using U-Center
-==================================================
-
--  Download and install \ `uBlox's u-center software <http://www.u-blox.com/en/evaluation-tools-a-software/u-center/u-center.html>`__
-     Note that this is Windows only.
--  Get the 3DR-Ublox.txt configuration file for Ublox6 or 7
-   `here <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_GPS/config>`__. 
-   For M8N the file is
-   `here <https://raw.githubusercontent.com/diydrones/ardupilot/master/libraries/AP_GPS/config/Marco-Ublox_M8N.txt>`__.
--  Run u-center and connect your uBlox to your computer.
--  Click the magic wand button to enable auto-bauding, then select your
-   appropriate COM port by clicking the down arrow next to the Connect
-   button. If the uBlox is connected to the port you selected, you
-   should see the serial activity indicator blinking in the program's
-   status bar in the lower right-hand corner of the window, it also
-   shows the current baud rate.
-
-   .. image:: ../../../images/COM-port-selection.png
-       :target: ../_images/COM-port-selection.png
-
--  To load the configuration file, In u-center go to the Tools menu,
-   then GPS Configuration. A small window should appear. Add the path to
-   the **3DR-Ublox.txt** configuration file, enable the **Store
-   configuration into BBR/Flash (non-volatile memory)** option, and
-   click the \ **File \| GPS** button.
-
-   .. image:: ../../../images/GPS-configuration.png
-       :target: ../_images/GPS-configuration.png
-   
-   .. image:: ../../../images/configuration-window.png
-       :target: ../_images/configuration-window.png
-
-You may get a \ **Configuration Version Check** alert telling you there
-is a version mismatch between the configuration file and the GPS.  This
-is because the configuration file was written for the GPS software
-version 7.03 so if you have a module with an older version (i.e. 7.01)
-it will complain but will likely still work. Click yes to continue.
-
-You should see a window with a log of the configuration file upload, if
-the upload is successful the window should close automatically and the
-GPS module should now be connected to u-center at 38400 baud. You can
-confirm this by checking the connection status in u-center's status bar.
-
-.. image:: ../../../images/connection-status.png
-    :target: ../_images/connection-status.png
-
-The uBlox module is now ready to be used with Copter, Rover or Plane on
-the APM2, PX4/Pixhawks.
-


### PR DESCRIPTION
Following a discussion on discuss.ardupilot.org/t/m8n-config-file-in-wiki-corrupt/12979/ it was decided that the u-blox config files are far to out of date to be trusted for reliable loading so this removes all mentions of the config loading. However the passthrough/wiring to the GPS and u-center is still a useful tool for debugging any GPS problems, so I've left that. (And removed the APM2 stuff).

Never worked with the wiki before, and the preview tab on the web interface doesn't work so feel free to critique away!