### PR TITLE
Update path to default MAVProxy params

### DIFF
--- a/dev/source/docs/sitl-native-on-windows.rst
+++ b/dev/source/docs/sitl-native-on-windows.rst
@@ -322,7 +322,7 @@ build and start SITL for a 4-core CPU and then launch a *MAVProxy map*:
 
    ::
 
-       param load ..\Tools\autotest\copter_params.parm
+       param load ..\Tools\autotest\default_params\copter.parm
 
 #. You can send commands to SITL from the command prompt and observe the
    results on the map.


### PR DESCRIPTION
Update
sitl-native-on-windows.html
section
"Running SITL and MAVProxy"
part 3

from:
..\Tools\autotest\copter_params.parm
to
..\Tools\autotest\default_params\copter.parm