### PR TITLE
Update compiler version

### DIFF
--- a/dev/source/docs/building-px4-with-make-on-mac.rst
+++ b/dev/source/docs/building-px4-with-make-on-mac.rst
@@ -26,7 +26,7 @@ on Mac OS X (ver 10.6 onwards) with *Make*.
        brew tap PX4/homebrew-px4
        brew update
        brew install genromfs
-       brew install gcc-arm-none-eabi
+       brew install gcc-arm-none-eabi-49
 
 #. Install the latest version of awk using brew (make sure
    **/usr/local/bin** takes precedence in your path):


### PR DESCRIPTION
using brew install gcc-arm-none-eabi would install Gcc version 4.7, a version between 4.9 and 5.9 is needed to compile so in order to install a 4.9 version brew install gcc-arm-none-eabi-49 should be used