### PR TITLE
Update raspberry-pi-via-mavlink.rst

### DIFF
--- a/dev/source/docs/raspberry-pi-via-mavlink.rst
+++ b/dev/source/docs/raspberry-pi-via-mavlink.rst
@@ -46,6 +46,10 @@ The easiest way to setup the RPi is to flash one of the existing :ref:`APSync <a
 - For `Linux follow these instructions <https://www.raspberrypi.org/documentation/installation/installing-images/linux.md>`__.
 - For `Mac follow these instructions <https://www.raspberrypi.org/documentation/installation/installing-images/mac.md>`__.
 
+.. note::
+
+   When extracting the contents of the compressed file on Mac you may get into an infinite loop of extraction (.xz to .cpgz and vice versa) using the default Archiver. In order to correctly extract the .img file you will need to use the Unarchiver (http://unarchiver.c3.cx/unarchiver).
+
 Setting up the Pixhawk
 ======================
 


### PR DESCRIPTION
Added a note to use the Unarchiver software to correctly extract the .img file on Mac. Currently the default archiver software gets caught in an infinite loop of extracting between a .xz file and a .cpgz file.