### PR TITLE
Update Installation instructions for python-wxgtk

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -76,7 +76,7 @@ this:
 
 ::
 
-    sudo apt-get install python-matplotlib python-serial python-wxgtk2.8 python-wxtools python-lxml
+    sudo apt-get install python-matplotlib python-serial python-wxgtk3.0 python-wxtools python-lxml
     sudo apt-get install python-scipy python-opencv ccache gawk git python-pip python-pexpect
     sudo pip install future pymavlink MAVProxy
 

--- a/dev/source/docs/using-mavexplorer-for-log-analysis.rst
+++ b/dev/source/docs/using-mavexplorer-for-log-analysis.rst
@@ -16,7 +16,7 @@ Linux do this:
 
 ::
 
-    sudo apt-get install python-matplotlib python-serial python-wxgtk2.8 python-lxml
+    sudo apt-get install python-matplotlib python-serial python-wxgtk3.0 python-lxml
     sudo apt-get install python-scipy python-opencv  python-pip python-pexpect python-tk
     sudo pip install --upgrade pymavlink mavproxy
 


### PR DESCRIPTION
python-wxgtk2.8 is deprecated and not available in Ubuntu 16.04. The Mavproxy docs say to use 3.0, so I think it should be fine to update here as well.