### PR TITLE
Update 3DR gps+compass module - RE: no longer produced

### DIFF
--- a/common/source/docs/common-installing-3dr-ublox-gps-compass-module.rst
+++ b/common/source/docs/common-installing-3dr-ublox-gps-compass-module.rst
@@ -4,7 +4,11 @@
 3DR UBlox GPS + Compass Module
 ==============================
 
-This page covers the installation of the `3DR UBlox GPS + Compass module <https://store.3dr.com/products/3dr-gps-ublox-with-compass>`__.
+This page covers the installation of the `3DR UBlox GPS + Compass module <https://3dr.com/support/articles/207681053/3dr_ublox_gps_with_compass_kit/>`__.
+
+.. note::
+
+    The 3DR UBlox GPS + Compass module is no longer produced or sold by 3DR, but it is still available from a few vendors. In addition, this page is still relevant to the installation of most gps modules. A number of alternatives can be found :ref:`here <common-positioning-landing-page>`.
 
 Overview
 ========

--- a/common/source/docs/common-positioning-landing-page.rst
+++ b/common/source/docs/common-positioning-landing-page.rst
@@ -10,15 +10,14 @@ positioning technologies:
 .. figure:: ../../../images/gps-landing-page.jpg
    :target: ../_images/gps-landing-page.jpg
 
-   Reach RTK Receiver
 
 .. toctree::
     :maxdepth: 1
 
-    3DR UBlox GPS + Compass <common-installing-3dr-ublox-gps-compass-module>
+    Mayan Robotics M8N Gps+Compass Module <https://store.mrobotics.io/mRo-GPS-u-Blox-Neo-M8N-HMC5983-Compass-p/gps002-mr.htm>
+    JDrones GPS Options <http://store.jdrones.com/GPS_s/193.htm>
     Zubax GNSS: GPS, Compass, Barometer <common-zubax-gnss-positioning-module-gps-compass-and-barometer>
     Emlid Reach RTK Receiver <common-reach-rtk-receiver>
     Septentrio AsteRx-mUAS RTK GPS <common-gps-septentrio>
     Trimble BD930 <common-gps-trimble>
     GPS – How it Works <common-gps-how-it-works>
-


### PR DESCRIPTION
The 3DR gps page is referenced in assembly instructions (http://ardupilot.org/copter/docs/assembly-instructions.html), so I figured it would be best to simply notify that that particular module isn't being made anymore (as I understand). Maybe a generalized gps page would be the next step?