### PR TITLE
Update Java note to specify 32 bit

### DIFF
--- a/dev/source/docs/editing-the-code-with-eclipse.rst
+++ b/dev/source/docs/editing-the-code-with-eclipse.rst
@@ -9,7 +9,7 @@ and building for Pixhawk/PX4 targets.
 
 .. note::
 
-   Ensure that you have Java installed before Eclipse can run.  If not, Java can be installed from `here <https://www.java.com/en/>`__.
+   Ensure that you have Java (32-bit) installed before Eclipse can run.  If not, Java can be installed from `here <https://www.java.com/en/>`__.
 
 Preconditions
 =============


### PR DESCRIPTION
The java link automatically took me to the 64 bit download (which I did not catch before installing). This caused errors when trying to open eclipse (Java returned error code 13).