### PR TITLE
clarify where vehicle starts in circle mode

### DIFF
--- a/copter/source/docs/circle-mode.rst
+++ b/copter/source/docs/circle-mode.rst
@@ -4,11 +4,8 @@
 Circle Mode
 ===========
 
-Circle will orbit a point of interest with the nose of the vehicle
-pointed towards the center.
-
-The radius of the circle can be controlled by modifying the
-CIRCLE_RADIUS parameter.
+Circle will orbit a point located CIRCLE_RADIUS centimeters in front
+of the vehicle with the nose of the vehicle pointed at the center.
 
 .. note::
 


### PR DESCRIPTION
the documentation on Circle mode wasn't clear about whether the
vehicle position when engaging circle mode was the center of the
circle or the edge of the circle.  This change attempts to make that
less ambiguous.