### PR TITLE
Update Intel Aero RTF page

### DIFF
--- a/common/source/docs/common-intel-aero-rtf.rst
+++ b/common/source/docs/common-intel-aero-rtf.rst
@@ -10,7 +10,7 @@ Intel Aero RTF
 The `Intel Aero RTF vehicle <https://software.intel.com/en-us/aero/drone-dev-kit>`__ includes the :ref:`Intel Aero compute board <common-intel-aero-overview>`,
 `Vision Accessory Kit <https://software.intel.com/en-us/aero/vision-kit>`__ and a `Spektrum DXe transmitter <http://spektrumrc.com/Products/Default.aspx?ProdId=SPM1000>`__.
 
-Within the vehicle is an ARM CPU flight controller board which can run ArduPilot (replacing the pre-loaded non-ArduPilot software).
+Within the vehicle is an STM32F427V flight controller board which can run ArduPilot (replacing the pre-loaded non-ArduPilot software).
 In this way, the higher powered :ref:`Intel Aero compute board <common-intel-aero-overview>` is used as a `companion computer <http://ardupilot.org/dev/docs/companion-computers.html>`__.
 
 ..  youtube:: DZm9S0lxiEg
@@ -22,20 +22,21 @@ Additional parts to buy
 Although "Ready-to-fly" some additional parts are required to complete the upgrade and fly with ArduPilot.
 
 - Lipo battery `3S <https://hobbyking.com/en_us/multistar-high-capacity-3s-5200mah-multi-rotor-lipo-pack.html>`__ or `4S <https://hobbyking.com/en_us/multistar-high-capacity-4s-5200mah-multi-rotor-lipo-pack.html>`__
-- 2GB (or larger) USB thumb drive (`like this one <https://www.amazon.com/SanDisk-Cruzer-Glide-Drive-SDCZ60-008G-B35/dp/B007YX9O94/ref=sr_1_4?ie=UTF8&qid=1492397331&sr=8-4>`__)
+- 2GB (or larger) USB thumb drive (`like this one <https://www.amazon.com/SanDisk-Cruzer-Glide-Drive-SDCZ60-008G-B35/dp/B007YX9O94/ref=sr_1_4?ie=UTF8&qid=1492397331&sr=8-4>`__) is needed for updating to the last release of the Linux distro.
 - Micro USB OTG to USB cable (`like this one <https://www.amazon.com/Micro-USB-OTG-Go-Adapter/dp/B005GI2VMG>`__)
 - `Spektrum USB programming cable <https://www.spektrumrc.com/Products/Default.aspx?ProdID=SPMA3065>`__ (optional)
     
 Upgrading the vehicle's software
 ================================
 
-The Aero RTF ships with out-of-date BIOS, compute-board and flight controller software which all should be upgraded.
+The Aero RTF may not have the last BIOS and Linux operating system. The Linux distro on Aero needs to be updated to version 1.2
+in order for the flight controller to be flashed with ArduPilot.
 
 `Official Setup Instuctions from Intel <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup>`__ should be followed which will ask you to:
 
 - Download the latest OS image (aka "intel-aero-image-intel-aero.iso") and Capsule/BIOS (aka "capsule-01.00.12-r0.core2_64.rpm") from the `Intel Download Center <https://downloadcenter.intel.com/download/26500/UAV-installation-files-for-Intel-Aero-Platform>`__
 - `Flash the BIOS to Aero compute board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-bios>`__
-- `Flash the OS image to the Aero compute board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flash-intel-aero-linux-distribution>`__ using a 2GB USB thumb drive
+- `Flash the OS image to the Aero compute board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flash-intel-aero-linux-distribution>`__ using a USB thumb drive
 - `Upgrade the FPGA <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-fpga>`__ using a .jam file included on the OS image
 
 The final step is to copy the arducopter.px4 firwmware to the Aero compute board and then flash it to the flight board:
@@ -43,6 +44,11 @@ The final step is to copy the arducopter.px4 firwmware to the Aero compute board
 - Download the latest aero-fc ardupilot firmware from `firmware.ardupilot.org <http://firmware.ardupilot.org/Copter/latest/>`__ (`issue <https://github.com/ArduPilot/ardupilot/issues/6058>`__ to make firmware available soon)
 - Copy the above firmware to the Aero compute board in much the same way the BIOS's .rpm file was copied
 - `Flash the flight controller board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-flight-controller-rtf-only>`__ with the ardupilot.px4 firmware
+
+If you are developing ArduPilot, you can flash directly from the command line after compiling. Refer to `Build instructions <https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md>`__ for more detailed instructions, but it's basically the following commands:
+
+    ./waf configure --board aerofc-v1
+    ./waf copter --upload
 
 Connecting and configuring with a ground station
 ================================================
@@ -58,10 +64,14 @@ Connecting and configuring with a ground station
 
 - regular :ref:`compass <common-compass-calibration-in-mission-planner>`, :ref:`Radio <common-radio-control-calibration>`, :ref:`accelerometer calibration <common-accelerometer-calibration>` is required (:ref:`ESC calibration <esc-calibration>` is not required)
 
+Connecting the Transmitter
+==========================
+
+The transmitter that comes with the RTF is an off the shelf DSM-X DXe and a SPM4648 receiver, which is of autobind mode. The transmitter should always be powered on before the receiver (which is normally powered together with the vehicle).  If powered on after the vehicle it won't connect.  To overcome this you can simply disconnect the cable from the receiver, or go through the binding process, which involves powering on the transmitter while holding the "BIND/PANIC/TRAINER" button pressed. More information about the binding and connectiong can be found on the `receiver documentation <https://www.horizonhobby.com/pdf/SPM4648-Manual-EN.pdf>`__.
+
 Known Issues with the Transmitter
 =================================
 
-- the transmitter should always be powered on before the vehicle.  If powered on after the vehicle it may lose its binding to the receiver.  They can be re-bound by turning off the transmitter and then turning it back on again with the "BIND/PANIC/TRAINER" button pressed.
 - the "MOTOR/THROW" switch on the back-right of the transmitter should always be left in the "ARM" position or the throttle value sent to the vehicle will be too low
 - the "FLAP" switch is connected to Ch7 so it can be used as an auxiliary switch but position "0" is actually On, "2" is off.
 - "AUX" and "RATE" switches are not configured to have any effect


### PR DESCRIPTION
  - Clarify the microcontroller model
  - Add version requirement for the Aero side of the software
  - Add instruction for developers to build and update the flight
    controller
  - Make a section for connecting the transmitter
