### PR TITLE
Update sitl-native-on-windows.rst

### DIFF
--- a/dev/source/docs/sitl-native-on-windows.rst
+++ b/dev/source/docs/sitl-native-on-windows.rst
@@ -148,6 +148,7 @@ Install required Python packages
    python -m ensurepip --user
    python -m pip install --user future
    python -m pip install --user lxml
+   python -m pip install --user uavcan
 
 
 Download and make ArduPilot


### PR DESCRIPTION
Add the line to install uavcan. In my experience it was required to build master 4ce0a8e24eb2d336a682325e332c4a8b772e25d1.