### PR TITLE
Update license-gplv3.rst

### DIFF
--- a/dev/source/docs/license-gplv3.rst
+++ b/dev/source/docs/license-gplv3.rst
@@ -4,7 +4,7 @@
 License (GPLv3)
 ===============
 
-ArduPilot (including Copter, Plane, Rover and AntennaTracker) and the Mission Planner are free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3 as published by the `Free Software Foundation <http://www.fsf.org/>`__.
+ArduPilot (including Copter, Plane, Rover, Sub and AntennaTracker) and the ground control software (including Mission Planner, APM Planner2 and MAVProxy) are free software: you can redistribute it and/or modify it under the terms of the GNU General Public License version 3 as published by the `Free Software Foundation <http://www.fsf.org/>`__.
 
 This program is distributed in the hope that it will be useful, but
 WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
trivia - added sub to the list of ardupilot platforms, and added APM Planner and MAVProxy to gcs types.