### PR TITLE
Replace Erle repo with ArduPilot repo

### DIFF
--- a/dev/source/docs/building-for-erle-brain-2.rst
+++ b/dev/source/docs/building-for-erle-brain-2.rst
@@ -35,8 +35,8 @@ Clone the source:
 
     #Move to home
     cd ~/
-    #Clone the repository in home
-    git clone https://github.com/erlerobot/ardupilot.git
+    #Clone the ArduPilot repository in home
+    git clone https://github.com/ArduPilot/ardupilot.git
     cd ardupilot
     git submodule update --init --recursive
 


### PR DESCRIPTION
Following a recommendation from Lucas

Lucas De Marchi @lucasdemarchi 
For sure we need to change our docs to point to our repo