### PR TITLE
update docs re: auto mode and arming

### DIFF
--- a/copter/source/docs/arming_the_motors.rst
+++ b/copter/source/docs/arming_the_motors.rst
@@ -7,21 +7,29 @@ Arming the motors
 Arming the motors
 =================
 
-Before arming the motors, make sure all people and objects are clear of
-the propellers. Then do the following:
+Arming the motors causes ArduPilot to apply power to your motors,
+which will cause them to start spinning.  Before arming the motors,
+make sure all people, objects, and any body parts (e.g., hands) are
+clear of the propellers. Then do the following:
+
+.. note::
+
+   You can only arm or disarm in Stabilize, ACRO, AltHold, Loiter,
+   and PosHold modes.  You cannot arm your copter in AUTO
+   mode.
 
 #. Turn on your transmitter
 #. Plug in your LiPo battery.  The red and blue lights should flash for
    a few seconds as the gyros are calibrated (do not move the copter)
 #. The pre-arm checks will run automatically and if any problems are
    found an APM2.x will double blink the red arming light, on a Pixhawk
-   the RGB led will blink yellow.  Please refer to\ :ref:`this page <prearm_safety_check>`.
+   the RGB led will blink yellow.  Please refer to :ref:`this page <prearm_safety_check>`.
 #. Check that your flight mode switch is set to Stabilize, ACRO, AltHold
-   or Loiter.
+   Loiter, or PosHold.
 #. If using a PX4, press the safety button until the light goes solid.
 #. If you are planning on using the autopilot (i.e. Loiter, RTL, Drift,
    Auto or Guided modes) you should wait for 30 seconds after the GPS
-   has gotten 3d lock.  This will give the GPS position time to settle. 
+   has gotten 3d lock.  This will give the GPS position time to settle.
    On APM2 the GPS lock is indicated by the blue LED going solid.  On an
    Pixhawk the RGB LED will blink green.
 #. Arm the motors by holding the throttle down, and rudder right for 5
@@ -30,14 +38,8 @@ the propellers. Then do the following:
    the rudder right for too long (>15 seconds) or you will begin the
    :ref:`AutoTrim <autotrim>` feature.
 #. Once armed, the red arming light should go solid and the propellers
-   will begin to spin slowly.  The speed they spin can be adjusted with
-   the MOT_SPIN_ARMED parameter.
+   will begin to spin.
 #. Raise the throttle to take-off.
-
-.. note::
-
-   You can only arm or disarm in Stabilize, ACRO, AltHold and Loiter
-   mode.
 
 .. note::
 
@@ -47,10 +49,11 @@ the propellers. Then do the following:
 Disarming the motors
 ====================
 
-To disarm the motors do the following:
+Disarming the motors will cause the motors to stop spinning. To disarm
+the motors do the following:
 
 #. Check that your flight mode switch is set to Stabilize, ACRO, AltHold
-   or Loiter
+   Loiter, or PosHold.
 #. Hold throttle at minimum and rudder to the left for 2 seconds
 #. The red arming light should start flashing on the APM2.  On the
    Pixhawk the RGB LED will start flashing green.

--- a/copter/source/docs/auto-mode.rst
+++ b/copter/source/docs/auto-mode.rst
@@ -30,8 +30,12 @@ including returning an HDOP of under 2.0.
 Controls
 ========
 
-AUTO should be set-up as one of the :ref:`Flight Modes <flight-modes>` on the flight
-mode switch.
+AUTO should be set-up as one of the :ref:`Flight Modes <flight-modes>`
+on the flight mode switch.
+
+You must arm your copter before you can engage AUTO mode. See
+:ref:`Arming the motors <arming_the_motors>` for details on how to arm
+your copter.
 
 If starting the mission while the copter is on the ground the pilot
 should ensure the throttle is down, then switch to the Auto flight mode,
@@ -39,7 +43,7 @@ then raise the throttle.  The moment that the throttle is raised above
 zero, the copter will begin the mission.
 
 If starting the mission from the air the mission will begin from the
-first command the moment that the flight mode switch is moved to Auto. 
+first command the moment that the flight mode switch is moved to Auto.
 If the first command in the mission is a take-off command but the
 vehicle is already above the take-off command's altitude the take-off
 command will be considered completed and the vehicle will move onto the


### PR DESCRIPTION
This commit implements suggestions from @hamishwillee in issue #804.
Specifically, it clarifies that a copter must be armed before engaging
auto mode, and it updates the list of armable modes.

This also removes the phrase "...and the propellers will begin to spin
slowly", because the propellers when armed are still spinning fast
enough to cause injury.

I have elected not to include Guided mode in these changes, even
though it is an armable mode.

Closes #804