### PR TITLE
SOLO WIKI: Added solo to left navbar in copter index

### DIFF
--- a/copter/source/index.rst
+++ b/copter/source/index.rst
@@ -176,6 +176,7 @@ Getting more info
    Traditional Helicopters <docs/traditional-helicopters>
    Tricopter <docs/tricopter>
    SingleCopter and CoaxCopter <docs/singlecopter-and-coaxcopter>
+   Solo Enhancements <docs/solo_arducopter_upgrade>
    AutoPilot Hardware Options <docs/common-autopilots>
    Use-Cases and Applications <docs/common-use-cases-and-applications>
    Antenna Tracking <docs/common-antenna-tracking>


### PR DESCRIPTION
Per comments in the other PR for the Solo Wiki, here's the index change to put Solo Enhancements into the left nav bar.