### PR TITLE
Update raspberry-pi-via-mavlink.rst

### DIFF
--- a/dev/source/docs/raspberry-pi-via-mavlink.rst
+++ b/dev/source/docs/raspberry-pi-via-mavlink.rst
@@ -144,7 +144,7 @@ packages:
 ::
 
     sudo apt-get update    #Update the list of packages in the software center
-    sudo apt-get install screen python-wxgtk2.8 python-matplotlib python-opencv python-pip python-numpy python-dev libxml2-dev libxslt-dev
+    sudo apt-get install screen python-wxgtk2.8 python-matplotlib python-opencv python-pip python-numpy python-dev libxml2-dev libxslt-dev python-lxml
     sudo pip install future
     sudo pip install pymavlink
     sudo pip install mavproxy


### PR DESCRIPTION
The package lxml doesn't appear to build if it's installed as a pip dependency - it simply hangs during build. This error was reported in this SO question: https://stackoverflow.com/questions/38782004/raspberry-pi-unable-to-install-lxml-pip-package and the proposed solution seems to work. Hence suggesting it as an addition this documentation.