### PR TITLE
Update license-gplv3.rst

### DIFF
--- a/dev/source/docs/license-gplv3.rst
+++ b/dev/source/docs/license-gplv3.rst
@@ -17,8 +17,7 @@ For more specific details see
 `copying.txt <https://github.com/ArduPilot/ardupilot/blob/master/COPYING.txt>`__
 in the codebase.
 
-The GNU operating system which is under the same license has an
-informative `FAQ here <http://www.gnu.org/licenses/gpl-faq.html>`__.
+The GNU operating system has an informative GPL `FAQ here <http://www.gnu.org/licenses/gpl-faq.html>`__.
 
 Note to developers
 ==================


### PR DESCRIPTION
perhaps nit-picky, but the "GNU Operating System", which for want of a better description is "pure" Linux, actually involves a range of different free software licenses.  So it is not strictly "the same license".  As this deals with licensing I think it best to be correct, that's all.