### PR TITLE
Pixhawk 2.1 URL update

### DIFF
--- a/common/source/docs/common-pixhawk2-overview.rst
+++ b/common/source/docs/common-pixhawk2-overview.rst
@@ -60,7 +60,7 @@ Use the :ref:`Pixhawk Wiring QuickStart <common-pixhawk-wiring-and-quick-start>`
 More Information
 ================
 
-see  `www.pixhawk2.com  <http://www.pixhawk2.com>`__
+see  `www.proficnc.com  <http://www.proficnc.com>`__
 
 More Images
 ===========


### PR DESCRIPTION
www.pixhawk2.com is just a redirect to proficnc, so I  made it proficnc just in case the redirect dies or is repurposed at some stage