### PR TITLE
Add future to required python modules

### DIFF
--- a/dev/source/docs/building-px4-with-make-on-mac.rst
+++ b/dev/source/docs/building-px4-with-make-on-mac.rst
@@ -40,8 +40,7 @@ on Mac OS X (ver 10.6 onwards) with *Make*.
    ::
 
        sudo easy_install pip
-       sudo pip install pyserial
-       sudo pip install future
+       sudo pip install pyserial future catkin_pkg empy
 
 #. Now create your directory and install all the software:
 

--- a/dev/source/docs/building-px4-with-make-on-mac.rst
+++ b/dev/source/docs/building-px4-with-make-on-mac.rst
@@ -41,6 +41,7 @@ on Mac OS X (ver 10.6 onwards) with *Make*.
 
        sudo easy_install pip
        sudo pip install pyserial
+       sudo pip install future
 
 #. Now create your directory and install all the software:
 


### PR DESCRIPTION
The module future is required for mavlink