### PR TITLE
STorM32 wiki corrections

### DIFF
--- a/common/source/docs/common-storm32-gimbal.rst
+++ b/common/source/docs/common-storm32-gimbal.rst
@@ -1,20 +1,20 @@
 .. _common-storm32-gimbal:
 
 =========================
-SToRM32 Gimbal Controller
+STorM32 Gimbal Controller
 =========================
 
-The *SToRM32-BGC* is a relatively low-cost 3-axis brushless gimbal
+The *STorM32-BGC* is a relatively low-cost 3-axis brushless gimbal
 controller that can communicate with ArduPilot (Copter, Plane and Rover)
 using MAVLink.
 
-With 3-axis control and MAVLink interface, the SToRM32 offers more
+With 3-axis control and MAVLink interface, the STorM32 offers more
 capabilities and than the Tarot Gimbal.  MAVLink is a richer
 communications format that PWM and may be used in the future to provide
 additional information to the gimbal including centrefugal force
 corrections leading to better performance during aggressive maneuvers.
 
-Please refer to the `SToRM32-BGC wiki pages <http://www.olliw.eu/storm32bgc-wiki/Main_Page>`__ for more
+Please refer to the `STorM32-BGC wiki pages <http://www.olliw.eu/storm32bgc-wiki/Main_Page>`__ for more
 detailed information including where the gimbals can be purchased.  This
 gimbal has been tested with a `DYS 3-axis brushless gimbal <http://www.hobbyking.com/hobbyking/store/__52136__DYS_Smart3_3_Axis_GoPro_Gimbal_with_AlexMos_Control_Board_BaseCam_.html>`__.
 
@@ -46,7 +46,7 @@ Configuring the gimbal
 ======================
 
 In addition to the regular gimbal configuration described on the
-`SToRM32-BGC wiki <http://www.olliw.eu/storm32bgc-wiki/Getting_Started>`__, the
+`STorM32-BGC wiki <http://www.olliw.eu/storm32bgc-wiki/Getting_Started>`__, the
 MAVlink heartbeats should be enabled through OlliW's o323BGCTool's
 **Tools \| Expert Tool** screen as shown below.
 
@@ -79,7 +79,7 @@ If using Serial4:
 .. image:: ../../../images/SToRM32_MP_Serial2Baud_new.png
     :target: ../_images/SToRM32_MP_Serial2Baud_new.png
 
-Set ``MNT_TYPE`` to "4" to enable the SToRM32 gimbal driver (the Pixhawk
+Set ``MNT_TYPE`` to "4" to enable the STorM32 gimbal driver (the Pixhawk
 must be rebooted for this change to take effect).
 
 Set ``MNT_RC_IN_TILT`` to "6" if you wish to control the gimbal's tilt
@@ -100,17 +100,18 @@ which the gimbal has:
 .. image:: ../../../images/SToRM32_MP_MountParams.png
     :target: ../_images/SToRM32_MP_MountParams.png
 
-Set-up through the Mission Planner (SToRM32 serial protocol)
+Set-up through the Mission Planner (STorM32 serial protocol)
 ============================================================
 
-The custom SToRM32 protocol was added as an alternative to the MAVLink
-protocol and has the same features.  To use the serial protocol use all
-the same settings as above except set the SERIALX_PROTOCOL to "8"
-(where "X" is "1", "2" or "4" depending upon which Pixhawk serial port
-the gimbal is connected to).
+The custom STorM32 protocol was added as an alternative to the MAVLink
+protocol and has the same features. To use the serial protocol use all
+the same settings as above except:
 
-When :ref:`Configuring the Gimbal <common-storm32-gimbal_configuring_the_gimbal>` controller the
-"MAVLink configuration" should be set to "no heartbeat".
+-  Set ``SERIALX_PROTOCOL`` to "8" (where "X" is "1", "2" or "4" depending upon which Pixhawk serial port
+the gimbal is connected to)
+-  Set ``MNT_TYPE`` to "5"
+-  When :ref:`Configuring the Gimbal <common-storm32-gimbal_configuring_the_gimbal>` controller set the
+"MAVLink configuration" parameter to "no heartbeat"
 
 Testing the gimbal
 ==================
@@ -118,7 +119,7 @@ Testing the gimbal
 For instructions for testing the gimbal moves correctly please check the
 :ref:`similar section for the Tarot gimbal <common-tarot-gimbal_testing_the_gimbal_moves_correctly>`.
 
-The video below shows the SToRM32 being tested on Copter3.3. It
+The video below shows the STorM32 being tested on Copter3.3. It
 demonstrates a few features that would not be possible on a 2-axis
 gimbal like the :ref:`Tarot Gimbal <common-tarot-gimbal>`.
 
@@ -129,7 +130,7 @@ Resistor issue on some boards
 =============================
 
 Some in-depth analysis `here on rcgroups <http://www.rcgroups.com/forums/showthread.php?t=2494532&page=5>`__
-turned up that some SToRM32 boards need resistor #4 (shown in pic below)
+turned up that some STorM32 boards need resistor #4 (shown in pic below)
 shorted (i.e. a wire soldered over the top of the resistor to turn it
 into a regular wire) in order for the gimbal controllers messages to get
 through to the Pixhawk.


### PR DESCRIPTION
- I've actually never tested myself, but from the code it seems clear that the serial protocol is activated with MNT_TYPE=5
- it's STorM32 and not SToRM32 ;)