### PR TITLE
Add Solo Smart Battery Calibration Page to Wiki and Link into Solo documentation

### DIFF
--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -54,7 +54,9 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot Discuss Forums <https://discuss.ardupilot.org/c/arducopter/copter-3-5>`_
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
- 
+
+.._solo_battery_calibration.rst:
+
 .. _solo_aducopter_upgrade_process:
 
 |

--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -54,8 +54,7 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot Discuss Forums <https://discuss.ardupilot.org/c/arducopter/copter-3-5>`_
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
-
-.._solo_battery_calibration.rst:
+-  :ref:`Solo Battery Calibration Process <solo_battery_calibration>`
 
 .. _solo_aducopter_upgrade_process:
 

--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -55,6 +55,8 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
 -  _`Solo Battery Calibration Process <solo_battery_calibration>`
+-  :ref:`Solo Battery Calibration Process <solo_battery_calibration>`
+
 
 .. _solo_aducopter_upgrade_process:
 

--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -54,7 +54,7 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot Discuss Forums <https://discuss.ardupilot.org/c/arducopter/copter-3-5>`_
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
--  :ref:`Solo Battery Calibration Process <solo_battery_calibration>`
+-  _`Solo Battery Calibration Process <solo_battery_calibration>`
 
 .. _solo_aducopter_upgrade_process:
 

--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -54,7 +54,6 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot Discuss Forums <https://discuss.ardupilot.org/c/arducopter/copter-3-5>`_
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
--  _`Solo Battery Calibration Process <solo_battery_calibration>`
 -  :ref:`Solo Battery Calibration Process <solo_battery_calibration>`
 
 

--- a/copter/source/docs/solo_battery_calibration.rst
+++ b/copter/source/docs/solo_battery_calibration.rst
@@ -11,3 +11,5 @@ The Solo Smart Battery may need recalibration from time to time.  The following 
 2. Allow the pack the relax for at least 5 hours.  The pack's voltage will climb above 12V during this process.  **DO NOT TRY TO DISCHARGE THE PACK AGAIN.**  Damage to the battery may result.
 3. Charge the pack completely and leave it on the charger for 48 hours.  The pack will relax, then do a balance cycle, then top off.
 4. Let the pack sit for at least 2 hours off the charnger before using the pack.
+
+This tutorial was written by the Solo EE team (Jeff Wurzbach and Philip Rowse).

--- a/copter/source/docs/solo_battery_calibration.rst
+++ b/copter/source/docs/solo_battery_calibration.rst
@@ -1,0 +1,13 @@
+.. _solo_arducopter_other_install:
+
+====================================================================
+3DR Solo - Smart Battery Calibration
+====================================================================
+
+The Solo Smart Battery may need recalibration from time to time.  The following write up details how execute a recalibration of the BMS.
+
+
+**1) Gently discharge the battery pack until it cuts off the first time (this is around 12V).
+**2) Allow the pack the relax for at least 5 hours.  The pack's voltage will climb above 12V during this process.  DO NOT TRY TO DISCHARGE THE PACK AGAIN.  Damage to the battery may result.
+**3) Charge the pack completely and leave it on the charger for 48 hours.  The pack will relax, then do a balance cycle, then top off.
+**4) Let the pack sit for at least 2 hours off the charnger before using the pack.

--- a/copter/source/docs/solo_battery_calibration.rst
+++ b/copter/source/docs/solo_battery_calibration.rst
@@ -7,7 +7,7 @@
 The Solo Smart Battery may need recalibration from time to time.  The following write up details how execute a recalibration of the BMS.
 
 
-**1) Gently discharge the battery pack until it cuts off the first time (this is around 12V).
-**2) Allow the pack the relax for at least 5 hours.  The pack's voltage will climb above 12V during this process.  DO NOT TRY TO DISCHARGE THE PACK AGAIN.  Damage to the battery may result.
-**3) Charge the pack completely and leave it on the charger for 48 hours.  The pack will relax, then do a balance cycle, then top off.
-**4) Let the pack sit for at least 2 hours off the charnger before using the pack.
+1. Gently discharge the battery pack until it cuts off the first time (this is around 12V).
+2. Allow the pack the relax for at least 5 hours.  The pack's voltage will climb above 12V during this process.  **DO NOT TRY TO DISCHARGE THE PACK AGAIN.**  Damage to the battery may result.
+3. Charge the pack completely and leave it on the charger for 48 hours.  The pack will relax, then do a balance cycle, then top off.
+4. Let the pack sit for at least 2 hours off the charnger before using the pack.


### PR DESCRIPTION
This PR adds a tutorial page for calibrating the Solo Smart Battery and the link to that page from the main Solo documentation page.  I am not sure if the link is setup correctly or not, because the preview in my fork does not seem to be rendering out the links correctly.