### PR TITLE
fix link to solo battery calibration

### DIFF
--- a/copter/source/docs/solo_arducopter_upgrade.rst
+++ b/copter/source/docs/solo_arducopter_upgrade.rst
@@ -54,7 +54,8 @@ There are several great resources online for modification ideas,vendors, beta te
 -  `ArduPilot Discuss Forums <https://discuss.ardupilot.org/c/arducopter/copter-3-5>`_
 -  `ArduPilot copter Wiki <http://ardupilot.org/copter/docs/common-advanced-configuration.html>`_
 -  `3DR Pilots Forum <https://3drpilots.com/>`_ 
--  :ref:`Solo Battery Calibration Process <solo_battery_calibration>`
+-  `Solo Battery Calibration Process <solo_battery_calibration>`
+
 
 
 .. _solo_aducopter_upgrade_process:


### PR DESCRIPTION
This is an attempt to fix the broken (text is there, but no hyperlink) link to the Solo Battery Calibration page ( http://ardupilot.org/copter/docs/solo_battery_calibration.html) in the resources section of this page.