### PR TITLE
Tested "MAV_CMD_DO_SET_ROI"

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -3326,7 +3326,7 @@ Copter
 ~~~~~~
 
 Points the :ref:`camera gimbal <common-cameras-and-gimbals>` at the "region
-of interest", and possibly also rotates the nose of the vehicle if the
+of interest", and also rotates the nose of the vehicle if the
 mount type does not support a yaw feature.
 
 After setting the ROI, the camera/vehicle will continue to follow it


### PR DESCRIPTION
Tested using DO_SET_ROI with a fixed camera. Traditional heli keeps nose pointed at ROI. Deleted the "probably" from the wiki.