### PR TITLE
Fix typo that wouldn't show Youtube video

### DIFF
--- a/common/source/docs/common-wiki_editing_guide.rst
+++ b/common/source/docs/common-wiki_editing_guide.rst
@@ -20,6 +20,7 @@ Making a quick edit
 ===================
 
 There is a YouTube tutorial for editing ArduPilot documentation here:
+
 ..  youtube:: fb73F8_MiMg
     :width: 100%
 


### PR DESCRIPTION
The Youtube tutorial of the editing guide wasn't showing up. It was a small typo.