### PR TITLE
Outline that downgrading is very likely to cause a crash.

### DIFF
--- a/plane/source/docs/plane-3-7-to-3-8-migration.rst
+++ b/plane/source/docs/plane-3-7-to-3-8-migration.rst
@@ -18,6 +18,9 @@ If you later downgrade from Plane 3.8 to an earlier version then any
 changes that were made to the RC_* and SERVOn_* parameters will be lost. 
 Upgrading back to 3.8 (or higher) will not copy over any new param changes. 
 This is only an issue if the user decides to downgrade.
+**Please note that downgrading from 3.8 to 3.7 is very likely to cause an
+immediate crash if you lose RCx_REV settings since some of your servos will
+be reserved**
 
 Change to Servo Range Parameters
 ================================

--- a/plane/source/docs/plane-3-7-to-3-8-migration.rst
+++ b/plane/source/docs/plane-3-7-to-3-8-migration.rst
@@ -14,13 +14,12 @@ but it is a complex migration and there is the possibility of errors,
 so careful testing is critical.
 
 .. warning:: 
-If you later downgrade from Plane 3.8 to an earlier version then any 
+If you later downgrade from Plane 3.8 to an earlier version, then any 
 changes that were made to the RC_* and SERVOn_* parameters will be lost. 
 Upgrading back to 3.8 (or higher) will not copy over any new param changes. 
 This is only an issue if the user decides to downgrade.
-**Please note that downgrading from 3.8 to 3.7 is very likely to cause an
-immediate crash if you lose RCx_REV settings since some of your servos will
-be reserved**
+**Please note that downgrading from 3.8 to 3.7 (or earlier) is very likely
+to cause a crash if you do not manually restore channel reversals.**
 
 Change to Servo Range Parameters
 ================================


### PR DESCRIPTION
Existing text does not make it clear that downgrading really requires very careful review of RC settings and that not doing so is very likely to cause a crash due to reversed servos (this did destroy my aircraft).
https://github.com/ArduPilot/ardupilot_wiki/issues/999