### PR TITLE
Spektrum pinout

### DIFF
--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -552,6 +552,37 @@ pinout is standard serial pinout, to connect to a standard FTDI cable
    </tbody>
    </table>
 
+**Spektrum/DSM Port**
+
+The Spektrum/DSM port is for connecting Spektrum DSM-2/DSMX receiver
+modules.
+
+.. raw:: html
+
+   <table border="1" class="docutils">
+   <tbody>
+   <tr>
+   <th>Pin</th>
+   <th>Signal</th>
+   <th>Volt</th>
+   </tr>
+   <tr>
+   <td>1 (white)</td>
+   <td>Signal</td>
+   <td>+3.3V</td>
+   </tr>
+   <tr>
+   <td>2 (black)</td>
+   <td>GND</td>
+   <td>GND</td>
+   </tr>
+   <tr>
+   <td>3 (red)</td>
+   <td>VCC</td>
+   <td>+3.3V</td>
+   </tr>
+   </tbody>
+   </table>
 
 
 Pixhawk system features

--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -82,7 +82,8 @@ RTS, 4 = CTS, 3 = RX, 2 = TX, 1 = 5V.**
 Pixhawk connector pin assignments
 =================================
 
-**TELEM1, TELEM2 ports**
+TELEM1, TELEM2 ports
+~~~~~~~~~~~~~~~~~~~~
 
 .. raw:: html
 
@@ -128,7 +129,8 @@ Pixhawk connector pin assignments
 
 
 
-**GPS port**
+GPS port
+~~~~~~~~
 
 .. raw:: html
 
@@ -174,8 +176,8 @@ Pixhawk connector pin assignments
 
 
 
-**SERIAL 4/5 port - due to space constraints two ports are on one
-connector.**
+SERIAL 4/5 port - due to space constraints two ports are on one connector.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 
@@ -222,7 +224,8 @@ connector.**
    </table>
 
 
-**ADC 6.6V**
+ADC 6.6V
+~~~~~~~~
 
 
 .. raw:: html
@@ -254,7 +257,8 @@ connector.**
 
 
 
-**ADC 3.3V**
+ADC 3.3V
+~~~~~~~~
 
 
 
@@ -297,7 +301,8 @@ connector.**
 
 
 
-**I2C**
+I2C
+~~~
 
 
 
@@ -335,7 +340,8 @@ connector.**
 
 
 
-**CAN**
+CAN
+~~~
 
 
 
@@ -371,7 +377,8 @@ connector.**
    </tbody>
    </table>
 
-**SPI**
+SPI
+~~~
 
 
 
@@ -422,7 +429,8 @@ connector.**
    </tbody>
    </table>
 
-**POWER**
+POWER
+~~~~~
 
 .. raw:: html
 
@@ -464,7 +472,8 @@ connector.**
    </tbody>
    </table>
 
-**SWITCH**
+SWITCH
+~~~~~~
 
 .. raw:: html
 
@@ -493,7 +502,8 @@ connector.**
    </tbody>
    </table>
 
-**Console Port**
+Console Port
+~~~~~~~~~~~~
 
 The system's serial console runs on the port labeled SERIAL4/5. The
 pinout is standard serial pinout, to connect to a standard FTDI cable
@@ -552,7 +562,8 @@ pinout is standard serial pinout, to connect to a standard FTDI cable
    </tbody>
    </table>
 
-**Spektrum/DSM Port**
+Spektrum/DSM Port
+~~~~~~~~~~~~~~~~~
 
 The Spektrum/DSM port is for connecting Spektrum DSM-2/DSMX receiver
 modules.


### PR DESCRIPTION
There are two commits in this PR.

The first adds information about the Spektrum/DSM port on the pixhawk, based on https://discuss.ardupilot.org/t/add-spektrum-port-pinout-diagram-to-pixhawk-pinout-page/23533/3.

The second adds third-level headings to this document, which at least when rendered on github result in named anchors that can be used to link directly to the pinout for a particular port.