### PR TITLE
adding the command "mkdir opt" under the root path

### DIFF
--- a/dev/source/docs/building-ardupilot-onwindows10.rst
+++ b/dev/source/docs/building-ardupilot-onwindows10.rst
@@ -88,6 +88,13 @@ Setup Ardupilot Dev Enviromment for Ubuntu bash on Windows 10
    
        git clone https://github.com/ArduPilot/ardupilot.git
 
+#. Create a folder named "opt" under the root path while WSL doesn't have:
+
+   .. code-block:: python
+       
+       cd /
+       mkdir opt
+       
 #. Run the install-prereqs-ubuntu.sh script:
 
    .. code-block:: python


### PR DESCRIPTION
the pre-install script have "OPT=/opt" while WSL doesn't have it.