### PR TITLE
merge the two commands into one

### DIFF
--- a/dev/source/docs/building-ardupilot-onwindows10.rst
+++ b/dev/source/docs/building-ardupilot-onwindows10.rst
@@ -88,12 +88,11 @@ Setup Ardupilot Dev Enviromment for Ubuntu bash on Windows 10
    
        git clone https://github.com/ArduPilot/ardupilot.git
 
-#. Create a folder named "opt" under the root path while WSL doesn't have:
+#. Create a folder named "opt" under the root path while WSL doesn't have it:
 
    .. code-block:: python
        
-       cd /
-       mkdir opt
+       sudo mkdir /opt
        
 #. Run the install-prereqs-ubuntu.sh script:
 


### PR DESCRIPTION
merge  "cd /   mkdir opt"
into "sudo mkdir /opt"

reason 1: "sudo" shall be added under the root path.
reason 2:  The user shall stay in the current ardupilot path, otherwise the command in the next step will fail.