### PR TITLE
Fix path of autotest script

### DIFF
--- a/dev/source/docs/the-ardupilot-autotest-framework.rst
+++ b/dev/source/docs/the-ardupilot-autotest-framework.rst
@@ -34,7 +34,7 @@ run:
 
 ::
 
-    ./Tools/scripts/autotest.py --list
+    ./Tools/autotest/autotest.py --list
 
 you will see what test scripts you can run. You can then add those
 commands on the command line to run them. For example, to build the
@@ -42,7 +42,7 @@ fixed wing code and then run a test flight do this:
 
 ::
 
-    ./Tools/scripts/autotest/autotest.py build.ArduPlane fly.ArduPlane
+    ./Tools/autotest/autotest.py build.ArduPlane fly.ArduPlane
 
 the results (and log files) will be put in the ../buildlogs directory.
 
@@ -51,7 +51,7 @@ watching autotest a bit less boring! Run it like this:
 
 ::
 
-    ./Tools/scripts/autotest/autotest.py build.ArduPlane fly.ArduPlane --map
+    ./Tools/autotest/autotest.py build.ArduPlane fly.ArduPlane --map
 
 you will actually see the map appear twice, once for when it loads the
 default parameters, and then for the real flight. Just close the first


### PR DESCRIPTION
Fix the path of autotest.py, since the _scripts_ folder doesn't contain the autotest module