### PR TITLE
Fix some types in skyviper.rst development info and add more info about the logging function

### DIFF
--- a/dev/source/docs/skyviper.rst
+++ b/dev/source/docs/skyviper.rst
@@ -131,7 +131,7 @@ Developing the Transmitter Firmware
    make
    ls -l txmain.img
 
-``txmain.img`` can be flashed usng the web interface.  Once the image is transfered, the transmitter will need to be wpoer-rthpower-cycled for the upgrade to continue.  It will take about 15 seconds to flash the new firmware. The LEDs will flash alternately at 1Hz during upgrade.
+``txmain.img`` can be flashed usng the web interface.  Once the image is transfered, the transmitter will need to be power-cycled for the upgrade to continue.  It will take about 15 seconds to flash the new firmware. The LEDs will flash alternately at 1Hz during upgrade.
 
 .. note::
 
@@ -246,7 +246,7 @@ Each test station uses a different set of channels, so are unlikely to interfere
 Log Files
 =========
 
-DataFlash logs are stored on the microSD card of the Sonix in the DATAFLASH directory. You can access them via the filesystem interface of the web interface.
+DataFlash logs are stored on the microSD card of the Sonix in the DATAFLASH directory. You can access them via the filesystem interface of the web interface. If the DATAFLASH directory is not present, then logging may not be enabled by default. In order to enable logging, go to the web interface Flight Parameters page, select Logging, in the drop-down, and set LOGGING_ENABLED to 1. After this you will see the DATAFLASH directory appear. Logs are binary files and can be viewed in several log viewers, including MissionPlanner.
 
 Factory Reset
 =============

--- a/dev/source/docs/skyviper.rst
+++ b/dev/source/docs/skyviper.rst
@@ -246,7 +246,9 @@ Each test station uses a different set of channels, so are unlikely to interfere
 Log Files
 =========
 
-DataFlash logs are stored on the microSD card of the Sonix in the DATAFLASH directory. You can access them via the filesystem interface of the web interface. If the DATAFLASH directory is not present, then logging may not be enabled by default. In order to enable logging, go to the web interface Flight Parameters page, select Logging, in the drop-down, and set LOGGING_ENABLED to 1. After this you will see the DATAFLASH directory appear. Logs are binary files and can be viewed in several log viewers, including MissionPlanner.
+DataFlash logs are stored on the microSD card of the Sonix in the DATAFLASH directory. You can access them via the filesystem interface of the web interface. In order to enable logging while Disarmed, go to the web interface Flight Parameters page, select Logging, in the drop-down, and set LOG_DISARMED to 1:ENABLED. 
+
+Logs are binary files and can be viewed in several log viewers, including MissionPlanner.
 
 Factory Reset
 =============


### PR DESCRIPTION
Made fixes to a few typos and extended information for logging. I also opened an issue on the information about DSMX instead of just changing it here.  In my transmitter, this function seems to be disabled because when I press that button on power on, absolutely nothing happens.  The code clearly indicates that it is being #ifdef-ed out.