### PR TITLE
Fix typo in Copter-Commands-in-Guided-Mode

### DIFF
--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -647,9 +647,9 @@ The protocol definition for this command is here:
 `SET_HOME_POSITION <http://mavlink.org/messages/common#SET_HOME_POSITION>`__
 
 
-.. _copter-commands-in-guided-mode_set_target_attitude:
+.. _copter-commands-in-guided-mode_set_attitude_target:
 
-SET_TARGET_ATTITUDE
+SET_ATTITUDE_TARGET
 -------------------
 
 Sets a desired vehicle attitude. Used by an external controller to command the vehicle (manual controller or other system).


### PR DESCRIPTION
Introduced in 15782b0fd6c9cdee830f825caf7ca7301b6e630b

Appeared in http://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html

Apologies for the carelessness..