### PR TITLE
Link to MAVLink example on Pixhawk-Arduino setup

### DIFF
--- a/dev/source/docs/companion-computers.rst
+++ b/dev/source/docs/companion-computers.rst
@@ -5,11 +5,15 @@ Companion Computers
 ===================
 
 Companion Computers can be used to interface and communicate with
-ArduPilot on a flight controller using the MAVLink protocol.  By doing
+ArduPilot on a flight controller using the MAVLink protocol. By doing
 this your companion computer gets all the MAVLink data produced by the
 autopilot (including GPS data) and can use it to make intelligent
 decisions during flight. For example, "take a photo when the vehicle is
-at these GPS co-ordinates".
+at these GPS co-ordinates", gather and preprocess information from advanced
+sensors or actuate on lights, auxiliary servos or any other interfaces.
+
+Companion Computers let flying tasks to the flight controller (pilot tasks),
+meanwhile adding processing power for other tasks (on board crew tasks).
 
 Related topics on this wiki include:
 
@@ -17,12 +21,13 @@ Related topics on this wiki include:
     :maxdepth: 1
 
     APSync <apsync-intro>
-    Maverick <https://goodrobots.github.io/maverick/#/>
-    FlytOS <flytos>
-    DroneKit Tutorial <droneapi-tutorial>
-    Raspberry Pi <raspberry-pi-via-mavlink>
-    ODroid <odroid-via-mavlink>
-    Intel Edison <intel-edison>
-    NVidia TX1 <companion-computer-nvidia-tx1>
+    Arduino family <https://discuss.ardupilot.org/t/mavlink-and-arduino-step-by-step/25566/1>
     BeaglePilot Project <beaglepilot>
+    DroneKit Tutorial <droneapi-tutorial>
+    FlytOS <flytos>
+    Intel Edison <intel-edison>
+    Maverick <https://goodrobots.github.io/maverick/#/>
+    NVidia TX1 <companion-computer-nvidia-tx1>
+    ODroid <odroid-via-mavlink>
+    Raspberry Pi <raspberry-pi-via-mavlink>
     Turnkey Companion Computer Solutions <turnkey-companion-computer-solutions>

--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -4,11 +4,15 @@
 MAVLink Commands
 ================
 
-ArduPilot has adopted a subset of the MAVLink protocol command set.
+ArduPilot uses a dialect of the MAVLink protocol, which includes elements of the baseline Common message set,
+plus unique messages for ArduPilot, uAvionix (ADS-B), and the NASA Icarous project.  Whilst attempts are made to keep
+the ArduPilot dialect aligned with basic MAVLink, as the MAVLink repository is not controlled by the ArduPilot Project,
+the branch located in the ArduPilot GitHub repository should be used to ensure compatibility with the ArduPilot ecosystem.
+
 Important links for working with commands are listed below:
 
--  `MAVLink Common Message Set in HTML <http://mavlink.org/messages/common>`__ and
-   `XML <https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml>`__
+-  `MAVLink ArduPilot Message Set in HTML <http://mavlink.org/messages/ardupilotmega>`__ and
+   `XML <https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml>`__
    (Protocol Definition).
 -  `MavLink Tutorial for Absolute Dummies (Part–1) <http://api.ning.com/files/i*tFWQTF2R*7Mmw7hksAU-u9IABKNDO9apguOiSOCfvi2znk1tXhur0Bt00jTOldFvob-Sczg3*lDcgChG26QaHZpzEcISM5/MAVLINK_FOR_DUMMIESPart1_v.1.1.pdf>`__
    (from `Shyam Balasubramanian <http://api.ning.com/files/i*tFWQTF2R*7Mmw7hksAU-u9IABKNDO9apguOiSOCfvi2znk1tXhur0Bt00jTOldFvob-Sczg3*lDcgChG26QaHZpzEcISM5/MAVLINK_FOR_DUMMIESPart1_v.1.1.pdf>`__).
@@ -26,6 +30,7 @@ Other relevant topics on this wiki include:
     :maxdepth: 1
 
     Command Package Format <ardupilot-mavlink-command-package-format>
+    Adding a new MAVLink Message <code-overview-adding-a-new-mavlink-message>
     Copter Commands (Guided Mode) <copter-commands-in-guided-mode>
     Plane Commands (Guided Mode) <plane-commands-in-guided-mode>
     MAVLink Routing <mavlink-routing-in-ardupilot>

--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -7,11 +7,12 @@ MAVLink Commands
 ArduPilot has adopted a subset of the MAVLink protocol command set.
 Important links for working with commands are listed below:
 
--  `MAVLINK Common Message Set in HTML <http://mavlink.org/messages/common>`__ and
+-  `MAVLink Common Message Set in HTML <http://mavlink.org/messages/common>`__ and
    `XML <https://github.com/mavlink/mavlink/blob/master/message_definitions/v1.0/common.xml>`__
    (Protocol Definition).
 -  `MavLink Tutorial for Absolute Dummies (Part–1) <http://api.ning.com/files/i*tFWQTF2R*7Mmw7hksAU-u9IABKNDO9apguOiSOCfvi2znk1tXhur0Bt00jTOldFvob-Sczg3*lDcgChG26QaHZpzEcISM5/MAVLINK_FOR_DUMMIESPart1_v.1.1.pdf>`__
    (from `Shyam Balasubramanian <http://api.ning.com/files/i*tFWQTF2R*7Mmw7hksAU-u9IABKNDO9apguOiSOCfvi2znk1tXhur0Bt00jTOldFvob-Sczg3*lDcgChG26QaHZpzEcISM5/MAVLINK_FOR_DUMMIESPart1_v.1.1.pdf>`__).
+-  `MAVLink communications between Pixhawk and Arduino <https://discuss.ardupilot.org/t/mavlink-and-arduino-step-by-step/25566>`__ (example from `Juan Pedro López <https://discuss.ardupilot.org/t/mavlink-and-arduino-step-by-step/25566>`__).
 -  :ref:`MAVLink Mission Command Messages (MAV_CMD) <planner:common-mavlink-mission-command-messages-mav_cmd>`
    (ArduPilot supported subset).
 -  User-modifiable MAVLink parameters: 


### PR DESCRIPTION
About a  month ago I published an example on using MAVLink to communicate a Pixhawk with an on board Arduino. I think it could be very useful to beginers as it is focused on a practical approach.
I am proposing an addition in the MAVLink examples list and a second one to the Companion Computers list.