### PR TITLE
Up-to-date on HighSierra 10.13.3

### DIFF
--- a/dev/source/docs/building-setup-mac.rst
+++ b/dev/source/docs/building-setup-mac.rst
@@ -4,7 +4,7 @@
 Setting up the Build Environment (MacOSX)
 =========================================
 
-This article shows how to setup your build environment on Mac OS X (ver 10.6 onwards).
+This article shows how to setup a minimal build environment on MacOS (ver 10.6 onwards).
 
 ..  youtube:: wLK2wLwEXm4
     :width: 100%
@@ -12,19 +12,23 @@ This article shows how to setup your build environment on Mac OS X (ver 10.6 onw
 Setup steps
 -----------
 
-#. Install `Homebrew <http://brew.sh>`__ for Mac OS X
-
-#. Install xcode and say YES to install Command Line Tools
+#. MacOS will alert you when you enter a command in the terminal that requires Xcode Command Line Tools. You can also install Xcode Command Line Tools manually
 
    ::
    
        xcode-select --install
-       
+
+#. Install `Homebrew <http://brew.sh>`__ for MacOS (Homebrew is a respected package manager for MacOS)
+
+   ::
+   
+      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+ 
 #. Install the following packages using brew
 
    ::
 
-       brew tap PX4/homebrew-px4
+       brew tap ardupilot/homebrew-px4
        brew update
        brew install genromfs
        brew install gcc-arm-none-eabi
@@ -41,7 +45,7 @@ Setup steps
    ::
 
        sudo easy_install pip
-       sudo pip install pyserial future catkin_pkg empy
+       sudo pip install pyserial future empy
 
 #. Follow the `MAVProxy's install instructions <https://ardupilot.github.io/MAVProxy/html/getting_started/download_and_installation.html#mac>`__ if you plan to use the simulator.
 


### PR DESCRIPTION
Added the link to the ardupilot tap
removed reference to catkin_pkg

@rmackay9 perhaps also editing the doc title from MacOS X just to the correct name MacOS