### PR TITLE
Plane: add reference to airspeed calibration on starting-up-and-calibrating page

### DIFF
--- a/plane/source/docs/starting-up-and-calibrating-arduplane.rst
+++ b/plane/source/docs/starting-up-and-calibrating-arduplane.rst
@@ -42,6 +42,15 @@ If the flight controller has a :ref:`safety switch <common-safety-switch-pixhawk
    safety mechanism to prevent accidental disarming during flight and
    accidental arming during transportation.
 
+Calibrate and check the Airspeed sensor (if present)
+====================================================
+
+If the vehicle has an :ref:`airspeed sensor <airspeed>` then the :ref:`pre-flight checks described here <calibrating-an-airspeed-sensor>` should be performed before each flight.
+
+.. image:: ../images/preflight.jpg
+    :target: ../_images/preflight.jpg
+    :width: 250px
+
 Wait for GPS lock
 =================
 


### PR DESCRIPTION
Added a small new section to the starting-up-and-calibrating page to tell people to calibrate and test the airspeed sensor (if present)