### PR TITLE
Plane: Update & Simplify Elevon Setup

### DIFF
--- a/plane/source/docs/guide-elevon-plane.rst
+++ b/plane/source/docs/guide-elevon-plane.rst
@@ -7,8 +7,11 @@ Elevon Planes
 Elevon planes (also known as delta-wings) are popular for their
 simplicity and robustness.
 
-A typical elevon plane will have 3 servo outputs. One will be the left
-elevon, another for right elevon and the 3rd for throttle.
+A typical elevon plane will have 2 servo outputs and one throttle
+output.
+
+Setting Up Your Plane
+=====================
 
 The recommended setup for APM:Plane with elevon planes is:
 
@@ -24,36 +27,41 @@ The recommended setup for APM:Plane with elevon planes is:
 .. warning:: You should remove the propeller from your aircraft before
              starting your setup.
 
-Setting Up Your Plane
-=====================
+RC Input Setup & Reversal
+=========================
 
-After you have setup your :ref:`RC inputs <rc-throw-trim>`, the next
-step is to setup your 3 outputs.
+Set up your :ref:`RC inputs <rc-throw-trim>` through the calibration
+process, and verify them for reversal. Reversals are critical to the
+process. Commanding pitch up and roll right must result in higher PWM
+values for RCn_in channnels. If the value does not respond correctly
+reverse the channel before continuing.
 
 You can connect your 3 servo cables to any output of your autopilot,
 although using the defaults listed above is recommended.
 
-Servo Reversal
-==============
+Servo Setup & Reversal
+======================
 
-The next step is to get the reversals right. You should connect the
+The next step is to get the servo reversals right. You should connect the
 battery (with propeller removed) and turn on your RC transmitter. Now
-switch to MANUAL mode and disable the safety switch (if fitted).
+switch to FBWA mode and press the safety switch (if fitted) to enable
+servo outputs.
 
-At this point your RC transmitter should have control of your 2
-elevons. You now should adjust the reversal of the two elevons and the
-order of the two elevons so that you get correct movement.
+At this point both the autopilot and RC transmitter should have control
+of the elevons. You now should adjust the reversal and function of the two 
+servos so that you get correct movement.
 
-Correct movement for an elevon plane is:
+Correct FBWA (automatic stabilization)movement for an elevon plane WITHOUT 
+PROVIDING RC INPUT is:
 
 .. raw:: html
 
    <table border="1" class="docutils">
    <tr><th>Input</th><th>Action</th></tr>
-   <tr><td>Right Roll</td><td>Left elevon goes down and right elevon goes up</td><tr>
-   <tr><td>Left Roll</td><td>Right elevon goes down and left elevon goes up</td><tr>
-   <tr><td>Pull back on pitch</td><td>Both elevons go up</td></tr>
-   <tr><td>Push forward on pitch</td><td>Both elevons go down</td></tr>
+   <tr><td>Roll right</td><td>Left elevon goes up and right elevon goes down</td><tr>
+   <tr><td>Roll left</td><td>Right elevon goes up and left elevon goes down</td><tr>
+   <tr><td>Pitch down</td><td>Both elevons go up</td></tr>
+   <tr><td>Pitch up</td><td>Both elevons go down</td></tr>
    </table>
 
 If your movements are incorrect then you need to adjust which servo
@@ -62,40 +70,40 @@ output is left/right and the reversals of each elevon.
 The parameters you should adjust are SERVO1_REVERSED, SERVO2_REVERSED,
 SERVO1_FUNCTION and SERVO2_FUNCTION.
 
-For example, if your left elevon on servo 1 is moving the wrong way,
-and SERVO1_REVERSED is currently 0, then changing it to 1 will change
-the direction it moves.
+If your left elevon on servo 1 is moving the wrong way for both pitch and
+roll corrections, set SERVO1_REVERSED to 1.
 
-Confirm Servo Reversal
-======================
+If your left elevon on servo 1 responds correctly to pitch, but incorrectly
+to roll, change the SERVO1_FUNCTION.
 
-The above servo reversal test in MANUAL mode assumes your RC inputs
-have been correctly setup. As it is so easy to get that wrong, you
-should also do a stabilisation check.
+Repeat the servo reversal or function change for the right elevon.
 
-Switch the plane to FBWA mode and with the transmitter sticks centered
-move the plane as follows:
+.. note:: In rare instances, both servo 1 and 2 will indivicually respond
+          correctly with the same FUNCTION. This is OK.
+          
+.. note:: while rolling the aircraft the autopilot will automatically
+          try to put in some up pitch, as it knows that upward pitch is needed
+          in turns. So you will probably see an asymmetry in elevon
+          movement. The elevon that is going down will not go down very far, or
+          (depending on your settings) may not go down at all.
+          
 
-.. raw:: html
-         
-   <table border="1" class="docutils">
-   <tr><th>Movement</th><th>Action</th></tr>
-   <tr><td>Pitch nose up</td><td>Both elevons go down</td><tr>
-   <tr><td>Pitch nose down</td><td>Both elevons go up</td><tr>
-   <tr><td>Roll plane right</td><td>Right elevon goes down and left elevon goes up</td><tr>
-   <tr><td>Roll plane left</td><td>Left elevon goes down and right elevon goes up</td><tr>
-   </table>
+Verify RC Inputs
+=================
 
-Note that while rolling the aircraft the autopilot will automatically
-try to put in some up pitch, as it knows that upward pitch is needed
-in turns. So you will probably see an asymmetry in elevon
-movement. The elevon that is going down will not go down very far, or
-(depending on your settings) may not go down at all.
+Now that the elevons are configured correctly, verify your RC inputs.
+In FBWA with the airplane level, command pitch-up from your transmitter
+and confirm that the elevons both rise. Command a roll to the right
+from your transmitter and confirm that the the right elevon rises and
+the left elevon lowers. If this is incorrect, read the :ref:`RC inputs <rc-throw-trim>` 
+page to fix your rc
+
+Switch the plane to MANUAL mode and confirm the same behavior.
 
 Servo Trim
 ==========
 
-Now switch back to MANUAL mode in order to adjust the servo trim
+Now stay in MANUAL mode in order to adjust the servo trim
 values. The servo trim is in the SERVOn_TRIM parameters.
 
 You should adjust the trim values so that the servo is centered when


### PR DESCRIPTION
Emphasized correct RC input reversal prior to starting this. Use stabilization to configure rather than transmitter. Adds case-by-case instructions when to reverse or change function.

In response to https://github.com/ArduPilot/ardupilot_wiki/issues/1204