### PR TITLE
Dev - updated build instructions for Cygwin on Windows

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -5,11 +5,9 @@
 Setting up the waf Build Environment on Windows using Cygwin
 ============================================================
 
-These setup instructions describe how to setup `Cygwin <http://www.cygwin.com/>`__ on Windows so that waf can run natively and be used for building.
+These setup instructions describe how to setup `Cygwin <http://www.cygwin.com/>`__ on Windows so that waf (the build system) can run natively and be used for building.
 
-   .. warning::
-
-      These instructions are new and have not been fully tested
+This has been tested with building SITL and Pixhawk-based targets.
 
 Install Pixhawk Toolchain
 -------------------------
@@ -42,7 +40,7 @@ Install Cygwin
    +----------------+----------------------------------------------------------------------------------+
    | ccache         | Devel \| ccache: A C compiler cache for improving recompilation                  |
    +----------------+----------------------------------------------------------------------------------+
-   | g++            | Devel \| gcc-g++ GNU Compiler Collection (C++)                                   |
+   | gcc-g++        | Devel \| gcc-g++ GNU Compiler Collection (C++)                                   |
    +----------------+----------------------------------------------------------------------------------+
    | git            | Devel \| git: Distributed version control system                                 |
    +----------------+----------------------------------------------------------------------------------+
@@ -52,7 +50,7 @@ Install Cygwin
    +----------------+----------------------------------------------------------------------------------+
    | gawk           | Interpreters \| gawk: GNU awk, a pattern scanning and processing language        |
    +----------------+----------------------------------------------------------------------------------+
-   | libexpat       | Libs \| libexpat-devel: Expat XML parser library (development files)             |
+   | libexpat-devel | Libs \| libexpat-devel: Expat XML parser library (development files)             |
    +----------------+----------------------------------------------------------------------------------+
    | libxml2-devel  | Libs \| libxml2-devel: Gnome XML library (development)                           |
    +----------------+----------------------------------------------------------------------------------+
@@ -60,8 +58,20 @@ Install Cygwin
    +----------------+----------------------------------------------------------------------------------+
    | python2-devel  | Python \| python2-devel: Python2 language interpreter (python3 does not work yet)|
    +----------------+----------------------------------------------------------------------------------+
-   | procps         | System \| procps-ng: System and process monitoring utilities (required for pkill)|
+   | python2-future | Python \| python2-future: Python 2 and 3 compatibility layer                     |
    +----------------+----------------------------------------------------------------------------------+
+   | python2-libxml2| Python \| python2-libxml2: Gnome XML Library (Python bindings                    |
+   +----------------+----------------------------------------------------------------------------------+
+   | python2-pip    | Python \| python2-pip: Python package installation tool                          |
+   +----------------+----------------------------------------------------------------------------------+
+   | procps-ng      | System \| procps-ng: System and process monitoring utilities (required for pkill)|
+   +----------------+----------------------------------------------------------------------------------+
+   | gdb            | Devel \| gdb: The GNU Debugger                                                   |
+   +----------------+----------------------------------------------------------------------------------+
+   | ddd            | Devel \| ddd: DDD, the data display debugger                                     |
+   +----------------+----------------------------------------------------------------------------------+
+   | zip            | Archive \| zip: Info-ZIP compression utility                                     |
+   +----------------+----------------------------------------------------------------------------------+   
 
 #. When all the packages are selected, click through the rest of the
    prompts and accept all other default options (including
@@ -73,10 +83,23 @@ Install Cygwin
       Sometimes the installation can stall because of anti-virus protection software is running.
       If this occurs, shutdown all other programs on your PC including the anti-virus protection and try again.
 
-Set up directories/paths in Cygwin
-----------------------------------
+Install MAVProxy
+-----------------------------------------------------
+
+The MAVProxy GCS is required when running SITL. If you're not planning to run SITL, you can skip this step.
+
+#. To install MAVProxy on Windows follow the `MAVProxy's install instructions for Windows <https://ardupilot.github.io/MAVProxy/html/getting_started/download_and_installation.html#windows>`__
+
+Set up directories/paths and extra packages in Cygwin
+-----------------------------------------------------
 
 #. open and then close the "Cygwin64 Terminal" application from the desktop or start menu icon.  This creates initialisation files for the user in the Cygwin home directory.
+
+#. open the "Cygwin64 Terminal" application from the desktop or start menu icon.  Enter the following command to install additional Python packages:
+
+::
+
+    pip2 install empy
 
 #. with your favourite text editor, open C:\\cygwin64\\home\\<username>\\.bashrc and add this line to include the Pixhawk Toolchain's compiler.
 

--- a/dev/source/docs/building-the-code.rst
+++ b/dev/source/docs/building-the-code.rst
@@ -14,7 +14,7 @@ Setting up the Build Environment
 - :ref:`Setup the Build Environment on Linux/Ubuntu <building-setup-linux>`
 - :ref:`Setup the make Build Environment on Windows <building-setup-windows>`
 - :ref:`Setup the waf Build Environment on Windows10 using WSL <building-setup-windows10>`
-- :ref:`Setup the waf Build Environment on Windows using Cygwin (not fully tested) <building-setup-windows-cygwin>`
+- :ref:`Setup the waf Build Environment on Windows using Cygwin <building-setup-windows-cygwin>`
 - :ref:`Setup the Build Environment on MacOSX <building-setup-mac>`
 
 Building / Compiling
@@ -29,8 +29,11 @@ In most cases the build dependencies described for **waf** and **make** are the 
 
 **Windows users:**
 
+Windows users have 3 options for setting up the build environment. All of the below options will allow building of native (SITL) and Pixhawk-based boards.
 
-- :ref:`Building for Pixhawk on Windows with Make <building-px4-with-make>` 
+- :ref:`Building for Pixhawk on Windows with Make and Eclipse <building-px4-with-make>` 
+- :ref:`Setup the Build Environment on Windows10 using WSL <building-setup-windows10>` 
+- :ref:`Setup the Build Environment on Windows using Cygwin <building-setup-windows-cygwin>` 
 
 **Board specific instructions:**
 
@@ -66,7 +69,7 @@ Links to all build pages
     :maxdepth: 1
 
     Setup the Build Environment on Linux/Ubuntu <building-setup-linux>
-    Setup the Build Environment on Windows <building-setup-windows>
+    Setup the make Build Environment on Windows <building-setup-windows>
     Setup the waf Build Environment on Windows10 using WSL <building-setup-windows10>
     Setup the waf Build Environment on Windows using Cygwin <building-setup-windows-cygwin>
     Setup the Build Environment on MacOSX <building-setup-mac>


### PR DESCRIPTION
Recently went through building SITL and Pixhawk/ChibiOS in Cygwin, so updated the instructions.

Also depreciated old (using make instead of waf) instructions for Windows/Cygwin.