### PR TITLE
Common: relabel page that deals with OpenPilot Revolution

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -23,7 +23,7 @@ Open hardware
     Beagle Bone Blue <common-beagle-bone-blue>
     Erle-Brain <common-erle-brain-linux-autopilot>
     F4BY <common-f4by>
-    OpenPilot Revo Mini <common-openpilot-revo-mini>
+    OpenPilot Revolution <common-openpilot-revo-mini>
     PXFmini RPi Zero Shield <common-pxfmini>
     TauLabs Sparky2 <common-taulabs-sparky2>
 

--- a/common/source/docs/common-openpilot-revo-mini.rst
+++ b/common/source/docs/common-openpilot-revo-mini.rst
@@ -1,8 +1,8 @@
 .. _common-openpilot-revo-mini:
 
-===================
-OpenPilot Mini Revo
-===================
+====================
+OpenPilot Revolution
+====================
 
 .. image:: ../../../images/openpilot-revo-mini.jpeg
     :target: ../_images/openpilot-revo-mini.jpeg
@@ -12,6 +12,10 @@ OpenPilot Mini Revo
 .. note::
 
    Support for the Revo Mini will be released with Copter-3.6.
+
+.. note::
+
+   The OpenPilot Revo Mini is also Supported
 
 Specifications
 ==============


### PR DESCRIPTION
The OpenPilot Revolution and OpenPilot Revo Mini are different boards

All the images on this plane are of the Revolution, not the Mini.
