### PR TITLE
Update common-osd-overview.rst

### DIFF
--- a/common/source/docs/common-osd-overview.rst
+++ b/common/source/docs/common-osd-overview.rst
@@ -1,4 +1,4 @@
-.. common-osd-overwiew:
+.. _common-osd-overwiew:
 
 ===
 OSD


### PR DESCRIPTION
fix link reference from optional hardware toctree