### PR TITLE
Update dji-f330-flamewheel.rst

### DIFF
--- a/copter/source/docs/dji-f330-flamewheel.rst
+++ b/copter/source/docs/dji-f330-flamewheel.rst
@@ -111,6 +111,10 @@ Frame and Motor Assembly
 .. image:: ../images/QuadHookUp800B.jpg
     :target: ../_images/QuadHookUp800B.jpg
 
+-  Be careful to wire motors to the PixHawk using the ArdiPilot numbering convention below. The numbering convention in the DJI FlameWheel F450 instructions are different, and incorrect writing leads to attitude instability.
+.. image:: ../images/MOTORS_QuadX.jpg
+    :target: ../_images/MOTORS_QuadX.jpg
+
 ESC Installation and Soldering the Power Distribution Board
 ===========================================================
 


### PR DESCRIPTION
http://dl.djicdn.com/downloads/flamewheel/en/F450_User_Manual_v2.2_en.pdf has motors 2 and 3 reversed, and when I wired it that way it caused instability in the pitch axis.

![motors_quadx](https://user-images.githubusercontent.com/35647716/42423080-f288c306-82a8-11e8-913f-49ec1d8834c1.jpg)
