### PR TITLE
Name P4 to Pixhawk where hardware is meant

### DIFF
--- a/common/source/docs/common-3dr-power-module.rst
+++ b/common/source/docs/common-3dr-power-module.rst
@@ -4,15 +4,15 @@
 Common Power Module
 ===================
 
-This page explains how to set up the Common Power Module to measure
-battery voltage and current consumption. The information will also be
-useful for setting up other types of Power Module.
+This page explains how to set up the Common Power Module to measure battery voltage and current consumption. 
+The information will also be useful for setting up other types of Power Module.
 
 Overview
 ========
 
 Most flight controllers including the Pixhawk have a dedicated connector for attaching the
-`Power Module <http://store.jdrones.com/APM25_PSU_XT60_p/pwrapm25x1.htm>`__. This is useful because it:
+`Power Module <http://store.jdrones.com/APM25_PSU_XT60_p/pwrapm25x1.htm>`__. 
+This is useful because it:
 
 -  Provides a stable 5.37V and 2.25Amp power supply which reduces the
    chances of a brown-out
@@ -22,10 +22,9 @@ Most flight controllers including the Pixhawk have a dedicated connector for att
 -  Allows the autopilot firmware to more accurately compensate for the
    interference on the compass from other components
 
-The PM accepts a maximum input voltage of 18V (up to 4S Lipo battery)
-and maximum current of 90Amps. When used with an APM the full 90Amp
-current sensing range can be used, with the PX4/Pixhawks up to 60Amps
-can be measured.
+The PM accepts a maximum input voltage of 18V (up to 4S LiPo battery) and maximum current of 90Amps. 
+When used with an APM board the full 90Amp current sensing range can be used, 
+with the Pixhawk-series boards up to 60Amps can be measured.
 
 There is more general information on powering in :ref:`Powering the Pixhawk <common-powering-the-pixhawk>` and :ref:`Powering the APM2 <common-powering-the-apm2>`.
 

--- a/common/source/docs/common-3dr-radio-v1.rst
+++ b/common/source/docs/common-3dr-radio-v1.rst
@@ -51,7 +51,7 @@ Connecting the radio
 Connecting to Pixhawk
 ---------------------
 
-The Pixhawk telemetry ports use a *DF13 6 pin connector cable (15cm)*
+The Pixhawk 1 telemetry ports use a *DF13 6 pin connector cable (15cm)*
 instead of the 5 pins used on the APM2. This allows flow control but
 unfortunately means that you will need to hack a cable to get a Version1
 radio to a Pixhawk. The connections required are shown below.
@@ -79,22 +79,3 @@ and on the 3DR radio side, plug the connector with the red cable on the
 .. image:: ../../../images/3dr_radio_v1_to_apm2.x_connection.jpg
     :target: ../_images/3dr_radio_v1_to_apm2.x_connection.jpg
 
-Connecting to PX4
------------------
-
-To use the 3DR Radio v1 with your PX4FMU plus PX4IO Flight Controller:
-
--  Plug the large black connector of the adapter cable into the 3DR
-   radio remote as shown above.
-
-   -  The side of the black connector with the wire missing goes towards
-      the center of the board.
-
--  Plug the adapter cable's beige connector into the PX4IO FMU UART5 as
-   shown above.
-
-   -  The FMU UART5 connector is on the opposite edge of the PX4IO from
-      the Servo connector and is in the middle of the board.
-
-.. image:: ../../../images/px4_3dr_telemetry_radio.jpg
-    :target: ../_images/px4_3dr_telemetry_radio.jpg

--- a/common/source/docs/common-camera-shutter-with-servo.rst
+++ b/common/source/docs/common-camera-shutter-with-servo.rst
@@ -55,7 +55,7 @@ setting:
 -  Open *Mission Planner* and then click on **CONFIG/TUNING \| Full
    Parameters List**.
 -  Set :ref:`CAM_TRIGG_TYPE` to 0 for a servo (output PWM signal) or 1 for a 
-   :ref:`relay <common-relay>` (Note: although ardupilot supports
+   :ref:`relay <common-relay>` (Note: although ArduPilot supports
    multiple relay channels only the first relay can be used as a camera
    trigger). The image below shows the camera trigger set as a servo.
 

--- a/common/source/docs/common-choosing-a-ground-station.rst
+++ b/common/source/docs/common-choosing-a-ground-station.rst
@@ -104,9 +104,9 @@ Python, and extensible via python modules.
 QGroundControl
 --------------
 
-QGroundControl work with MAVLink capable autopilots. It's main focus orginally has been PX4 Flight Stack,
-but it now also comes with complete support for ArduPilot based autopilots. It's unique among the GCS offerings
-as it runs on all platforms desktop and mobile.
+QGroundControl work with MAVLink capable autopilots. 
+It's main focus was originally the PX4 Flight Stack, but it now also comes with complete support for ArduPilot based autopilots. 
+It's unique among the GCS offerings as it runs on all platforms desktop and mobile.
 
 -  **Platform**: Windows, Mac OS X, Linux, Android and iOS
 -  **Licence**: `Open Source <http://www.qgroundcontrol.org/license>`__
@@ -122,7 +122,8 @@ as it runs on all platforms desktop and mobile.
 UgCS - Universal Ground Control Station
 ---------------------------------------
 
-Universal and easy to use ground control station with a 3D interface. Supports APM, Pixhawk as well as drones from other manufacturers such as DJI, Mikrokopter and more.
+Universal and easy to use ground control station with a 3D interface. 
+Supports APM, Pixhawk as well as drones from other manufacturers such as DJI, Mikrokopter and more.
 Intended for enthusiasts as well as professional users.
 
 It is capable of communicating with and controlling multiple drones simultaneously. 
@@ -198,7 +199,8 @@ See website for how-to on how connect it to your autopilot
 SidePilot
 ---------
 
-ArduPilot compatible GCS that runs on iPhone/iPad. Also supports PX4 and 3DR Solo.
+ArduPilot compatible GCS that runs on iPhone/iPad. 
+Also supports PX4 and 3DR Solo.
 
 See website for how-to on how connect it to your autopilot
 

--- a/common/source/docs/common-commercial-support-bak.rst
+++ b/common/source/docs/common-commercial-support-bak.rst
@@ -68,9 +68,8 @@ the Pixhawk2 which is used in the 3DR Solo.
 -  Accessory customization
 -  Mechanical consulting
 -  Systems engineering
--  Intricate knowledge of the Pixhawk system (designer of  Pixhawk 2,
-   and Pixhawk Fire)
--  Co-designed the PX4 CAN ESC
+-  Intricate knowledge of the Pixhawk system (designer of  Pixhawk 2, and Pixhawk Fire)
+-  Co-designed the Pixhawk CAN ESC
 
 --------------
 
@@ -141,11 +140,10 @@ Website: `jdrones.com <http://jdrones.com>`__
 .. image:: ../../../images/jDrones-APM_Wiki_CollageP2_sml.jpg
     :target: ../_images/jDrones-APM_Wiki_CollageP2_sml.jpg
 
-jDrones is a leading integrator of ArduPilot into small UAVs. Since
-creating the original ArduCopter frame design in 2010 jDrones has grown
+jDrones is a leading integrator of ArduPilot into small UAVs. 
+Since creating the original ArduCopter frame design in 2010 jDrones has grown
 to provide a wide range of components and consulting services, and is
-always looking to provide innovative solutions to the needs of both
-hobbyist and professional users
+always looking to provide innovative solutions to the needs of both hobbyist and professional users
 
 .. image:: ../../../images/jDrones-APM_Wiki_CollageP3_sml.jpg
     :target: ../_images/jDrones-APM_Wiki_CollageP3_sml.jpg
@@ -347,14 +345,13 @@ Email: davidbuzz@gmail.com
 -  Consultation Services
 -  Customizations of Ardupilot/APM code
 -  Microcontroller Development - including Arduino/APM(atmel),
-   Pixhawk/PX4(ARM Cortex), RFD900/SiK (8051), esp8266 wifi (Tensilica
+   Pixhawk (ARM Cortex), RFD900/SiK (8051), esp8266 wifi (Tensilica
    RISC) etc.
 
    Web Software Development - HTML, PHP, SQL , Javascript, etc
 -  Server/Network Systems Administration/Integration - including
    Private, Cloud, AWS, Google etc
--  Ground Control Station development - Mission Planner tweaks, MavProxy
-   modules, dronekit
+-  Ground Control Station development - Mission Planner tweaks, MavProxy modules, DroneKit
 -  Vehicle Design/Integration - Plane and Copter
 -  Vehicle Setup - Plane and Copter
 -  Mechanical consulting
@@ -381,7 +378,7 @@ Website: `http://autosystems.io <http://autosystems.io>`__
 
 ASC is founded by two core developers from the ArduPilot ecosystem and has close connections with ArduPilot developers around the world.
 
-ASC offer more than just consulting on Ardupilot code, but complete end-to-end solutions. R&D, vehicle design, rapid prototyping micro-manufacturing, program management, autopilot code, payload integration, user interfaces.  ASC also offer assistance with operations, flight training, etc.  As little or as much as required to get customer’s ideas off the ground, or along it!  Companies can focus on integrating mobile robotics into their business and developing new revenue streams, instead of having to undertake the long and difficult process of developing UAS expertise and technology in-house.
+ASC offer more than just consulting on ArduPilot code, but complete end-to-end solutions. R&D, vehicle design, rapid prototyping micro-manufacturing, program management, autopilot code, payload integration, user interfaces.  ASC also offer assistance with operations, flight training, etc.  As little or as much as required to get customer’s ideas off the ground, or along it!  Companies can focus on integrating mobile robotics into their business and developing new revenue streams, instead of having to undertake the long and difficult process of developing UAS expertise and technology in-house.
 
 **Capabilities:**
 

--- a/common/source/docs/common-commercial-support.rst
+++ b/common/source/docs/common-commercial-support.rst
@@ -138,7 +138,7 @@ support for ArduPilot including vehicle design, tuning, log analysis, bug fixes 
             <div class="line">David Buzz Bussenschutt, <a href="mailto:davidbuzz@gmail.com?Subject=ArduPilot%20commercial%20support" target="_top">davidbuzz@gmail.com</a></div>
             <div class="line"><br/></div>
             <div class="line">Consultation Services, Customizations of Ardupilot code</div>
-            <div class="line">Microcontroller Development including Pixhawk/PX4(ARM Cortex),</div>
+            <div class="line">Microcontroller Development including Pixhawk (ARM Cortex),</div>
             <div class="line">RFD900/SiK (8051), esp8266 wifi, Web Software Development</div>
             <div class="line">Ground Control Station development, Vehicle Design.</div>
             </div>

--- a/common/source/docs/common-compass-setup-advanced.rst
+++ b/common/source/docs/common-compass-setup-advanced.rst
@@ -39,9 +39,9 @@ table below:
 +-------------------------------------------+--------------+-----------------+
 | Configuration                             | Compass #1   | Compass #2      |
 +===========================================+==============+=================+
-| Pixhawk/PX4 + Compass                     | External     | Internal        |
+| Pixhawk + Compass                         | External     | Internal        |
 +-------------------------------------------+--------------+-----------------+
-| Pixhawk/PX4 (no external compass used)    | Internal     | Available       |
+| Pixhawk (no external compass used)        | Internal     | Available       |
 +-------------------------------------------+--------------+-----------------+
 | APM2.6                                    | External     | Not supported   |
 +-------------------------------------------+--------------+-----------------+
@@ -51,12 +51,10 @@ table below:
 +-------------------------------------------+--------------+-----------------+
 
 Most users will only need to select their autopilot/compass
-configuration and perform the :ref:`Live Calibration <common-compass-setup-advanced_live_calibration_of_offsets>` but details are also given on the less-used  :ref:`CompassMot <common-compass-setup-advanced_compassmot_compensation_for_interference_from_the_power_wires_escs_and_motors>` and
-Manual Declination.  
-Most of this configuration can be
-performed from the *Mission Planner*'s **Initial Setup \| Mandatory
-Hardware \| Compass** screen.  Other ground stations may have similar
-features.
+configuration and perform the :ref:`Live Calibration <common-compass-setup-advanced_live_calibration_of_offsets>` but details are also given on the less-used  :ref:`CompassMot <common-compass-setup-advanced_compassmot_compensation_for_interference_from_the_power_wires_escs_and_motors>` and Manual Declination.  
+Most of this configuration can be performed from the *Mission Planner*'s **Initial Setup \| Mandatory
+Hardware \| Compass** screen.  
+Other ground stations may have similar features.
 
 .. tip::
 
@@ -248,7 +246,7 @@ Please follow these instructions:
    down into the ground when the throttle is raised
 -  Secure the copter (perhaps with tape) so that it does not move
 -  Turn on your transmitter and keep throttle at zero
--  Connect your vehicle's Lipo battery
+-  Connect your vehicle's LiPo battery
 -  Connect your flight controller to your computer with the usb cable
 -  **If using AC3.2:**
 
@@ -321,7 +319,7 @@ Although we do not believe this is ever necessary, you can manually tune
 the declination in flight using the Channel 6 tuning knob on your
 transmitter by following these steps:
 
-#. Connect your APM/PX4 to the Mission Planner
+#. Connect your Pixhawk (or other board) to the Mission Planner
 #. Go to the **Software \| Copter Pids** screen
 #. Set the Ch6 Opt to "Declination", Min to "0.0" and Max to "3.0". 
    This will give a tunable range of -30 to +30 degrees.  Set Max to

--- a/common/source/docs/common-connect-mission-planner-autopilot.rst
+++ b/common/source/docs/common-connect-mission-planner-autopilot.rst
@@ -79,10 +79,9 @@ If Mission planner is unable to connect:
    blocking the IP traffic.
 
 You should also ensure that the autopilot controller board has
-appropriate ArduPilot firwmare installed and has booted correctly (on
-Pixhawk/PX4 there are useful :ref:`LEDs <common-leds-pixhawk>` and
-:ref:`Sounds <common-sounds-pixhawkpx4>` which can tell you the state of
-the autopilot).
+appropriate ArduPilot firmware installed and has booted correctly (on
+Pixhawk there are useful :ref:`LEDs <common-leds-pixhawk>` and
+:ref:`Sounds <common-sounds-pixhawkpx4>` which can tell you the state of the autopilot).
 
 Related topics
 ==============

--- a/common/source/docs/common-contact-us.rst
+++ b/common/source/docs/common-contact-us.rst
@@ -4,7 +4,7 @@
 Communication Channels
 ======================
 
-It is possible to directly communicate with members of the ardupilot community, including developers, through the following channels:
+It is possible to directly communicate with members of the ArduPilot community, including developers, through the following channels:
 
 Support
 =======
@@ -22,8 +22,8 @@ Development
 ===========
 
 - `Mon/Tue Weekly Meetings on Mumble <http://ardupilot.org/dev/docs/ardupilot-mumble-server.html>`__
-- `ArduPilot Gitter (live chat) <https://gitter.im/ArduPilot/ardupilot>`__ the starting place to discuss ardupilot development (not for support questions)
-- `ArduPilot Gitter General Chat <https://gitter.im/ArduPilot/GeneralChat>`__ for discussions not always directly related to ardupilot development
+- `ArduPilot Gitter (live chat) <https://gitter.im/ArduPilot/ardupilot>`__ the starting place to discuss ArduPilot development (not for support questions)
+- `ArduPilot Gitter General Chat <https://gitter.im/ArduPilot/GeneralChat>`__ for discussions not always directly related to ArduPilot development
 - `ArduPilot Gitter Mission Planner Chat <https://gitter.im/ArduPilot/MissionPlanner>`__ for discussion related to Mission Planner development
 - `ArduPilot Gitter APSync and Companion Computer chat <https://gitter.im/ArduPilot/companion>`__ for chat on companion computer development
 - `ArduPilot Gitter APM Planner 2.0 chat <https://gitter.im/ArduPilot/apm_planner>`__ for discussion related to APM Planner 2.0

--- a/common/source/docs/common-diagnosing-problems-using-logs.rst
+++ b/common/source/docs/common-diagnosing-problems-using-logs.rst
@@ -115,13 +115,12 @@ For more advanced vibration analysis, see :ref:`Batch Sampling <common-imu-batch
 Compass interference
 ====================
 
-Interference from the power distribution board, motors, battery, esc and
-other electrical devices near the APM or PX4 can throw off the compass
+Interference from the power distribution board, motors, battery, ESC and
+other electrical devices near the APM or Pixhawk boards can throw off the compass
 heading which can lead to circling (aka "toilet bowling") or even the
 copter flying off in completely the wrong direction.  Graphing the
 tlog's mag_field (found under "CUSTOM") and throttle (found under
-VFR_HUD) values are the easiest way to quickly see the amount of
-interference.
+VFR_HUD) values are the easiest way to quickly see the amount of interference.
 
 In the graph's below shows an acceptable amount of magnetic
 interference.  You can see the mag_field fluctuates when the throttle
@@ -195,11 +194,11 @@ attempts to ignore glitches by sanity checking the positions.
 Power Problems (BrownOuts, etc)
 ===============================
 
-The introduction of the 3dr power module has made it much easier for
-people to provide a reliable power supply to their APM/PX4.  This has
+The introduction of the 3DR Power Module has made it much easier for
+people to provide a reliable power supply to their Pixhawk-series.  This has
 led to a massive reduction in the number of brown-outs reported but they
-do still occur.  They can normally be reconised by the logs suddenly
-ending while the copter is still in the air (i.e. barometer or inerital
+do still occur.  They can normally be recognised by the logs suddenly
+ending while the copter is still in the air (i.e. barometer or inertial
 navigation altitude is still well above zero).
 
 Try graphing the:
@@ -225,7 +224,7 @@ other weird behaviour.  The board voltage can be graphed using:
 
 In the image directly below shows the board voltage sinking by 0.15V
 when the throttle is raised.  This is generally not a good thing but
-because it's only 0.15V it's probably ok. The 2nd graph below (a
+because it's only 0.15V it's probably OK. The 2nd graph below (a
 dataflash graph from a different user's log) shows a more random
 variation in voltage but also up to 0.15V which is typical.
 

--- a/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
+++ b/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
@@ -117,14 +117,14 @@ Setting what data you want recorded
 ===================================
 
 The LOG_BITMASK parameter controls what message types are recorded in
-the dataflash.  Recent versions of the mission planner and ardupilot
+the dataflash.  Recent versions of the mission planner and ArduPilot
 allow individual messages to be enabled/disabled from the MP's
 Config/Tuning, Standard Params screen.
 
 .. image:: ../../../images/mp_dataflash_log_bitmask.png
     :target: ../_images/mp_dataflash_log_bitmask.png
 
-Earlier versions of MP/ardupilot allow selecting the message using a
+Earlier versions of MP/ArduPilot allow selecting the message using a
 drop-down as shown below. 
 
 .. image:: ../../../images/mp_log_bitmask.png
@@ -516,7 +516,7 @@ esc/motor/RC output
 Viewing KMZ FILES
 =================
 
-When you download the dataflash log files from the APM/PX4 it will
+When you download the dataflash log files from the flight controller it will
 automatically create a KMZ file (file with extension .kmz). This file
 can be opened with Google Earth (just double click the file) to view
 your flight in Google Earth. Please see the instructions on the

--- a/common/source/docs/common-downloads_advanced_user_tools.rst
+++ b/common/source/docs/common-downloads_advanced_user_tools.rst
@@ -62,12 +62,12 @@ DATE POSTED	January 29, 2014
 User manual for the third version of the 3DR PPM Encoder module
 
 
-USB Driver for PX4 Boards
--------------------------
+USB Driver for Pixhawk Boards
+-----------------------------
 
 `px4_win_drivers.zip <http://firmware.us.ardupilot.org/Tools/PX4_Windows_Driver/px4_win_drivers.zip>`__
 
-Drivers for PX4 Boards
+Drivers for Pixhawk Boards
 Date Posted: May 15, 2013
 
 

--- a/common/source/docs/common-external-magnetometer-for-improved-performance.rst
+++ b/common/source/docs/common-external-magnetometer-for-improved-performance.rst
@@ -18,8 +18,8 @@ Overview
 ========
 
 The 3DR external compass should only be used with the APM series of
-flight controllers, its 5 volt signal output is not compatible with PX4
-or Pixhawk which require 3.3 volts. For the Pixhawk or PX4 use the :ref:`3DR combination GPS / Magnetometer module <common-installing-3dr-ublox-gps-compass-module>`.
+flight controllers, its 5 volt signal output is not compatible with Pixhawk which require 3.3 volts. 
+For the Pixhawk use the :ref:`3DR combination GPS / Magnetometer module <common-installing-3dr-ublox-gps-compass-module>`.
 
 .. image:: ../../../images/Magnetometer1.jpg
     :target: ../_images/Magnetometer1.jpg

--- a/common/source/docs/common-glossary.rst
+++ b/common/source/docs/common-glossary.rst
@@ -229,7 +229,7 @@ camera pointed towards.
 The square-wave pulse train used to transmit multiple channels of
 information between some RC transmitters and receivers. Some RC
 receivers provide a PPM output (sometimes referred to as the PPM Sum)
-which can be used on the APM and PX4. Other receivers convert the PPM
+which can be used on Pixhawk-series boards. Other receivers convert the PPM
 signal and only provide PWM signals for each channel.
 
 **PWM**: Pulse Width Modulation. The square-wave signals used in RC
@@ -237,7 +237,7 @@ control to drive servos and speed controllers. There is one PWM signal
 for each channel. The width varies from 1000 to 2000 microseconds,
 depending on the RC manufacturer.
 
-**PX4 (PX4FMU and PX4IO)**: Flight Controller system providing
+**Pixhawk (PX4FMU and PX4IO)**: Flight Controller system providing
 capabilities for stabilized flight, position maintenance and automated
 mission (waypoint) path following.
 

--- a/common/source/docs/common-here-plus-gps.rst
+++ b/common/source/docs/common-here-plus-gps.rst
@@ -116,9 +116,10 @@ When base/rover is already connected to U-center, click View, go to Message View
 	
 As shown in the figure, the current firmware version is FWVER = HPG 1.30 REF, indicating that the current firmware version is 1.30 for base module. 
 
-Basic opperating manual
-=======================
-This part of the tutorial uses Mission Planner ground control software and Arducopter-3.5 flight control firmware for operating instructions. If you are using PX4 firmware and QGroundControl ground station software, please refer to `this link <https://docs.px4.io/en/advanced_features/rtk-gps.html>`__.
+Basic operating manual
+======================
+This part of the tutorial uses Mission Planner ground control software and Arducopter-3.5 flight control firmware for operating instructions. 
+If you are using PX4 firmware and QGroundControl ground station software, please refer to `this link <https://docs.px4.io/en/advanced_features/rtk-gps.html>`__.
 
 Preperation before operation.
 -----------------------------

--- a/common/source/docs/common-history-of-ardupilot.rst
+++ b/common/source/docs/common-history-of-ardupilot.rst
@@ -27,7 +27,7 @@ May 2009 - `First ArduPilot board <http://diydrones.com/profiles/blogs/ardupilot
 `thermopiles <http://diydrones.com/profiles/blogs/attopilot-ir-sensors-now>`__)
 released by Jordi/3DRobotics
 
-Nov 2009 - `ardupilot code repository <https://code.google.com/p/ardupilot/>`__ created by Jordi
+Nov 2009 - `ArduPilot code repository <https://code.google.com/p/ardupilot/>`__ created by Jordi
 
 Nov 2009 - first version of ArduIMU written by Jordi, Doug Weibel, Jose
 Julio using DCM from William Premerlani
@@ -81,7 +81,7 @@ is released by Michael Oborne
 Aug 2010 - `TradHeli support <https://vimeo.com/14135066>`__\ added by
 Randy
 
-Dec 2010 - first successful fork of ardupilot code as `MegaPirates group extends original CopterNG code <http://diydrones.com/profiles/blogs/arducopter-ng-taken-over-by>`__
+Dec 2010 - first successful fork of ArduPilot code as `MegaPirates group extends original CopterNG code <http://diydrones.com/profiles/blogs/arducopter-ng-taken-over-by>`__
 
 April 2011 – First fully autonomous Copter mission flown by Jason at
 `Sparkfun AVC <http://diydrones.com/profiles/blogs/acm-at-the-avc>`__
@@ -118,7 +118,7 @@ Jonathan Challinger leads to Copter's inertial based altitude hold by
 Randy and Leonard
 (`AC2.9 <http://diydrones.com/forum/topics/arducopter-2-9-released>`__).
 
-Jan 2013 - ardupilot code moved from `google code <http://code.google.com/p/ardupilot/>`__ to
+Jan 2013 - ArduPilot code moved from `google code <http://code.google.com/p/ardupilot/>`__ to
 `github <https://github.com/ArduPilot/ardupilot>`__
 
 Jan/Feb 2013 - Android GCSs appear (`DroidPlanner from
@@ -183,13 +183,13 @@ June 2015 - `Parrot Bebop port's first successful flights <http://diydrones.com/
 Aug 2015 - Michael Clement & Michael Day fly 
 `50 arduplanes in a multi-vehicle environment <http://diydrones.com/profiles/blogs/from-zero-to-fifty-planes-in-twenty-seven-minutes>`__
 
-Sep 2015 - `First major news event involving a misbehaving pilot of an ardupilot vehicle (a Solo) <http://edition.cnn.com/2015/09/04/us/us-open-tennis-drone-arrest/>`__
+Sep 2015 - `First major news event involving a misbehaving pilot of an ArduPilot vehicle (a Solo) <http://edition.cnn.com/2015/09/04/us/us-open-tennis-drone-arrest/>`__
 
 March 2016 - 3DR ceases direct funding of ArduPilot community as it `cuts jobs <http://www.marketwatch.com/story/drone-maker-3d-robotics-reboots-by-cutting-jobs-refocusing-on-corporate-market-2016-03-23>`__.
 
 March 2016 - Formation of the `ardupilot.org non profit organisation <http://diydrones.com/profiles/blogs/a-new-chapter-in-ardupilot-development>`__ and new website.
 
-May 2016 - `Flirtey delivery drone (using ardupilot) is entered into Smithsonian Air and Space Museum <http://www.smithsonianmag.com/smart-news/first-delivery-drone-united-states-lands-spot-smithsonian-180958964/?no-ist>`__.
+May 2016 - `Flirtey delivery drone (using ArduPilot) is entered into Smithsonian Air and Space Museum <http://www.smithsonianmag.com/smart-news/first-delivery-drone-united-states-lands-spot-smithsonian-180958964/?no-ist>`__.
 
 Sep 2016 - Flymaple board support removed ( not actively tested or used , also lacks a maintainer see PR #4191 ).
 

--- a/common/source/docs/common-intel-aero-rtf.rst
+++ b/common/source/docs/common-intel-aero-rtf.rst
@@ -21,7 +21,7 @@ Additional parts to buy
 
 Although "Ready-to-fly" some additional parts are required to complete the upgrade and fly with ArduPilot.
 
-- Lipo battery `3S <https://hobbyking.com/en_us/multistar-high-capacity-3s-5200mah-multi-rotor-lipo-pack.html>`__ or `4S <https://hobbyking.com/en_us/multistar-high-capacity-4s-5200mah-multi-rotor-lipo-pack.html>`__
+- LiPo battery `3S <https://hobbyking.com/en_us/multistar-high-capacity-3s-5200mah-multi-rotor-lipo-pack.html>`__ or `4S <https://hobbyking.com/en_us/multistar-high-capacity-4s-5200mah-multi-rotor-lipo-pack.html>`__
 - 2GB (or larger) USB thumb drive (`like this one <https://www.amazon.com/SanDisk-Cruzer-Glide-Drive-SDCZ60-008G-B35/dp/B007YX9O94/ref=sr_1_4?ie=UTF8&qid=1492397331&sr=8-4>`__) is needed for updating to the last release of the Linux distro.
 - Micro USB OTG to USB cable (`like this one <https://www.amazon.com/Micro-USB-OTG-Go-Adapter/dp/B005GI2VMG>`__)
 - `Spektrum USB programming cable <https://www.spektrumrc.com/Products/Default.aspx?ProdID=SPMA3065>`__ (optional)
@@ -39,11 +39,11 @@ in order for the flight controller to be flashed with ArduPilot.
 - `Flash the OS image to the Aero compute board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flash-intel-aero-linux-distribution>`__ using a USB thumb drive
 - `Upgrade the FPGA <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-fpga>`__ using a .jam file included on the OS image
 
-The final step is to copy the arducopter.px4 firwmware to the Aero compute board and then flash it to the flight board:
+The final step is to copy the **arducopter.px4** firmware to the Aero compute board and then flash it to the flight board:
 
-- Download the latest aero-fc ardupilot firmware from `firmware.ardupilot.org <http://firmware.ardupilot.org/Copter/latest/>`__ 
+- Download the latest aero-fc ArduPilot firmware from `firmware.ardupilot.org <http://firmware.ardupilot.org/Copter/latest/>`__ 
 - Copy the above firmware to the Aero compute board in much the same way the BIOS's .rpm file was copied
-- `Flash the flight controller board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-flight-controller-rtf-only>`__ with the ardupilot.px4 firmware
+- `Flash the flight controller board <https://github.com/intel-aero/meta-intel-aero/wiki/02-Initial-setup#flashing-the-flight-controller-rtf-only>`__ with the **ardupilot.px4** firmware
 
 If you are developing ArduPilot, you can flash directly from the command line after compiling. Refer to `Build instructions <https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md>`__ for more detailed instructions, but it's basically the following commands:
 
@@ -53,7 +53,7 @@ If you are developing ArduPilot, you can flash directly from the command line af
 Connecting and configuring with a ground station
 ================================================
 
-- Connect a Lipo battery to the vehicle
+- Connect a LiPo battery to the vehicle
 - Turn on the vehicle by pushing the "Power" button found between the two rear arms
 - From your PC, connect to the vehicle's wifi access point (normally starts with "Aero-"), the default password is "1234567890"
 - Start the ground station (i.e. mission planner), select "UDP" from the connection type and press "Connect"

--- a/common/source/docs/common-leds-pixhawk.rst
+++ b/common/source/docs/common-leds-pixhawk.rst
@@ -1,12 +1,12 @@
 .. _common-leds-pixhawk:
 
-==================
-LEDs (Pixhawk/PX4)
-==================
+==============
+LEDs (Pixhawk)
+==============
 
 This topic explains how to interpret the colours and flash sequence of
 the main LED. Some of the LED patterns have associated sound/tone
-patterns as listed in :ref:`Sounds (Pixhawk/PX4) <common-sounds-pixhawkpx4>`.
+patterns as listed in :ref:`Sounds (Pixhawk) <common-sounds-pixhawkpx4>`.
 
 Video Overview
 ==============

--- a/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
+++ b/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
@@ -10,8 +10,8 @@ Examples of these boards include the :ref:`OpenPilot RevoMini <common-openpilot-
 Installing ArduPilot to these flight controller involves:
 
 - Installing the required driver and flashing tool
-- Downloading the appropriate ardupilot firmware
-- Loading ardupilot to the board
+- Downloading the appropriate ArduPilot firmware
+- Loading ArduPilot to the board
 
 .. note::
 

--- a/common/source/docs/common-loading-firmware-onto-pixhawk.rst
+++ b/common/source/docs/common-loading-firmware-onto-pixhawk.rst
@@ -33,9 +33,8 @@ Select the COM port
 
 If using the *Mission Planner* select the COM port drop-down on the
 upper-right corner of the screen (near the **Connect** button).  Select
-**AUTO** or the specific port for your board (**PX4 FMU** or **Arduino
-Mega 2560**). Set the Baud rate to **115200** as shown. Don't hit
-**Connect** just yet.
+**AUTO** or the specific port for your board (**PX4FMU** or **Arduino Mega 2560**). 
+Set the Baud rate to **115200** as shown. Don't hit **Connect** just yet.
 
 .. image:: ../../../images/Pixhawk_ConnectWithMP.png
     :target: ../_images/Pixhawk_ConnectWithMP.png

--- a/common/source/docs/common-measuring-vibration.rst
+++ b/common/source/docs/common-measuring-vibration.rst
@@ -87,7 +87,7 @@ Earlier firmware versions
    
 -  Fly your copter in Stabilize mode and try to maintain a level hover
    (it doesn't need to be perfectly stable or level)
--  Disconnect the Lipo, reconnect your APM/PX4 to the mission planner
+-  Disconnect the Lipo, reconnect your Pixhawk to the mission planner
 -  :ref:`Download the dataflash logs and <common-downloading-and-analyzing-data-logs-in-mission-planner_downloading_logs_via_mavlink>`
    after the download has completed, use the Mission Planner's "Review a
    Log" buttong to open the latest file in the log directory (it's last

--- a/common/source/docs/common-mission-planner-telemetry-logs.rst
+++ b/common/source/docs/common-mission-planner-telemetry-logs.rst
@@ -127,7 +127,7 @@ tlog.  This file is tab separated and contains a full list of parameters
 during the flight.  This can be opened in excel or a text editor.
 
 Extract WPs will create one or more .txt files containing any missions
-uploaded to the APM/PX4.  These files can be opened in the Mission
+uploaded to the flight controller.  These files can be opened in the Mission
 Planner by switching to the Flight Plan screen, right-mouse-button
 clicking on the map and selecting "File Load/Save", "Load WP File".
 

--- a/common/source/docs/common-navio-overview.rst
+++ b/common/source/docs/common-navio-overview.rst
@@ -39,7 +39,7 @@ Specifications
 
 More details can be found from the `emlid.com website <http://www.emlid.com/>`__.
 
-Developer build information can be found on the :ref:`ardupilot dev wiki <dev:building-for-navio-on-rpi2>`.
+Developer build information can be found on the :ref:`ArduPilot dev wiki <dev:building-for-navio-on-rpi2>`.
 
 ..  youtube:: 63vjrphteRs
     :width: 100%

--- a/common/source/docs/common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems.rst
+++ b/common/source/docs/common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems.rst
@@ -231,7 +231,7 @@ Spektrum Satellite Receivers Operate on PPM-Sum
 -  Although Spektrum main receivers do not communicate by PPM-Sum their
    range extending "satellite" receivers do.
 -  So it is feasible to use a single `Spektrum Satellite Receiver <http://www.spektrumrc.com/Products/Default.aspx?ProdID=SPM9645>`__
-   to act as a PPM-Sum receiver with PX4 and Pixhawk.
+   to act as a PPM-Sum receiver with Pixhawk.
 
    -  Simply pre-bind the Spektrum Satellite to your transmitter using a
       conventional Spektrum receiver with satellite attached.
@@ -316,7 +316,7 @@ Using a Standard RC Radio Receiver with 3DR PPM Encoder
 
 .. note::
 
-   If you are using this PPM Encoder with PX4 it is important to know that
+   If you are using this PPM Encoder with PX4FMU it is important to know that
    when you are calibrating your transmitter you will quite likely need
    to hook up your flight battery to the PX4IO because the USB port
    alone can't supply enough power.

--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -599,13 +599,12 @@ modules.
 Pixhawk system features
 =======================
 
--  The Pixhawk flight controller is a further evolution of the PX4
-   flight controller system. Pixhawk consists of a PX4-FMU controller
+-  The Pixhawk (FMUv2) flight controller consists of a PX4-FMU controller
    and a PX4-IO integrated on a single board with additional IO, Memory
    and other features.
 -  It is highly optimized to provide control and automation for APM
    flight navigation software with high performance and
-   capacity. Pixhawk allows current APM and PX4 operators to seamlessly
+   capacity. Pixhawk allows users of older boards to seamlessly
    transition to this system and lowers the barriers to entry for new
    users.
 -  The NuttX real-time operating system features high performance,
@@ -680,15 +679,13 @@ Pixhawk system features
    -  Weight: 38g (1.31oz), Width: 50mm (1.96"), Thickness: 15.5mm
       (.613"), Length: 81.5mm (3.21")
 
-Comparison of PX4-FMU-IO and Pixhawk
-====================================
+Comparison of PX4FMU/PX4IO and Pixhawk
+======================================
 
-The new PX4 \ `Pixhawk module <http://pixhawk.org/modules/pixhawk>`__ is an evolution
-of the
-existing \ `FMU <http://pixhawk.org/modules/px4fmu>`__ and `IO <http://pixhawk.org/modules/px4io>`__ modules
+The new Pixhawk is an evolution of the PX4FMU  and PX4IO modules
 and is completely compatible.
 
--  The PX4 FMU and IO stack is very small (the size of an 8 ch RC
+-  The PX4FMU and PX4IO stack is very small (the size of an 8 ch RC
    receiver) and very densely packed, Pixhawk has more space, more
    serial ports and more PWM outputs.
 -  There are two groups of servo connectors, one main group of 8 outputs
@@ -701,9 +698,9 @@ and is completely compatible.
 -  Inside Pixhawk a FMUv2 and an IOv2 do their duties on a single board
    (and developers will find that the software will refer to FMUv2 and
    IOv2)
--  The PX4 / Pixhawk system has more than 10 times the CPU performance
-   and memory of the APM and a lot more as well.
--  14 PWM outputs (Pixhawk) vs. 12 PWM outputs (PX4)
+-  The Pixhawk system has more than 10 times the CPU performance
+   and memory of the APM2.x and a lot more as well.
+-  14 PWM outputs (Pixhawk) vs. 12 PWM outputs (PX4FMU/PX4IO)
 -  All Pixhawk PWM outputs on servo connectors (PX4: 8 on servo, 4 on 15
    pin DF13 connector)
 -  5 serial ports vs. 4 (with some double functionality, so only 3 in
@@ -890,5 +887,5 @@ See also
     Pixhawk Wiring Quick Start <common-pixhawk-wiring-and-quick-start>
     Powering the Pixhawk <common-powering-the-pixhawk>
     Mounting the Flight Controller <common-mounting-the-flight-controller>
-    Compatible RC Transmitter and Receiver Systems (Pixhawk/PX4) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>
+    Compatible RC Transmitter and Receiver Systems (Pixhawk) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>
 [/site]

--- a/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
+++ b/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
@@ -53,7 +53,7 @@ can be used to convert the receiver outputs to PPM-SUM.
 
 .. tip::
 
-   Information about compatible receivers and how they are connected can be found in :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk/PX4) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
+   Information about compatible receivers and how they are connected can be found in :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
 
 .. figure:: ../../../images/FRSkyTaranis.jpg
    :target: ../_images/FRSkyTaranis.jpg
@@ -154,7 +154,7 @@ Related information
     :maxdepth: 1
 
     Powering the Pixhawk <common-powering-the-pixhawk>
-    Compatible RC Tx/Rx Systems (Pixhawk/PX4) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>
+    Compatible RC Tx/Rx Systems (Pixhawk) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>
 
 [site wiki="copter"]
     Advanced Pixhawk Quadcopter Wiring Chart <advanced-pixhawk-quadcopter-wiring-chart>

--- a/common/source/docs/common-power-module-configuration-in-mission-planner.rst
+++ b/common/source/docs/common-power-module-configuration-in-mission-planner.rst
@@ -60,9 +60,9 @@ to configure an "unknown" power module.
 
 To calibrate the voltage reading:
 
-#. Check the voltage of your lipo battery with a hand-held volt meter or
+#. Check the voltage of your LiPo battery with a hand-held volt meter or
    a `power analyzer <http://www.hobbyking.com/hobbyking/store/__10080__Turnigy_130A_Watt_Meter_and_Power_Analyzer.html>`__
-#. Connect your APM/PX4 to your computer and plug in the lipo battery
+#. Connect your Pixhawk-series to your computer and plug in the LiPo battery
 #. Check the voltage through the *Mission Planner*'s **INITIAL SETUP \|
    Optional Hardware \| Battery Monitor** screen or on the Flight Data
    screen's HUD or *Status* tab.

--- a/common/source/docs/common-px4fmu-overview.rst
+++ b/common/source/docs/common-px4fmu-overview.rst
@@ -8,32 +8,28 @@ Archived:PX4FMU Overview
 
     **ARCHIVED**
     
-    The PX4FMU ("PX4") is end of life and is not
-    generally available for purchase. This article is made available for
-    existing users.
+    The PX4FMU (v1) is end of life and is not generally available for purchase. 
+    This article is made available for existing users.
 
-This page provides an overview of the PX4 Flight Management Unit.
+This page provides an overview of the Pixhawk Flight Management Unit.
 
-Pixhawk (FMUv2) and PX4 (FMUv1)
-===============================
+Pixhawk (FMUv2) and PX4FMU (FMUv1)
+==================================
 
-There are now two separate platforms supporting the PX4 system:
+The Pixhawk (FMUv2) single board flight controller evolved from the original "PX4 system", 
+which consists of the PX4FMU and various piggyback boards including the PX4IO and PX4IOAR.
 
--  The Pixhawk (FMUv2) single board flight controller.
--  And the original PX4 system which consists of the PX4 FMUv1 and
-   various piggyback boards including the PX4IO and PX4IOAR.
-
-The new Pixhawk also incorporates several additional features to provide
-extended capabilities for our APM flight system.
+The Pixhawk incorporates several additional features to provide
+extended capabilities for our ArduPilot flight system.
 
 A connector diagram of the Pixhawk is shown below, but :ref:`Go to this link for full information on the Pixhawk <common-pixhawk-overview>`
 
-The PX4 (FMUv1) Flight Management System Includes:
-==================================================
+The PX4FMU/PX4IO (FMUv1) Flight Management System Includes:
+===========================================================
 
 -  **The PX4-FMU (Flight Management Unit).**
 
-   -  A powerful Cortex M4F microcontroller and flash memory for
+   -  A powerful Cortex M4F micro-controller and flash memory for
       controlling flight and communications.
    -  A socket for a plug in SD memory card.
    -  A 3 axis gyro for determining orientation.
@@ -49,7 +45,7 @@ The PX4 (FMUv1) Flight Management System Includes:
 
 -  **The PX4-IO (Input Output) Board.**
 
-   -  Contains its own on board microcontroller and stacks with the FMU.
+   -  Contains its own on board micro-controller and stacks with the FMU.
    -  Direct battery input power supply.
    -  8 High speed servo PWM outputs.
    -  Futaba SBUS or PPM-SUM serial servo output.
@@ -57,13 +53,13 @@ The PX4 (FMUv1) Flight Management System Includes:
    -  Two user assignable relays, two 1/2 amp 5 volt outputs and an
       analog input port.
 
--  **The PX4-FLOW Smart (Optical Flow) Camera.**
+-  **The PX4FLOW Smart (Optical Flow) Camera.**
 
    -  Specialized downward pointing camera module that uses ground
       texture and features to determine aircraft motion over the ground.
-   -  The PX4 Flow has the same powerful Cortex M4F Microcontroller as
+   -  The PX4FLOW has the same powerful Cortex M4F micro-controller as
       is used in the PX4FMU.
-   -  The built in microcontroller performs on board automated binned
+   -  The built in micro-controller performs on board automated binned
       pixel image analysis to determine motion relative to ground.
    -  A built in 3 axis gyro enables automatic compensation for variance
       in aircraft tilt angle.
@@ -71,7 +67,7 @@ The PX4 (FMUv1) Flight Management System Includes:
 -  **The PX4-IOAR Quad Carrier is a specialized interface board for the
    Parrot AR.Drone.**
 
-**The PX4 FMU circuit board comes preassembled and ready to load the
+**The PX4FMU circuit board comes preassembled and ready to load the
 firmware for your airframe using the Mission Planner.**
 
 .. image:: ../../../images/PX4OverviewDiagram.jpg
@@ -83,7 +79,7 @@ Detailed Description
 .. image:: ../../../images/PX4-2.jpg
     :target: ../_images/PX4-2.jpg
 
-**The Back of the PX4 FMU showing the SD card carrier and buzzer
+**The Back of the PX4FMU board showing the SD card carrier and buzzer
 socket:**
 
 .. image:: ../../../images/PX4FMUbottom1.jpg
@@ -98,13 +94,12 @@ PX4FMU Connector diagram
 Analog and digital pins
 =======================
 
-This section lists what pins (analog and digital) are available on the
-PX4.
+This section lists what pins (analog and digital) are available on the PX4FMU.
 
 PX4v1 Analog inputs
 -------------------
 
-The PX4 has the following “available” Analog input port pins which may
+The PX4FMUv1 has the following “available” Analog input port pins which may
 be put to a variety of uses.
 
 **Pin 10** (High voltage analog pin):
@@ -240,7 +235,7 @@ Copter wiring (diagram and instructions)
    x 3 angle connector that is nearest the edge of the PX4IO board with
    the signal wire furthest from the board and the ground closest to the
    board.**
-#. **Wire the PX4 boards servo out signals to your ESC control inputs.**
+#. **Wire the PX4FMU boards servo out signals to your ESC control inputs.**
 
    #. Run the Signal wires ONLY from the ESCs to the 3 x 9 Servo
       Connector on the PX4IO board.
@@ -282,13 +277,13 @@ Copter wiring (diagram and instructions)
     PX4IO <common-px4io-overview>
     
 [site wiki="rover"]
-    PX4 Wiring and QuickStart <rover-px4-quickstart>
+    Archived:Rover PX4FMU/PX4IO Wiring Quick Start <rover-px4-quickstart>
 [/site]
 
 [site wiki="copter"]
-    Archived:PX4 Wiring QuickStart <px4fmu-plus-px4io-wiring>
+    Archived:PX4FMU Wiring QuickStart <px4fmu-plus-px4io-wiring>
 [/site]
 
 [site wiki="plane"]
-    Archived:PX4 Wiring QuickStart <px4fmu-plus-px4io-wiring>
+    Archived:PX4FMU Wiring QuickStart <px4fmu-plus-px4io-wiring>
 [/site]

--- a/common/source/docs/common-px4io-overview.rst
+++ b/common/source/docs/common-px4io-overview.rst
@@ -22,12 +22,12 @@ Archived:PX4IO Overview
 -  All power inputs are reverse polarity protected.
 -  All power outputs are current limited.
 -  All logic inputs and outputs are ESD protected.
--  All PX4 boards use positive retention DF13 connectors and a variety
+-  All PX4IO boards use positive retention DF13 connectors and a variety
    of connectors.
 -  Wires with pre-crimped sockets and pre-made cables are available
    inexpensively for the PX4-IO from 3DRobotics.
 
-The Bottom of the PX4 IO Board
+The Bottom of the PX4IO Board
 ==============================
 
 .. image:: ../../../images/PX4io-bottom.jpg
@@ -37,26 +37,26 @@ The Bottom of the PX4 IO Board
 -  For high power servos you can remove L1 to allow you to supply power
    from an external power supply to a servo connector center pin.
 
-The Top of the PX4 IO Board
-===========================
+The Top of the PX4IO Board
+==========================
 
 .. image:: ../../../images/PX4io-top.jpg
     :target: ../_images/PX4io-top.jpg
 
-A Breif Description of the PX4 IO Board
-=======================================
+A Breif Description of the PX4IO Board
+======================================
 
 .. image:: ../../../images/PX4IOdiagram.jpg
     :target: ../_images/PX4IOdiagram.jpg
 
-The PX4 IO Board Connector pin assignments
-==========================================
+The PX4IO Board Connector pin assignments
+=========================================
 
 .. image:: ../../../images/PX4IOconnectors.jpg
     :target: ../_images/PX4IOconnectors.jpg
 
-The PX4 IO Board Stacks On Top of the PX4 FMU board
-===================================================
+The PX4IO Board Stacks On Top of the PX4-FMU board
+==================================================
 
 .. image:: ../../../images/PX4-STACK1.jpg
     :target: ../_images/PX4-STACK1.jpg

--- a/common/source/docs/common-rally-points.rst
+++ b/common/source/docs/common-rally-points.rst
@@ -64,10 +64,9 @@ The following should be considered when using Rally Points:
    are inside the geofence.
 #. Make sure Rally Point altitudes are high enough to clear terrain and
    buildings.
-#. Because of the limited flash memory size on the APM hardware the
+#. Because of the limited flash memory size on the APM2.x hardware the
    number of Rally Points is restricted to 10 on Plane and 6 on Copter
-   -- this limit may be expanded on other platforms such as PX4 and
-   Pixhawk in the future.
+   -- this limit may be expanded on other platforms such as Pixhawk in the future.
 #. On Plane, loiter radius for a Rally Point is the same as all other
    loiter points; determined by the :ref:`WP_LOITER_RAD <plane:WP_LOITER_RAD>`
    parameter.

--- a/common/source/docs/common-rangefinder-lidarlite.rst
+++ b/common/source/docs/common-rangefinder-lidarlite.rst
@@ -257,7 +257,7 @@ To configure Copter, Plane or Rover to use the LIDAR-Lite:
 #. Set the ``RNGFND_TYPE`` value based on the flight controller and connection method (PWM or I2C): 
 
    * ``RNGFND_TYPE=5``: Pixhawk via PWM 
-   * ``RNGFND_TYPE=4``: Pixhawk/PX4 via I2C
+   * ``RNGFND_TYPE=4``: Pixhawk via I2C
    * ``RNGFND_TYPE=3``: APM2 via I2C
 
 #. Set the ``RNGFND_MAX_CM`` to 4000 (40m). This parameter represents the maximum distance in centimeters that the LiDAR is reliable over — when ignoring “0” distance readings in the driver, a value of 4000 should work well in almost all conditions.

--- a/common/source/docs/common-safety-switch-pixhawk.rst
+++ b/common/source/docs/common-safety-switch-pixhawk.rst
@@ -36,4 +36,6 @@ This is normally not required but in some rare cases is required after a firmwar
 
 .. note::
 
-   A Pixhawk has two CPUs, the main CPU (aka FMU) is where ardupilot runs.  There is a separate I/O CPU which is responsible for some I/O including pwm outputs to the MAIN OUT channels.  Pixracers only have the main CPU.
+   A Pixhawk has two CPUs, the main CPU (aka FMU) is where ArduPilot runs.  
+   There is a separate I/O CPU which is responsible for some I/O including PWM outputs to the MAIN OUT channels.  
+   Pixracers only have the main CPU.

--- a/common/source/docs/common-sounds-pixhawkpx4.rst
+++ b/common/source/docs/common-sounds-pixhawkpx4.rst
@@ -1,8 +1,8 @@
 .. _common-sounds-pixhawkpx4:
 
-====================
-Sounds (Pixhawk/PX4)
-====================
+================
+Sounds (Pixhawk)
+================
 
 The tone alarm plays tunes to indicate various states. Click on the
 descriptions below to download and listen to the associated tune.
@@ -21,4 +21,3 @@ descriptions below to download and listen to the associated tune.
 * `Barometer Glitch <http://download.ardupilot.org/downloads/wiki/pixhawk_sound_files/BaroGlitch.wav>`__
 * `Parachute Release <http://download.ardupilot.org/downloads/wiki/pixhawk_sound_files/parachute_release.wav>`__
 * `Lost Copter Alarm <http://download.ardupilot.org/downloads/wiki/pixhawk_sound_files/LostCopter.wav>`__
-

--- a/common/source/docs/common-taulabs-sparky2.rst
+++ b/common/source/docs/common-taulabs-sparky2.rst
@@ -58,9 +58,9 @@ Videos
 ..  youtube:: 3esk1lnw3SI
     :width: 100%
 
-*first flight of ardupilot on Sparky2*
+* first flight of ArduPilot on Sparky2*
 
 ..  youtube:: WGLc7jNqAyE
     :width: 100%
 
-*2nd flight using PosHold, RTL*
+* 2nd flight using PosHold, RTL*

--- a/common/source/docs/common-uavcan-escs.rst
+++ b/common/source/docs/common-uavcan-escs.rst
@@ -51,7 +51,7 @@ ESC setup using CLI
 
 Each ESC must go through a one-time manual setup using an `FTDI cable <http://store.jdrones.com/cable_ftdi_6pin_5v_p/cblftdi5v6p.htm>`__
 to define it's UAVCAN Node Id and motor number.  In future versions of
-ardupilot this will be replaced with a setup procedure using the mission
+ArduPilot this will be replaced with a setup procedure using the mission
 planner (and other GCSs).
 
 The steps required are:

--- a/common/source/docs/common-vibration-damping.rst
+++ b/common/source/docs/common-vibration-damping.rst
@@ -106,12 +106,12 @@ Gel pads
    .. figure:: ../../../images/Flamewheel330PX4onZeal2.jpg
       :target: ../_images/Flamewheel330PX4onZeal2.jpg
 
-      FlameWheel F330 With PX4 Mounted on Intermediate platform
+      FlameWheel F330 With PX4FMU/PX4IO Mounted on Intermediate platform
 
    .. figure:: ../../../images/Flamewheel330PX4Hardtop.jpg
       :target: ../_images/Flamewheel330PX4Hardtop.jpg
 
-      FlameWheel F330 With PX4 on Zeal Pads with Protective Hard Top
+      FlameWheel F330 With PX4FMU/PX4IO on Zeal Pads with Protective Hard Top
 
    .. figure:: ../../../images/PX4F330accels_5_9_13.jpg
       :target: ../_images/PX4F330accels_5_9_13.jpg
@@ -491,7 +491,7 @@ Additional Vibration Reduction Considerations
    less than 2 ounces and this is a very small mass.
 #. Virtually all off the shelf solutions (either pad or stud type) are
    designed for an isolated mass that would weigh at least 5 to 10 times
-   what an APM or PX4 / IO board weighs for optimal effectiveness. This
+   what an APM2.x or PX4FMU/PX4IO board weighs for optimal effectiveness. This
    includes all pre-made Sorbothane, Alpha gel, EAR, memory foam or
    other silicone or urethane gel or foam mounts as well as Lord Micro
    mounts.

--- a/common/source/docs/common-zed.rst
+++ b/common/source/docs/common-zed.rst
@@ -55,7 +55,7 @@ Optionally you may also:
 Ground Testing
 ==============
 
-- Plug in the vehicle's lipo battery so that both the TX1 and flight controller are powered
+- Plug in the vehicle's LiPo battery so that both the TX1 and flight controller are powered
 - Connect the flight controller to a ground station using a USB cable
 - If you are using Mission Planner as your ground station, once messages are successfully passing from the ZED/TX1 to the flight controller:
   - a proximity viewer should appear showing the distance to objects ahead of the vehicle (if :ref:`PRX_TYPE <PRX_TYPE>` was enabled above) 

--- a/copter/source/docs/ac_rollpitchtuning.rst
+++ b/copter/source/docs/ac_rollpitchtuning.rst
@@ -45,7 +45,7 @@ transmitter's channel 6 tuning knob by following these instructions:
 #. Move the CH6 knob back to the middle
 #. Arm and fly your copter in Stabilize mode adjusting the ch6 knob
    until you get a copter that is responsive but not wobbly
-#. After the flight, disconnect your lipo battery and reconnect the APM
+#. After the flight, disconnect your LiPo battery and reconnect the APM
    to the mission planner
 #. With the CH6 knob in the position that gave the best performance,
    return to the Copter Pids screen and push the "Refresh Params" button

--- a/copter/source/docs/ac_throttlemid.rst
+++ b/copter/source/docs/ac_throttlemid.rst
@@ -24,7 +24,7 @@ that your copter hovers at 50% throttle:
 
 -  Fly your copter in stabilize mode in a stable hover for at least 30
    seconds
--  Disconnect your lipo battery and connect your APM/PX4 to the Mission
+-  Disconnect your LiPo battery and connect your APM/PX4 to the Mission
    Planner
 -  Go to the Terminal screen and download your latest dataflash log file
    (more details on working with dataflash logs can be found

--- a/copter/source/docs/connect-escs-and-motors.rst
+++ b/copter/source/docs/connect-escs-and-motors.rst
@@ -4,11 +4,10 @@
 Connect ESCs and Motors
 =======================
 
-This article explains how to connect the ESCs, Motors and Propellers for
-Pixhawk, PX4, APM 2.x. and Erle-Brain2.
+This article explains how to connect the ESCs, Motors and Propellers for Pixhawk, APM 2.x. and Erle-Brain2.
 
-Connect motor PWM signal outputs (Pixhawk/PX4)
-==============================================
+Connect motor PWM signal outputs (Pixhawk)
+==========================================
 
 Connect the power (+), ground (-), and signal (s) wires for each ESC to
 the controller main output pins by motor number. Find your frame type
@@ -58,8 +57,7 @@ module, it is optional to connect the power and ground wires from the
 PDB to the flight controller board. If you would like to use these
 cables in addition to or instead of the power module or as a common
 point for low current servos, connect the ground (-) wire to a main
-output ground (-) pin and the power (+) wire to a main output power (+)
-pin.
+output ground (-) pin and the power (+) wire to a main output power (+) pin.
 
 .. note::
 

--- a/copter/source/docs/hoverthings-flip-sport-quadcopter.rst
+++ b/copter/source/docs/hoverthings-flip-sport-quadcopter.rst
@@ -81,9 +81,9 @@ Assembling the frame
 ====================
 
 #. There are two different construction methods depending on whether you
-   are using a Pixhawk or a PX4.
+   are using a Pixhawk or a PX4FMU/PX4IO.
 #. For the Pixhawk you will use the second untabbed center plate on top
-   as shown above, for a PX4 you will not.
+   as shown above, for a PX4FMU/PX4IO you will not.
 #. Construction procedure is as follows (Use blue Locktite on all
    machine screws.)
 #. Assemble the 2 tabbed center sections with four 7/8" standoffs on the
@@ -153,20 +153,20 @@ Installing the Pixhawk flight controller
 #. Mount the GPS module to the top center of the top frame plate using
    double sided tape.
 
-Installing the Px4 FMU / PX4IO flight controller
-================================================
+Installing the PX4FMU/PX4IO flight controller
+=============================================
 
 #. If you are using a PX4 we can't use the top frame plate but can
    construct a little hard top if desired.
 #. Cut a 2" by 2" rectangle from scrap plastic or fiberglass to support
-   the PX4.
+   the PX4FMU/PX4IO.
 #. Drill 4 holes in the rectangle that line up with the mounting hole in
    the PX4 board (roughly centered)
 #. using 4 of the supplied black screws, mount 4 standoffs to the
    rectangle.
 #. Insert the PX4FMU board (connector side up) over the 4 standoff studs
    and (carefully) screw 4 more standoffs over them.
-#. Carefully fasten 4 nuts over the exposed studs securing the PX4
+#. Carefully fasten 4 nuts over the exposed studs securing the PX4FMU/PX4IO
    modules to the rectangle you made.
 #. Place the PX4IO board over the PX4FMU board so that the connector is
    aligned and push down over the studs.
@@ -176,11 +176,11 @@ Installing the Px4 FMU / PX4IO flight controller
    servo connector facing to the rear (between the black frame arms).
 #. Drill a hole through the top 2 frame plates near a frame arm near the
    edge on one side to accommodate the "safety" button.
-#. Also mount the buzzer on the top frame member behind the PX4 stack
+#. Also mount the buzzer on the top frame member behind the PX4FMU/PX4IO stack
    such that it does not touch the "rectangle".
 #. Insert the power connector into the PX4IO board and solder the power
    leads and the ESC power leads to a battery connector.
-#. Connect the buzzer and "Safety" button leads to the PX4 boards.
+#. Connect the buzzer and "Safety" button leads to the PX4FMU/PX4IO boards.
 #. Install the ESC's signal leads into the PX4IO board servo connectors
    (signal wire on top).
 #. 
@@ -194,7 +194,7 @@ Installing the Px4 FMU / PX4IO flight controller
    #. Ensure that your receiver does not block the USB connector on the
       side of the PX4FMU board (put it on the other side).
    #. Run a single servo lead from the PPM-Sum output of the receiver to
-      the far left side of the Px4IO servo connector.
+      the far left side of the PX4IO servo connector.
    #. Or if it is a Spektrum Satellite receiver run the Spektrum
       receiver lead to the Spektrum socket on top of the Pixhawk.
 
@@ -246,9 +246,7 @@ Setup and additions
 ===================
 
 #. Your Flip can now be configured as described elsewhere in this wiki
-   for Pixhawk (recommended) or PX4.
-#. For a PX4 set both board and compass orientation parameters to "Roll
-   180" because it is installed upside down for connector access.
+   for Pixhawk.
 #. There is space for a 3DR telemetry radio and / or an OSD and FPV
    transmitter between the 2 side tabs.
 
@@ -262,6 +260,5 @@ Setup and additions
 #. I have had several crashes and only managed to break 2 props while
    trying (unsuccessfully) to cut down a 80' bull pine tree with them.
 #. This little copter is very high performance, fully acrobatic,
-   surprisingly efficient and nearly indestructible and it is a blast to
-   fly.
+   surprisingly efficient and nearly indestructible and it is a blast to fly.
 

--- a/copter/source/docs/px4fmu-only-wiring.rst
+++ b/copter/source/docs/px4fmu-only-wiring.rst
@@ -97,21 +97,21 @@ Wiring the PX4FMU Board to Your QuadCopter
    -  Connect the PPM-SUM RC Receivers Power lead to pin 1 of the Multi
       connector on the PX4 board.
 
--  **Wire the PX4 boards 4 servo out signals to the ESC control
+-  **Wire the PX4FMU board's 4 servo out signals to the ESC control
    inputs.**
 
    -  The wires can be put together with connectors as shown in the
       diagram or solder and heat shrink tubing can be used.
-   -  Wire PX4 PWM control 4 (Multi Connector pin 9) to The ESC signal
+   -  Wire PX4FMU PWM control 4 (Multi Connector pin 9) to The ESC signal
       in for Motor 4.
-   -  Wire PX4 PWM control 2 (Multi Connector pin 10) to The ESC signal
+   -  Wire PX4FMU PWM control 2 (Multi Connector pin 10) to The ESC signal
       in for Motor 2.
-   -  Wire PX4 PWM control 1 (Multi Connector pin 11) to The ESC signal
+   -  Wire PX4FMU PWM control 1 (Multi Connector pin 11) to The ESC signal
       in for Motor 1.
-   -  Wire PX4 PWM control 3 (Multi Connector pin 12) to The ESC signal
+   -  Wire PX4FMU PWM control 3 (Multi Connector pin 12) to The ESC signal
       in for Motor 3.
 
--  **Run a wire from the PX4's Battery Monitor connection (Multi
+-  **Run a wire from the PX4FMU's Battery Monitor connection (Multi
    Connector pin 5) to the positive battery power lead.**
 -  **Note! The cable that is supplied in the plastic envelope with the
    UBLOX GPS which has white 6 pin connectors on both ends is NOT the

--- a/copter/source/docs/px4fmu-plus-px4io-wiring.rst
+++ b/copter/source/docs/px4fmu-plus-px4io-wiring.rst
@@ -1,14 +1,14 @@
 .. _px4fmu-plus-px4io-wiring:
 
-==============================
-Archived:PX4 Wiring QuickStart
-==============================
+=================================
+Archived:PX4FMU Wiring QuickStart
+=================================
 
 .. warning::
 
     **ARCHIVED**
     
-    The PX4 is end of life and is not generally available for purchase. 
+    The PX4FMU is end of life and is not generally available for purchase. 
     This article is made available for existing users.
 
 This article provides an overview of the :ref:`PX4FMU <common-px4fmu-overview>` and
@@ -23,13 +23,13 @@ PX4FMU plus PX4IO Wiring Diagrams
 .. figure:: ../../../images/PX4FMU_PX4IO_Wire_3DRradio2.jpg
    :target: ../_images/PX4FMU_PX4IO_Wire_3DRradio2.jpg
 
-   PX4 Wiring: PX4FMU plus PX4IO with 3DR 8 channel encoder and 3DRtelemetry radio
+   Wiring: PX4FMU plus PX4IO with 3DR 8 channel encoder and 3DR Telemetry radio
 
 Assembly
 ========
 
 #. **Solder the right angle 9x3 pin connector that was included with
-   your PX4 kit to the side of the PX4IO board that has "PX4 autopilot"
+   your PX4FMU kit to the side of the PX4IO board that has "PX4 autopilot"
    printed on it.**
 
    #. When you insert the 9 x 3 connector into the PX4IO board put it in
@@ -115,7 +115,7 @@ Wire the PX4FMU and PX4IO boards to Your Copter
    x 3 angle connector that is nearest the edge of the PX4IO board with
    the signal wire furthest from the board and the ground closest to the
    board.**
-#. **Wire the PX4 boards servo out signals to your ESC control inputs.**
+#. **Wire the PX4FMU board's servo out signals to your ESC control inputs.**
 
    #. Run the Signal wires ONLY from the ESCs to the 3 x 9 Servo
       Connector on the PX4IO board.
@@ -218,7 +218,7 @@ female servo jumpers.
 Compatible remote control (RC) receivers
 ========================================
 
-PX4 is compatible with PPM remote control (RC) receivers, Futaba S.Bus
+PX4FMU is compatible with PPM remote control (RC) receivers, Futaba S.Bus
 receivers, and Spektrum DSM,DSM2, and DSM-X Satellite receivers. For
 traditional single-wire-per-channel (PWM) receivers a PPM encoder can be
 used to convert the receiver outputs to PPM-SUM.  Information about

--- a/copter/source/docs/set-motor-range.rst
+++ b/copter/source/docs/set-motor-range.rst
@@ -16,7 +16,7 @@ Measuring the deadzone
 ======================
 
 -  Remove the propellers from the vehicle
--  Connect the lipo battery
+-  Connect the LiPo battery
 -  Connect the flight controller to the Mission Planner using a USB cable or telemetry
 -  Open the Mission Planner's Initial Setup >> Optional Hardware >> Motor Test page
 

--- a/copter/source/docs/sonar.rst
+++ b/copter/source/docs/sonar.rst
@@ -67,21 +67,17 @@ A0 pins as shown in the diagram below:
 .. image:: ../images/APM2_Sonar.jpg
     :target: ../_images/APM2_Sonar.jpg
 
-Connecting the Sonar Sensor on PX4
-==================================
+Connecting the Sonar Sensor on PX4FMU
+=====================================
 
 You will need to assign the Sonar (signal line) to an appropriate PX4
 pin in Mission Planner - Configuration - Advanced Params - Adv Parameter
-List using the SONAR_PIN parameter.  The following PX4 "Pins" are
-available for SONAR use.
+List using the SONAR_PIN parameter.  The following PX4 "Pins" are available for SONAR use.
 
 SONAR_PIN = 11 - (recommended)
 
-The "airspeed" pin. Located on a 3 pin DF13 connector on the PX4IO
-
-board, but directly visible to the ADC on the PX4FMU. This pin can
-
-take voltages up to 6.6V (it has an internal voltage divider).
+The "airspeed" pin. Located on a 3 pin DF13 connector on the PX4IO board, but directly visible to the ADC on the PX4FMU. 
+This pin can take voltages up to 6.6V (it has an internal voltage divider).
 
 SONAR_PIN = 12
 

--- a/copter/source/docs/troubleshooting.rst
+++ b/copter/source/docs/troubleshooting.rst
@@ -181,7 +181,7 @@ Check the following:
    receiver and telemetry (TM1000+AR8000 to DX8) module, connect them
    both together(TM1000 to AR8000). With the transmitter off (DX8 off),
    press the tiny button on the side of the telemetry module (TM1000)
-   and power the receiver (plug the lipo batteries but do not plug the
+   and power the receiver (plug the LiPo batteries but do not plug the
    4-wire connection). Both the receiver and telemetry module will start
    to blink (if they do not blink TM1000 is no good). When that happens
    turn on your radio holding the trainer/bind button and it will bind

--- a/copter/source/docs/what-you-need.rst
+++ b/copter/source/docs/what-you-need.rst
@@ -24,7 +24,7 @@ are also supported.
 You'll need a radio control transmitter to manually control your Copter
 and to activate its flight modes. You can use any RC
 transmitter/receiver system with at least six channels. Some of the
-options are discussed in the topic :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk/PX4) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
+options are discussed in the topic :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
 
 .. image:: ../../../images/spektrum-dx8.jpg
     :target: ../_images/spektrum-dx8.jpg

--- a/dev/source/docs/advanced-configuration-settings.rst
+++ b/dev/source/docs/advanced-configuration-settings.rst
@@ -972,4 +972,4 @@ copy was taken.
     EKF2 Estimation System <ekf2-estimation-system>
     How to sign a Pixhawk with your Certificate of Authenticity <how-to-use-the-auth-command-to-sign-a-pixhawk-board-with-your-certificate-of-authenticity>
     Forcing Pixhawk px4io flash <pixhawk-force-px4io-flash>
-    Troubleshooting Pixhawk/PX4 Boot <troubleshooting-pixhawkpx4-boot>
+    Troubleshooting Pixhawk Boot <troubleshooting-pixhawkpx4-boot>

--- a/dev/source/docs/building-apm2-with-eclipse-on-windows.rst
+++ b/dev/source/docs/building-apm2-with-eclipse-on-windows.rst
@@ -6,14 +6,16 @@ Archived: Building ArduPilot for APM2.x with Eclipse on Windows
 
 .. warning::
 
-    This topic is archived because APM2.x is no longer a supported autopilot (since AC3.2.1). The information may still be relevant if attempting to use Eclipse for Pixhawk or other autopilots.
+    This topic is archived because APM2.x is no longer a supported autopilot (since AC3.2.1). 
+    The information may still be relevant if attempting to use Eclipse for Pixhawk or other autopilots.
     
 
 This article shows how to build ArduPilot for APM2.x on Windows using the Eclipse IDE.
 
 .. note::
 
-   These instructions show to use *Eclipse Luna* from the *PX4 Toolchain* to build for APM targets. They have been tested by building the *ArduCopter-3.2.1* branch on Windows 10.
+   These instructions show to use *Eclipse Luna* from the *PX4 Toolchain* to build for APM2.x targets. 
+   They have been tested by building the *ArduCopter-3.2.1* branch on Windows 10.
 
 .. warning::
 

--- a/dev/source/docs/building-ardupilot-for-apm2-x-on-windows-with-make.rst
+++ b/dev/source/docs/building-ardupilot-for-apm2-x-on-windows-with-make.rst
@@ -140,7 +140,7 @@ Hints for speeding up compile time
 ==================================
 
 Anti virus protection is likely to slow the compile times especially for
-PX4 so it is recommended that the folders containing the ArduPilot
+Pixhawk so it is recommended that the folders containing the ArduPilot
 source code is excluded from your virus protections real-time scan.
 
 The first scan after a ``make px4-clean`` will be very slow as it

--- a/dev/source/docs/building-px4-with-qtcreator.rst
+++ b/dev/source/docs/building-px4-with-qtcreator.rst
@@ -1,23 +1,22 @@
 .. _building-px4-with-qtcreator:
 
-=====================================================================
-Building ArduPilot for Pixhawk/PX4 on Windows or Linux with QtCreator
-=====================================================================
+=================================================================
+Building ArduPilot for Pixhawk on Windows or Linux with QtCreator
+=================================================================
 
 This article shows how you can set up Qt Creator for editing ArduPilot code
-and building for Pixhawk/PX4 targets on Windows and Linux.
+and building for Pixhawk targets on Windows and Linux.
 
 Preconditions for Linux
 =======================
 
-Follow the instructions in :ref:`Building for Pixhawk/PX4 on Linux with Make <building-px4-with-make>`
-to download the required source code
-(*ardupilot*, *PX4Firmware* and *PX4NuttX*) and toolchain.
+Follow the instructions in :ref:`Building for Pixhawk on Linux with Make <building-px4-with-make>`
+to download the required source code (*ardupilot*, *PX4Firmware* and *PX4NuttX*) and toolchain.
 
 Preconditions for Windows
 =========================
 
-Follow the instructions in :ref:`Pixhawk/PX4 on Windows with Make <building-px4-with-make>` 
+Follow the instructions in :ref:`Pixhawk on Windows with Make <building-px4-with-make>` 
 to download the required source code (*ardupilot*, *PX4Firmware* and *PX4NuttX*) and toolchain.
 
 Make sure you have no Cygwin installed (or have it at least out of the environment variables), 
@@ -221,7 +220,7 @@ This section discusses how to build the code in Qt Creator.
 Apply coding style guidelines
 =============================
 It is useful that the Qt Creator editor is configured so that it automatically applies the layout guidelines
-described in :ref:`Ardupilot Style Guide <style-guide>`.
+described in :ref:`ArduPilot Style Guide <style-guide>`.
 		
 #. Indentation: Click on the **Tools** menu
    and choose **Options**. Subsequently, pick the **Text Editor** view and then the **Behaviour** tab page.
@@ -230,6 +229,6 @@ described in :ref:`Ardupilot Style Guide <style-guide>`.
 #. Other interesting settings can be found in the **C++** view in the same *Options* dialog. You can define
    how specific parts of your code will be aligned (e.g. assignments, switch/cases, control statements, braces, etc.)
    
-#. Commenting: In order to comply with the coding guidelines , you will need to provide docmentation in Doxygen format.
+#. Commenting: In order to comply with the coding guidelines , you will need to provide documentation in Doxygen format.
    Qt Creator will automatically generate a Doxygen documentation template if you type ``/**`` before the definition
    of the class, function, ...   

--- a/dev/source/docs/building-the-code-onlinux.rst
+++ b/dev/source/docs/building-the-code-onlinux.rst
@@ -124,7 +124,7 @@ the top level of the repository. You can set some defaults in
 
 2. In the sketch directory, type ``make`` to build for APM2.
 Alternatively, ``make apm1`` will build for the APM1 and \`make px4\`
-will build for the PX4. The binaries will generated in
+will build for the Pixhawk. The binaries will generated in
 \`/tmp/\ *sketchname*.build\`.
 
 3. Type \`make upload\` to upload. You may need to set the correct

--- a/dev/source/docs/building-the-code.rst
+++ b/dev/source/docs/building-the-code.rst
@@ -59,7 +59,7 @@ Deprecated instructions
 - :ref:`APM2.x on MacOS with Arduino <building-the-code-on-mac>`
 - :ref:`APM2.x on Linux with Make <building-the-code-onlinux>`
 - :ref:`Building for Flymaple on Linux <building-apm-for-flymaple>`
-- :ref:`Building for Pixhawk/PX4 on Windows or Linux with QtCreator <building-px4-with-qtcreator>`
+- :ref:`Building for Pixhawk on Windows or Linux with QtCreator <building-px4-with-qtcreator>`
 - :ref:`Building for NAVIO+ on RPi2 <building-for-navio-on-rpi2>`
 
 Links to all build pages

--- a/dev/source/docs/building_with_make.rst
+++ b/dev/source/docs/building_with_make.rst
@@ -122,7 +122,7 @@ based platforms.
     $ cd ArduPlane
     $ make upload
 
-For PX4 platforms, the \`px4-upload\` target will use the PX4 bootloader
+For Pixhawk platforms, the \`px4-upload\` target will use the PX4 bootloader
 to perform an upload.
 
 Troubleshooting

--- a/dev/source/docs/can-bus.rst
+++ b/dev/source/docs/can-bus.rst
@@ -58,7 +58,7 @@ but instead should send all data to AP_UAVCAN class in their own preferable way.
 Initialization description
 ==========================
 
-The following initialization is based on px4 hardware and is provided as example
+The following initialization is based on Pixhawk hardware and is provided as example.
 
 .. image:: ../images/can_init.png
 

--- a/dev/source/docs/extended-kalman-filter.rst
+++ b/dev/source/docs/extended-kalman-filter.rst
@@ -14,7 +14,7 @@ available tuning parameters.
 Overview
 ========
 
-The availability of faster processors such as Pixhawk and the PX4 have
+The availability of faster processors (like the one on Pixhawk) have
 enabled more advanced mathematical algorithms to be implemented to
 estimate the orientation, velocity and position of the flight vehicle.
 An Extended Kalman Filter (EKF) algorithm has been developed that uses
@@ -40,7 +40,7 @@ significant errors so that the vehicle becomes less susceptible to
 faults that affect a single sensor.
 
 Another feature of the EKF algorithm is that it is able to estimate
-offsets in the vehicles compas readings and also estimate the earth's
+offsets in the vehicles compass readings and also estimate the earth's
 magnetic field for both plane, copter and rover applications. This makes
 it less sensitive to compass calibration errors than current DCM and
 INAV algorithms.

--- a/dev/source/docs/how-to-use-the-auth-command-to-sign-a-pixhawk-board-with-your-certificate-of-authenticity.rst
+++ b/dev/source/docs/how-to-use-the-auth-command-to-sign-a-pixhawk-board-with-your-certificate-of-authenticity.rst
@@ -6,7 +6,7 @@ How to use the "auth" command to sign a Pixhawk Board with your Certificate of A
 
 The essence of this process is an RSA private/public key pair and a
 signing process that uses these keys to put some unique information onto
-every PX4 board.
+every Pixhawk board.
 
 Public/Private Key/s, SD Card, and Logging
 ==========================================
@@ -78,7 +78,7 @@ Preparing SD card (one time only)
    public key.  See below.
 -  Make the public key file on the SD card:
 
-   -  With the SD card inserted, and the PX4 booted, use the *nsh
+   -  With the SD card inserted, and the Pixhawk booted, use the *nsh
       shell*, and type:
 
       ::

--- a/dev/source/docs/learning-ardupilot-the-example-sketches.rst
+++ b/dev/source/docs/learning-ardupilot-the-example-sketches.rst
@@ -38,8 +38,9 @@ waf can list the examples it can build:
 
 Once you have uploaded the example you can look at the output by
 attaching to the console. What the console is depends on the type of
-board. On PX4 boards (ie. PX4v1 and Pixhawk) it is the USB connector. So
-just connect to the USB device with your favourite serial program (the
+board. 
+On Pixhawk boards it is the USB connector. 
+So just connect to the USB device with your favourite serial program (the
 baudrate doesn't matter).
 
 For example, if you have mavproxy installed, you could do this to
@@ -110,12 +111,12 @@ in the loop() function.
 Note that this setup()/loop() arrangement is only the tip of the iceberg
 for more complex boards. It may make it seem that ArduPilot is single
 threaded, but in fact there is a lot more going on underneath, and on
-boards that have threading (such as PX4 and Linux based boards) there
+boards that have threading (such as Pixhawk and Linux based boards) there
 will in fact be lots of realtime threads started. See the section on
 understanding ArduPilot threading below.
 
 The AP_HAL_MAIN() macro
--------------------------
+-----------------------
 
 You will notice a extra line like this at the bottom of every sketch:
 

--- a/dev/source/docs/learning-ardupilot-threading.rst
+++ b/dev/source/docs/learning-ardupilot-threading.rst
@@ -66,7 +66,7 @@ HAL specific threads
 
 On platforms that support real threads the AP_HAL for that platform
 will create a number of threads to support basic operations. For
-example, on PX4 the following HAL specific threads are created:
+example, on Pixhawk the following HAL specific threads are created:
 
 -  The UART thread, for reading and writing UARTs (and USB)
 -  The timer thread, which supports the 1kHz timer functionality
@@ -153,8 +153,8 @@ libraries/AP_InertalSensor/AP_InertialSensor_MPU6000.cpp, and another
 MPU6000 driver in PX4Firmware/src/drivers/mpu6000.
 
 The reason for this duplication is that the PX4 project already provides
-a set of well tested drivers for hardware that comes with PX4 boards,
-and we enjoy a good collaborative relationship with the PX4 project on
+a set of well tested drivers for hardware that comes with Pixhawk boards,
+and we enjoy a good collaborative relationship with the PX4 team on
 developing and enhancing these drivers. So when we build ArduPilot for
 PX4 we take advantage of the PX4 drivers by writing small "shim" drivers
 which present the PX4 drivers with the standard ArduPilot library
@@ -165,8 +165,8 @@ this board and automatically makes all of them available as part of the
 ArduPilot AP_InertialSensor library.
 
 So if we have an MPU6000 on the board we use the
-AP_InertialSensor_MPU6000.cpp driver on non-PX4 platforms, and the
-AP_InertialSensor_PX4.cpp driver on PX4 based platforms.
+AP_InertialSensor_MPU6000.cpp driver on non-Pixhawk/NuttX platforms, and the
+AP_InertialSensor_PX4.cpp driver on NuttX based platforms.
 
 The same type of split can also happen for other AP_HAL ports. For
 example, we could use Linux kernel drivers for some sensors on Linux

--- a/dev/source/docs/pixhawk-advanced-hardware-info.rst
+++ b/dev/source/docs/pixhawk-advanced-hardware-info.rst
@@ -13,4 +13,4 @@ Please follow the links below to learn more about potential Pixhawk boot issues 
 
     How to sign a Pixhawk with your Certificate of Authenticity <how-to-use-the-auth-command-to-sign-a-pixhawk-board-with-your-certificate-of-authenticity>
     Loading a bootloader with DFU <using-DFU-to-load-bootloader>
-    Troubleshooting Pixhawk/PX4 Boot <troubleshooting-pixhawkpx4-boot>
+    Troubleshooting Pixhawk Boot <troubleshooting-pixhawkpx4-boot>

--- a/dev/source/docs/troubleshooting-pixhawkpx4-boot.rst
+++ b/dev/source/docs/troubleshooting-pixhawkpx4-boot.rst
@@ -1,25 +1,20 @@
 .. _troubleshooting-pixhawkpx4-boot:
 
-================================
-Troubleshooting Pixhawk/PX4 Boot
-================================
+============================
+Troubleshooting Pixhawk Boot
+============================
 
-This article explains how to check if the Pixhawk/PX4 has booted
-properly.
+This article explains how to check if the Pixhawk has booted properly.
 
-The following tests can help you determine if boot has failed, and
-possible causes:
+The following tests can help you determine if boot has failed, and possible causes:
 
--  Check the Pixhawk/PX4
-   :ref:`LEDs <copter:common-leds-pixhawk>`
+-  Check the Pixhawk :ref:`LEDs <copter:common-leds-pixhawk>`
    and
    :ref:`Sounds <copter:common-sounds-pixhawkpx4>`
    as these can immediately confirm a successful boot. If boot fails,
    these can broadly indicate the point of failure.
--  Check that the the board has appropriate ArduPilot firwmare
-   installed.
--  Ensure the memory card is fully inserted into the Pixhawk/controller
-   card socket.
+-  Check that the the board has appropriate ArduPilot firwmare installed.
+-  Ensure the memory card is fully inserted into the Pixhawk/controller card socket.
 -  **Check the boot log:**
 
    #. Remove the SD card from from the board and insert into your

--- a/planner/source/docs/mission-planner-overview.rst
+++ b/planner/source/docs/mission-planner-overview.rst
@@ -21,7 +21,7 @@ autonomous vehicle. Here are just a few things you can do with Mission
 Planner:
 
 -  Load the :ref:`firmware <common-glossary>` (the software) into the
-   autopilot (APM, PX4...) that controls your vehicle.
+   autopilot board (i.e. Pixhawk series) that controls your vehicle.
 -  Setup, configure, and tune your vehicle for optimum performance.
 -  Plan, save and load autonomous missions into you autopilot with
    simple point-and-click way-point entry on Google or other maps.

--- a/planner2/source/docs/compass-calibration.rst
+++ b/planner2/source/docs/compass-calibration.rst
@@ -21,7 +21,7 @@ Before preforming setup, ensure that:
 ---------------
 
 Under **Orientation**, **select your autopilot** configuration:
-Pixhawk/PX4, APM 2.5 and earlier, or APM 2.6 with 3DR GPS+Compass.
+Pixhawk, APM 2.5 and earlier, or APM 2.6 with 3DR GPS+Compass.
 Ensure that the option to **Enable the compass** and **allow Auto
 Declination** are selected as shown below.
 

--- a/planner2/source/docs/install-firmware.rst
+++ b/planner2/source/docs/install-firmware.rst
@@ -29,8 +29,8 @@ firmware installation in complete.
 .. image:: ../images/ap2_install-firmware-complete.png
     :target: ../_images/ap2_install-firmware-complete.png
 
-3 (Pixhawk/PX4) Power cycle and listen for the tone.
-----------------------------------------------------
+3 (Pixhawk) Power cycle and listen for the tone.
+------------------------------------------------
 
 After the firmware installation is complete, power cycle your vehicle by
 disconnecting and reconnecting the USB. Listen for the tone! If you hear

--- a/rover/source/docs/gettit.rst
+++ b/rover/source/docs/gettit.rst
@@ -68,7 +68,7 @@ it will have at least two toggles switches, and one of those switches
 will have three positions. If you're on a budget, the `Turnigy 9x <http://hobbyking.com/hobbyking/store/__8992__Turnigy_9X_9Ch_Transmitter_w_Module_8ch_Receiver_Mode_2_v2_Firmware_.html>`__ ($54)
 is a popular choice. If you'd like better quality, we like the :ref:`Taranis FrSky Reciever <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems_frsky_taranis_ppm-sum_compatible_transmitter>`.
 
-Some other options are discussed in the topic :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk/PX4) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
+Some other options are discussed in the topic :ref:`Compatible RC Transmitter and Receiver Systems (Pixhawk) <common-pixhawk-and-px4-compatible-rc-transmitter-and-receiver-systems>`.
 
 GPS module
 ----------

--- a/rover/source/docs/rover-px4-quickstart.rst
+++ b/rover/source/docs/rover-px4-quickstart.rst
@@ -1,8 +1,8 @@
 .. _rover-px4-quickstart:
 
 =========================================
-Archived:Rover PX4 Wiring and Quick Start
-=========================================
+Archived:Rover PX4FMU/PX4IO Wiring and Quick Start
+==================================================
 
 .. warning::
 
@@ -12,7 +12,7 @@ Archived:Rover PX4 Wiring and Quick Start
     This article is made available for existing users.
 
 This article provides high level information about how to wire up the
-:ref:`PX4 autopilot board <common-px4fmu-overview>` for Rover and connect
+:ref:`PX4FMU/PX4IO autopilot board <common-px4fmu-overview>` for Rover and connect
 its most important peripherals.
 
 Mounting the PX4FMU / PX4IO board stack
@@ -29,7 +29,7 @@ See also :ref:`Mounting the Flight Controller <common-mounting-the-flight-contro
 RC Setup
 ========
 
-PX4 uses a single PPM sum RC input. Output depends on whether a steering
+Pixhawk uses a single PPM sum RC input. Output depends on whether a steering
 servo or "skid steer" (left or right motors turn faster to turn in the
 opposite direction) is used on your rover
 
@@ -49,14 +49,14 @@ Reassigning your RC transmitter stick channels
 The default transmitter stick configuration should be suitable in almost
 all cases. If you do need to change them, then see :ref:`RCMAP Input Channel Mapping <common-rcmap>`.
 
-PX4 Normal One Motor Servo Steering Wiring Diagram
---------------------------------------------------
+Normal One Motor Servo Steering Wiring Diagram
+----------------------------------------------
 
 .. image:: ../images/PX4IOWiringRover2.jpg
     :target: ../_images/PX4IOWiringRover2.jpg
 
-PX4 Two Motor Skid Steering Wiring Diagram
-------------------------------------------
+Two Motor Skid Steering Wiring Diagram
+--------------------------------------
 
 .. image:: ../images/PX4IOWiringRoverSkid1.jpg
     :target: ../_images/PX4IOWiringRoverSkid1.jpg
@@ -64,10 +64,9 @@ PX4 Two Motor Skid Steering Wiring Diagram
 Check out the Basic Operating Modes of the Rover2 Firmware
 ==========================================================
 
-**The PX4 must have its automatic Safety disengaged before the Rover can
-be driven.**
+**The board must have its automatic Safety disengaged before the Rover can be driven.**
 
--  **PX4 Safety Button LED Indications:**
+-  **Safety Button LED Indications:**
 
    -  Fast Blinking indicates: Error Condition, Safety cannot be
       disengaged. Possibly not calibrated or sensor error.
@@ -88,8 +87,8 @@ Test MANUAL mode
 ----------------
 
 To test the Manual mode, put the Rover up on blocks, to prevent a
-runaway, turn on the R/C transmitter, power up the APM or PX4
-(depressing the safety button on the PX4 for 5 seconds to disengage the
+runaway, turn on the R/C transmitter, power up the flight controller
+(depressing the safety button on the PX4FMU for 5 seconds to disengage the
 safety lock (LED solid on)), and when a 3D lock has been obtained
 
 #. verify that when the elevator joystick is moved forward that the
@@ -98,7 +97,7 @@ safety lock (LED solid on)), and when a 3D lock has been obtained
 #. the steering wheels go to the left and vice versa.
 #. A R/C receiver radio tester that can display channel PWM values can
    also be used to determine the throttle and steering outputs of the
-   APM/PX4.
+   Pixhawk.
 #. If either the throttle or steering channel is reversed, then the R/C
    transmitter channel reversing function must be used to reverse the
    appropriate channel.

--- a/rover/source/docs/sonar-sensors.rst
+++ b/rover/source/docs/sonar-sensors.rst
@@ -56,12 +56,12 @@ on the other side is an IR sensor, used to compare results.
 .. image:: ../images/rover_apm2.x_setup.jpg
     :target: ../_images/rover_apm2.x_setup.jpg
 
-**PX4 Sonar Pins:** Sonar is now supported for Rover on the PX4. You
+**PX4 Sonar Pins:** Sonar is now supported for Rover on PX4FMU/PX4IO. You
 will need to assign one or both possible Sonars to the appropriate
 "SONAR_PIN and SONAR2_PIN parameters in: Mission Planner -
 Configuration - Advanced Params - Adv Parameter List.
 
-The following PX4 "Pins" are available for Sonar use.
+The following PX4FMU/PX4IO "Pins" are available for Sonar use.
 
 -  PIN = 11 : The "airspeed" pin. Located on a 3 pin DF13 connector on
    the PX4IO board, but directly visible to the ADC on the PX4FMU. This


### PR DESCRIPTION
Tried to fix this up
- Where PX4 means Pixhawk, this has been changed
- Where PX4 means PX4FMU/PX4IO has been changed.
- Minor tidy of other bits.

There are still some problem cases - ie misuses in parameter docs.