### PR TITLE
TF-Mini Lidar via serial incorrect configuration

### DIFF
--- a/common/source/docs/common-benewake-tfmini-lidar.rst
+++ b/common/source/docs/common-benewake-tfmini-lidar.rst
@@ -28,7 +28,7 @@ If the SERIAL4/5 port on a Pixhawk is being used then the following parameters s
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 20 (Benewake TFmini)
+-  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 8 (LightWare Serial)
 -  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 30
 -  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **1000** for indoor use OR **600** for outdoors.  *This is the distance in centimeters that the rangefinder can reliably read.*
 -  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*


### PR DESCRIPTION
Setting the RNGFND_TYPE to 20 does not currently work over serial ports! It only works when = 8.