### PR TITLE
Fix broken links in FrSky Telemetry

### DIFF
--- a/common/source/docs/common-frsky-telemetry.rst
+++ b/common/source/docs/common-frsky-telemetry.rst
@@ -434,7 +434,7 @@ Enabling Scripts on OpenTX
 
    The version installed on your Taranis may not have the option to run scripts. If this is the case, you will need to install a new version via OpenTX Companion. This can be done in a few easy steps.
 
-   1. Download and install the latest version of OpenTX Companion from `OpenTX <www.open-tx.org/downloads.html>`__. Open the OpenTX Companion program, then go to Settings >> Settings
+   1. Download and install the latest version of OpenTX Companion from `OpenTX <http://www.open-tx.org/downloads.html>`__. Open the OpenTX Companion program, then go to Settings >> Settings
 
    .. image:: ../../../images/opentx_settingstab.png
        :target: ../_images/opentx_settingstab.png
@@ -534,7 +534,7 @@ Requirements
   the firmware and about ErSky9x in general from `the
   documentation`_.
 
-.. _frsky xjt: http://www.frsky-rc.com/product/pro.php?pro_id=104
+.. _frsky xjt: https://www.frsky-rc.com/product/xjt-2/
 .. _djt:  http://www.frsky-rc.com/product/pro.php?pro_id=8
 .. _the documentation: http://openrcforums.com/forum/viewtopic.php?f=122&t=5575#p79483
 


### PR DESCRIPTION
One link wasn't going external. The other was a 404 error due to a change.