### PR TITLE
Irlock broken links

### DIFF
--- a/copter/source/docs/precision-landing-with-irlock.rst
+++ b/copter/source/docs/precision-landing-with-irlock.rst
@@ -38,8 +38,8 @@ Connecting to Pixhawk
 
 The IR-LOCK sensor can be connected directly to Pixhawk via an `I2C cable <https://irlock.com/collections/shop/products/pixhawk-cable>`__. If
 you are using multiple I2C sensors, then you will need an \ `I2C splitter <http://store.jdrones.com/Pixhawk_I2C_splitter_p/dstpx4i2c01.htm>`__.
-More detailed instructions are included in the `irlock.com Documentation <https://irlock.readme.io/docs>`__. The IR-LOCK sensor can
-also be `connected via USB to a Linux system <https://irlock.readme.io/docs/interfacing-sensor-w-linux-and-python>`__,
+More detailed instructions are included in the `irlock.com Documentation <https://irlock.readme.io/docs>`__. 
+The IR-LOCK sensor can also be `connected via USB to a Linux system <https://irlock.readme.io/v1.0/docs/interfacing-sensor-w-linux-and-python>`__,
 and sensor output can be retrieved in Python.
 
 .. figure:: ../images/precision_landing_connect_irlock_to_pixhawk.jpg
@@ -110,7 +110,7 @@ and examine the PL messages.
 -  The pX, pY values show the horizontal distance to the target from the vehicle.
 -  The vX, vY values show the estimated velocity of the target relative to the vehicle.
 
-Refer to the IR-LOCK `wiki page <https://irlock.readme.io/docs/interpreting-pl-logs>`__ for more trouble-shooting information.
+Refer to the IR-LOCK `wiki page <https://irlock.readme.io/v1.0/docs/interpreting-pl-logs>`__ for more trouble-shooting information.
 
 ..  youtube:: IRfo5GcHniU
     :width: 100%

--- a/copter/source/docs/precision-landing-with-irlock.rst
+++ b/copter/source/docs/precision-landing-with-irlock.rst
@@ -39,8 +39,6 @@ Connecting to Pixhawk
 The IR-LOCK sensor can be connected directly to Pixhawk via an `I2C cable <https://irlock.com/collections/shop/products/pixhawk-cable>`__. If
 you are using multiple I2C sensors, then you will need an \ `I2C splitter <http://store.jdrones.com/Pixhawk_I2C_splitter_p/dstpx4i2c01.htm>`__.
 More detailed instructions are included in the `irlock.com Documentation <https://irlock.readme.io/docs>`__. 
-The IR-LOCK sensor can also be `connected via USB to a Linux system <https://irlock.readme.io/v1.0/docs/interfacing-sensor-w-linux-and-python>`__,
-and sensor output can be retrieved in Python.
 
 .. figure:: ../images/precision_landing_connect_irlock_to_pixhawk.jpg
    :target: ../_images/precision_landing_connect_irlock_to_pixhawk.jpg
@@ -109,8 +107,6 @@ and examine the PL messages.
 -  If the "TAcq" (meaning Target Acquired) field is not "1" then the sensor is not seeing the target.
 -  The pX, pY values show the horizontal distance to the target from the vehicle.
 -  The vX, vY values show the estimated velocity of the target relative to the vehicle.
-
-Refer to the IR-LOCK `wiki page <https://irlock.readme.io/v1.0/docs/interpreting-pl-logs>`__ for more trouble-shooting information.
 
 ..  youtube:: IRfo5GcHniU
     :width: 100%


### PR DESCRIPTION
IR lock have updated their links from v1.0 to [v2.0](https://irlock.readme.io/v2.0/docs). The new docs do not include the instructions/tool for connecting via linux. 

I have fixed the links to point to the 1.0 docs but it is possible that this is not supported for whatever reason. @rmackay9 Any ideas how we can find out?