### PR TITLE
Fix up all links to mavlink.io

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -131,7 +131,7 @@ potential conflicts.
 
 Developer information including Simulation
 ==========================================
-The data is transmitted via the `ADSB_VEHICLE message <http://mavlink.org/messages/common#ADSB_VEHICLE>`__. When
+The data is transmitted via the `ADSB_VEHICLE message <https://mavlink.io/en/messages/common.html#ADSB_VEHICLE>`__. When
 received by ArduPilot, it is streamed out using the SRx_ADSB value where x is the telemetry port number and the
 value is how many vehicles per second to be streamed. If using telem1 the streamrate param would be ``SR1_ADSB``. The list will not repeat any faster than 1 second. This
 flexibility is useful to conserve bandwidth on data links but also allow maximum update rate for high-speed links

--- a/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
+++ b/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
@@ -214,7 +214,7 @@ a mission):**
 +--------+----------------------------------------------------------------------------------------+
 | CNum   | This command's number in the mission (0 is always home, 1 is the first command, etc)   |
 +--------+----------------------------------------------------------------------------------------+
-| CId    | The `MAVLink message id <http://mavlink.org/messages/common>`__                        |
+| CId    | The `MAVLink message id <https://mavlink.io/en/messages/common.html>`__                        |
 +--------+----------------------------------------------------------------------------------------+
 | Copt   | The option parameter (used for many different purposes)                                |
 +--------+----------------------------------------------------------------------------------------+

--- a/common/source/docs/common-gripper-servo.rst
+++ b/common/source/docs/common-gripper-servo.rst
@@ -53,4 +53,4 @@ The gripper position can be controlled during a mission in AUTO mode using the :
 Controlling Gripper from the ground station
 ===========================================
 
-The gripper can be opened or closed in real-time from the ground station if the ground station sends a `COMMAND_LONG <http://mavlink.org/messages/common#COMMAND_LONG>`__ with the command field set to DO_GRIPPER (i.e. 211) but there are no ground stations (as far as we know) that support doing this.
+The gripper can be opened or closed in real-time from the ground station if the ground station sends a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ with the command field set to DO_GRIPPER (i.e. 211) but there are no ground stations (as far as we know) that support doing this.

--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -2596,7 +2596,7 @@ Set system mode (preflight, armed, disarmed etc.)
    <tr>
    <td><strong>param1</strong></td>
    <td></td>
-   <td>Mode, as defined by `MAV_MODE <http://mavlink.org/messages/common#MAV_MODE>`__</td>
+   <td>Mode, as defined by `MAV_MODE <https://mavlink.io/en/messages/common.html#MAV_MODE>`__</td>
    </tr>
    <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
@@ -3777,7 +3777,7 @@ in the mission.
    <tr>
    <td><strong>param7</strong></td>
    <td></td>
-   <td>`MAV_MOUNT_MODE <http://mavlink.org/messages/common#MAV_MOUNT_MODE>`__ enum value.</td>
+   <td>`MAV_MOUNT_MODE <https://mavlink.io/en/messages/common.html#MAV_MOUNT_MODE>`__ enum value.</td>
    </tr>
    </tbody>
    </table>

--- a/common/source/docs/common-telemetry-port-setup-for-apm-px4-and-pixhawk.rst
+++ b/common/source/docs/common-telemetry-port-setup-for-apm-px4-and-pixhawk.rst
@@ -53,6 +53,6 @@ Due to CPU or bandwidth limitations, the actual rate of the data sent may be low
 
 .. note::
 
-   Most ground stations set the desired stream rate by sending the `REQUEST_DATA_STREAM <http://mavlink.org/messages/common#REQUEST_DATA_STREAM>`__ MAVLink message to the vehicle instead of directly settting the parameters mentioned above.  If done this way, Copter **DOES NOT** save the rate changes to eeprom meaning they will not persist over a reboot.
+   Most ground stations set the desired stream rate by sending the `REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__ MAVLink message to the vehicle instead of directly settting the parameters mentioned above.  If done this way, Copter **DOES NOT** save the rate changes to eeprom meaning they will not persist over a reboot.
 
    In practice users may notice that if the vehicle is rebooted but the telemetry connection is not disconnected and reconnected that the data from the vehicle may be much slower or missing.  I.e. the vehicle's position on the map may not update.  Normally disconnecting/reconnecting with the ground station will resolve this.

--- a/copter/source/docs/ac2_guidedmode.rst
+++ b/copter/source/docs/ac2_guidedmode.rst
@@ -74,6 +74,6 @@ Instructions
 
 Guided_NoGPS
 ============
-This variation of Guided mode does not require a GPS but it only accepts `attitude targets <http://mavlink.org/messages/common#SET_ATTITUDE_TARGET>`__.  Because it does not accept position or velocity targets like regular Guided mode it is generally not useful for regular users.  This mode was created for use by companion computers that may want to fly the vehicle as if it was in AltHold mode.
+This variation of Guided mode does not require a GPS but it only accepts `attitude targets <https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET>`__.  Because it does not accept position or velocity targets like regular Guided mode it is generally not useful for regular users.  This mode was created for use by companion computers that may want to fly the vehicle as if it was in AltHold mode.
 
 This mode is only available in Copter-3.4 (and higher).

--- a/copter/source/docs/mission-command-list.rst
+++ b/copter/source/docs/mission-command-list.rst
@@ -5,7 +5,7 @@ Copter Mission Command List
 ===========================
 
 This page provides details of all the mission commands 
-(i.e. `MAVLink commands <http://mavlink.org/messages/common#MAV_CMD_NAV_WAYPOINT>`__) supported by Copter that can be run as part of a mission (i.e. :ref:`AUTO flight mode <auto-mode>`).
+(i.e. `MAVLink commands <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_WAYPOINT>`__) supported by Copter that can be run as part of a mission (i.e. :ref:`AUTO flight mode <auto-mode>`).
 
 Each of the commands below is either a "Navigation" command or a "Do"
 command.  Navigation commands (i.e. "TakeOff" and "Waypoint") affect the

--- a/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
+++ b/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
@@ -34,7 +34,7 @@ MAV_CMD_NAV_TRICK similar to the MAV_CMD_NAV_WAYPOINT definition
 
 Alternatively you may want to send down a new type of sensor data from
 the vehicle to the ground station.  Perhaps similar to the
-`SCALED_PRESSURE <http://mavlink.org/messages/common#SCALED_PRESSURE>`__
+`SCALED_PRESSURE <https://mavlink.io/en/messages/common.html#SCALED_PRESSURE>`__
 message.
 
 **Step #3:** Add the new message definition to the

--- a/dev/source/docs/code-overview-adding-support-for-a-new-mavlink-gimbal.rst
+++ b/dev/source/docs/code-overview-adding-support-for-a-new-mavlink-gimbal.rst
@@ -15,7 +15,7 @@ Messages the gimbal should support
 ==================================
 
 #. The gimbal should listen on the serial port for a
-   `HEARTBEAT <http://mavlink.org/messages/common#HEARTBEAT>`__ message
+   `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__ message
    from the vehicle. It can generally assume that the first heart beat
    it receives will be from the vehicle but to be certain you can check
    the "type" field to be sure it's something sensible (i.e. MAV_TYPE =
@@ -29,7 +29,7 @@ Messages the gimbal should support
    long as it's not zero nor the component id of the vehicle or any
    other device on the vehicle.
 #. The gimbal should send a
-   `HEARTBEAT <http://mavlink.org/messages/common#HEARTBEAT>`__ message
+   `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__ message
    out the serial port at approximately 1hz
 
    -  the system-id and component-id should be as mentioned above.
@@ -44,25 +44,25 @@ Messages the gimbal should support
 #. To support reading/writing parameter values from the ground station
    the gimbal should implement these message:
 
-   -  `PARAM_REQUEST_READ <http://mavlink.org/messages/common#PARAM_REQUEST_READ>`__
+   -  `PARAM_REQUEST_READ <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_READ>`__
       - if the gimbal receives this message and "target_system" and
       "target_component" values match the gimbal's system-id and
       component-id, it should respond with a
-      `PARAM_VALUE <http://mavlink.org/messages/common#PARAM_VALUE>`__
+      `PARAM_VALUE <https://mavlink.io/en/messages/common.html#PARAM_VALUE>`__
       message which contains the value of the parameter specified by the
       "param_id" field (simply an enum, the gimbal can assign whatever
       enum it wishes to each of it's internal paramters)
-   -  `PARAM_REQUEST_LIST <http://mavlink.org/messages/common#PARAM_REQUEST_LIST>`__
+   -  `PARAM_REQUEST_LIST <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_LIST>`__
       - respond to this message by sending a
-      `PARAM_VALUE <http://mavlink.org/messages/common#PARAM_VALUE>`__
+      `PARAM_VALUE <https://mavlink.io/en/messages/common.html#PARAM_VALUE>`__
       message for every parameter within the gimbal.
-   -  `PARAM_SET <http://mavlink.org/messages/common#PARAM_SET>`__ -
+   -  `PARAM_SET <https://mavlink.io/en/messages/common.html#PARAM_SET>`__ -
       respond to this by setting the internal variable to the value in
       the "param_value" field.
 
 #. Ardupilot will send angle requests to the gimbal via MAVLink which
    will arrive as
-   `COMMAND_LONG <http://mavlink.org/messages/common#COMMAND_LONG>`__
+   `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__
    messages with the "command" field set to MAV_CMD_DO_MOUNT_CONTROL
    (i.e 205).
 
@@ -74,7 +74,7 @@ Messages the gimbal should support
 
 #. If the gimbal needs extra data from the vehicle it can request it
    using the
-   `REQUEST_DATA_STREAM <http://mavlink.org/messages/common#REQUEST_DATA_STREAM>`__
+   `REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__
    message.
 
    -  the target system and component id should be for the vehicle.
@@ -82,11 +82,11 @@ Messages the gimbal should support
       Some useful values are:
 
       -  MAV_DATA_STREAM_POSITION will cause the vehicle to send
-         `GLOBAL_POSITION_INT <http://mavlink.org/messages/common#GLOBAL_POSITION_INT>`__
+         `GLOBAL_POSITION_INT <https://mavlink.io/en/messages/common.html#GLOBAL_POSITION_INT>`__
          messages which includes lat, lon, alt, velocity (3d) and
          heading)
       -  MAV_DATA_STREAM_EXTRA1 will send the
-         `MSG_ATTITUDE <http://mavlink.org/messages/common#ATTITUDE>`__
+         `MSG_ATTITUDE <https://mavlink.io/en/messages/common.html#ATTITUDE>`__
          which includes euler angles for roll, pitch, yaw
 
 Testing

--- a/dev/source/docs/code-overview-object-avoidance.rst
+++ b/dev/source/docs/code-overview-object-avoidance.rst
@@ -4,7 +4,7 @@
 Copter Object Avoidance
 =======================
 
-ArduCopter, from release 3.5, supports object avoidance using a :ref:`Lightware SF40C <copter:common-lightware-sf40c-objectavoidance>`, :ref:`TeraRanger Tower <copter:common-teraranger-tower-objectavoidance>`  or with any sensor capable of providing distances using the MAVLink `DISTANCE_SENSOR <http://mavlink.org/messages/common#DISTANCE_SENSOR>`__ message.
+ArduCopter, from release 3.5, supports object avoidance using a :ref:`Lightware SF40C <copter:common-lightware-sf40c-objectavoidance>`, :ref:`TeraRanger Tower <copter:common-teraranger-tower-objectavoidance>`  or with any sensor capable of providing distances using the MAVLink `DISTANCE_SENSOR <https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR>`__ message.
 This page describes how the object avoidance feature works and how "proximity sensors" should provide data into ArduPilot.
 
 Avoidance in Loiter
@@ -56,7 +56,7 @@ This is quite different from Loiter mode in which the pilot cannot force the veh
 .. note::
 
    The vehicle will also stop before hitting barriers above it there is an upward facing range finder.
-   Currently this range finder's distance must be sent to ardupilot using the `DISTANCE_SENSOR <http://mavlink.org/messages/common#DISTANCE_SENSOR>`__ message with the orientation field set to 24 (upwards).
+   Currently this range finder's distance must be sent to ardupilot using the `DISTANCE_SENSOR <https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR>`__ message with the orientation field set to 24 (upwards).
 
 Reporting to the Ground Station
 ===============================
@@ -80,7 +80,7 @@ These are separate messages though and are likely transferred at a different rat
 Providing Distance Sensor messages to ArduPilot
 ===============================================
 
-For developers of new "proximity" sensors (i.e. sensors that can somehow provide the distance to nearby objects) the easiest method to get your distance measurements into ardupilot is to send `DISTANCE_SENSOR <http://mavlink.org/messages/common#DISTANCE_SENSOR>`__ message for each direction the sensor is capable of.
+For developers of new "proximity" sensors (i.e. sensors that can somehow provide the distance to nearby objects) the easiest method to get your distance measurements into ardupilot is to send `DISTANCE_SENSOR <https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR>`__ message for each direction the sensor is capable of.
 The system id of the message should match the system id of the vehicle (default is "1" but can be changed using the SYSID_THISMAV parameter).
 The component id can be anything but MAV_COMP_ID_PATHPLANNER (195) or MAV_COMP_ID_PERIPHERAL (158) are probably good choices.
 
@@ -92,7 +92,7 @@ These messages should be sent at between 10hz and 50hz (the faster the better). 
 - current_distance : the shortest distance in cm to the object
 - type : 0 (ignored)
 - id : 0 (ignored)
-- orientation : 0 to 7 (0=forward, each increment is 45degrees more in clockwise direction), 24 (upwards) or 25 (downwards).  search for MAV_SENSOR_ORIENTATION on the `mavlink/common page <http://mavlink.org/messages/common>`__.
+- orientation : 0 to 7 (0=forward, each increment is 45degrees more in clockwise direction), 24 (upwards) or 25 (downwards).  search for MAV_SENSOR_ORIENTATION on the `mavlink/common page <https://mavlink.io/en/messages/common.html>`__.
 - covariance : 0 (ignored)
 
 When DISTANCE_SENSOR messages are not received for all 8 sectors, empty sectors are filled in with the distance from an adjacent sector (if available).  This conveniently leads to a "cup" shaped fence which is more likely to protect the vehicle from hitting the object.

--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -31,7 +31,7 @@ MAV_CMDs
 =========
 
 These MAV_CMDs can be processed if packaged within a
-`COMMAND_LONG <http://mavlink.org/messages/common#COMMAND_LONG>`__ message.
+`COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
 
 :ref:`MAV_CMD_NAV_TAKEOFF <copter:mav_cmd_nav_takeoff>`
 (Copter 3.2.1 or earlier)
@@ -84,37 +84,37 @@ These MAV_CMDs can be processed if packaged within a
 :ref:`MAV_CMD_DO_GRIPPER <copter:mav_cmd_do_gripper>`
 (If gripper enabled) (Copter 3.2.1 or earlier)
 
-`MAV_CMD_START_RX_PAIR <http://mavlink.org/messages/common#MAV_CMD_START_RX_PAIR>`__
+`MAV_CMD_START_RX_PAIR <https://mavlink.io/en/messages/common.html#MAV_CMD_START_RX_PAIR>`__
 (Copter 3.3) Starts receiver pairing
 
-`MAV_CMD_PREFLIGHT_CALIBRATION <http://mavlink.org/messages/common#MAV_CMD_PREFLIGHT_CALIBRATION>`__
+`MAV_CMD_PREFLIGHT_CALIBRATION <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_CALIBRATION>`__
 (Copter 3.3)
 
-`MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS <http://mavlink.org/messages/common#MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS>`__
+`MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS>`__
 (Copter 3.3)
 
-`MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <http://mavlink.org/messages/common#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
+`MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
 (Copter 3.3)
 
-`MAV_CMD_DO_MOTOR_TEST <http://mavlink.org/messages/ardupilotmega#MAV_CMD_DO_MOTOR_TEST>`__
+`MAV_CMD_DO_MOTOR_TEST <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_MOTOR_TEST>`__
 (Copter 3.3)
 
-`MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES <http://mavlink.org/messages/common#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES>`__
+`MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES <https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES>`__
 (Copter 3.3)
 
-`MAV_CMD_GET_HOME_POSITION <http://mavlink.org/messages/common#MAV_CMD_GET_HOME_POSITION>`__
+`MAV_CMD_GET_HOME_POSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_GET_HOME_POSITION>`__
 (Copter 3.3)
 
-`MAV_CMD_DO_START_MAG_CAL <http://mavlink.org/messages/ardupilotmega#MAV_CMD_DO_START_MAG_CAL>`__
+`MAV_CMD_DO_START_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_START_MAG_CAL>`__
 (Master - not in Copter 3.3)
 
-`MAV_CMD_DO_ACCEPT_MAG_CAL <http://mavlink.org/messages/ardupilotmega#MAV_CMD_DO_ACCEPT_MAG_CAL>`__
+`MAV_CMD_DO_ACCEPT_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_ACCEPT_MAG_CAL>`__
 (Master - not in Copter 3.3)
 
-`MAV_CMD_DO_CANCEL_MAG_CAL <http://mavlink.org/messages/ardupilotmega#MAV_CMD_DO_CANCEL_MAG_CAL>`__
+`MAV_CMD_DO_CANCEL_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_CANCEL_MAG_CAL>`__
 (Master - not in Copter 3.3)
 
-`MAV_CMD_DO_FLIGHTTERMINATION <http://mavlink.org/messages/common#MAV_CMD_DO_FLIGHTTERMINATION>`__
+`MAV_CMD_DO_FLIGHTTERMINATION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FLIGHTTERMINATION>`__
 (Copter 3.3) Disarms motors immediately (Copter falls!).
 
 MAV_CMD_DO_SEND_BANNER - No link available (?)
@@ -124,7 +124,7 @@ inside `:ref:`COMMAND_LONG``): `MAV_CMD_DO_DIGICAM_CONFIGURE <copter:mav_cmd_do_
 
 :ref:`MAV_CMD_DO_DIGICAM_CONTROL <copter:mav_cmd_do_digicam_control>`
 
-`MAV_CMD_DO_MOUNT_CONFIGURE <http://mavlink.org/messages/common#MAV_CMD_DO_MOUNT_CONFIGURE>`__
+`MAV_CMD_DO_MOUNT_CONFIGURE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONFIGURE>`__
 
 :ref:`MAV_CMD_DO_MOUNT_CONTROL <copter:mav_cmd_do_mount_control>`
 
@@ -139,73 +139,73 @@ in GUIDED mode.
    Most of these commands are not relevant to DroneKit-Python apps or
    are already provided through the API.
 
-`HEARTBEAT <http://mavlink.org/messages/common#HEARTBEAT>`__
+`HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__
 
-`SET_MODE <http://mavlink.org/messages/common#SET_MODE>`__
+`SET_MODE <https://mavlink.io/en/messages/common.html#SET_MODE>`__
 
-`PARAM_REQUEST_READ <http://mavlink.org/messages/common#PARAM_REQUEST_READ>`__
+`PARAM_REQUEST_READ <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_READ>`__
 
-`PARAM_REQUEST_LIST <http://mavlink.org/messages/common#PARAM_REQUEST_LIST>`__
+`PARAM_REQUEST_LIST <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_LIST>`__
 
-`PARAM_SET <http://mavlink.org/messages/common#PARAM_SET>`__
+`PARAM_SET <https://mavlink.io/en/messages/common.html#PARAM_SET>`__
 
-`MISSION_WRITE_PARTIAL_LIST <http://mavlink.org/messages/common#MISSION_WRITE_PARTIAL_LIST>`__
+`MISSION_WRITE_PARTIAL_LIST <https://mavlink.io/en/messages/common.html#MISSION_WRITE_PARTIAL_LIST>`__
 
-`MISSION_ITEM <http://mavlink.org/messages/common#MISSION_ITEM>`__
+`MISSION_ITEM <https://mavlink.io/en/messages/common.html#MISSION_ITEM>`__
 
-`MISSION_REQUEST <http://mavlink.org/messages/common#MISSION_REQUEST>`__
+`MISSION_REQUEST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST>`__
 
-`MISSION_SET_CURRENT <http://mavlink.org/messages/common#MISSION_SET_CURRENT>`__
+`MISSION_SET_CURRENT <https://mavlink.io/en/messages/common.html#MISSION_SET_CURRENT>`__
 
-`MISSION_REQUEST_LIST <http://mavlink.org/messages/common#MISSION_REQUEST_LIST>`__
+`MISSION_REQUEST_LIST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST_LIST>`__
 
-`MISSION_COUNT <http://mavlink.org/messages/common#MISSION_COUNT>`__
+`MISSION_COUNT <https://mavlink.io/en/messages/common.html#MISSION_COUNT>`__
 
-`MISSION_CLEAR_ALL <http://mavlink.org/messages/common#MISSION_CLEAR_ALL>`__
+`MISSION_CLEAR_ALL <https://mavlink.io/en/messages/common.html#MISSION_CLEAR_ALL>`__
 
-`REQUEST_DATA_STREAM <http://mavlink.org/messages/common#REQUEST_DATA_STREAM>`__
+`REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__
 
-`GIMBAL_REPORT <http://mavlink.org/messages/ardupilotmega#GIMBAL_REPORT>`__
+`GIMBAL_REPORT <https://mavlink.io/en/messages/ardupilotmega.html#GIMBAL_REPORT>`__
 
-`RC_CHANNELS_OVERRIDE <http://mavlink.org/messages/common#RC_CHANNELS_OVERRIDE>`__
+`RC_CHANNELS_OVERRIDE <https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE>`__
 
-`COMMAND_ACK <http://mavlink.org/messages/common#COMMAND_ACK>`__
+`COMMAND_ACK <https://mavlink.io/en/messages/common.html#COMMAND_ACK>`__
 
-`HIL_STATE <http://mavlink.org/messages/common#HIL_STATE>`__
+`HIL_STATE <https://mavlink.io/en/messages/common.html#HIL_STATE>`__
 
-`RADIO <http://mavlink.org/messages/ardupilotmega#RADIO>`__
+`RADIO <https://mavlink.io/en/messages/ardupilotmega.html#RADIO>`__
 
-`RADIO_STATUS <http://mavlink.org/messages/common#RADIO_STATUS>`__
+`RADIO_STATUS <https://mavlink.io/en/messages/common.html#RADIO_STATUS>`__
 
-`LOG_REQUEST_DATA <http://mavlink.org/messages/common#LOG_REQUEST_DATA>`__
+`LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__
 
-`LOG_ERASE <http://mavlink.org/messages/common#LOG_ERASE>`__
+`LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__
 
-`LOG_REQUEST_LIST <http://mavlink.org/messages/common#LOG_REQUEST_LIST>`__
+`LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__
 
-`LOG_REQUEST_END <http://mavlink.org/messages/common#LOG_REQUEST_END>`__
+`LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__
 
-`SERIAL_CONTROL <http://mavlink.org/messages/common#SERIAL_CONTROL>`__
+`SERIAL_CONTROL <https://mavlink.io/en/messages/common.html#SERIAL_CONTROL>`__
 
-`GPS_INJECT_DATA <http://mavlink.org/messages/common#GPS_INJECT_DATA>`__
+`GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
 
-`TERRAIN_DATA <http://mavlink.org/messages/common#TERRAIN_DATA>`__
+`TERRAIN_DATA <https://mavlink.io/en/messages/common.html#TERRAIN_DATA>`__
 
-`TERRAIN_CHECK <http://mavlink.org/messages/common#TERRAIN_CHECK>`__
+`TERRAIN_CHECK <https://mavlink.io/en/messages/common.html#TERRAIN_CHECK>`__
 
-`RALLY_POINT <http://mavlink.org/messages/ardupilotmega#RALLY_POINT>`__
+`RALLY_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_POINT>`__
 
-`RALLY_FETCH_POINT <http://mavlink.org/messages/ardupilotmega#RALLY_FETCH_POINT>`__
+`RALLY_FETCH_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_FETCH_POINT>`__
 
-`AUTOPILOT_VERSION_REQUEST <http://mavlink.org/messages/ardupilotmega#AUTOPILOT_VERSION_REQUEST>`__
+`AUTOPILOT_VERSION_REQUEST <https://mavlink.io/en/messages/ardupilotmega.html#AUTOPILOT_VERSION_REQUEST>`__
 
-`LED_CONTROL <http://mavlink.org/messages/ardupilotmega#LED_CONTROL>`__
+`LED_CONTROL <https://mavlink.io/en/messages/ardupilotmega.html#LED_CONTROL>`__
 
-`ADSB_VEHICLE <http://mavlink.org/messages/common#ADSB_VEHICLE>`__
+`ADSB_VEHICLE <https://mavlink.io/en/messages/common.html#ADSB_VEHICLE>`__
 
-`REMOTE_LOG_BLOCK_STATUS <http://mavlink.org/messages/ardupilotmega#REMOTE_LOG_BLOCK_STATUS>`__
+`REMOTE_LOG_BLOCK_STATUS <https://mavlink.io/en/messages/ardupilotmega.html#REMOTE_LOG_BLOCK_STATUS>`__
 
-`LANDING_TARGET <http://mavlink.org/messages/common#LANDING_TARGET>`__
+`LANDING_TARGET <https://mavlink.io/en/messages/common.html#LANDING_TARGET>`__
 (Planned for Copter 3.4)
 
 :ref:`SET_HOME_POSITION <copter-commands-in-guided-mode_set_home_position>` (Master branch - not in
@@ -284,7 +284,7 @@ bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9:
    (0b0000111111111000) OR all three bits for the velocity
    (0b0000111111000111). Setting just one bit of the position/velocity or
    mixing the bits is not supported. The **acceleration**, **yaw**,
-   **yaw_rate** are present in the `protocol definition <http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED>`__
+   **yaw_rate** are present in the `protocol definition <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__
    but are not supported by ArduPilot.
 
    
@@ -427,7 +427,7 @@ coordinate system.
    only be interrupted when the next movement command was received.
 
 The protocol definition is here:
-`SET_POSITION_TARGET_GLOBAL_INT <http://mavlink.org/messages/common#SET_POSITION_TARGET_GLOBAL_INT>`__.
+`SET_POSITION_TARGET_GLOBAL_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT>`__.
 
 **Command parameters**
 
@@ -480,7 +480,7 @@ bit 3: z, bit 4: vx, bit 5: vy, bit 6: vz, bit 7: ax, bit 8: ay, bit 9:
    (0b0000111111111000) OR all three bits for the velocity
    (0b0000111111000111). Setting just one bit of the position/velocity or
    mixing the bits is not supported. The **acceleration**, **yaw**,
-   **yaw_rate** are present in the `protocol definition <http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED>`__
+   **yaw_rate** are present in the `protocol definition <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__
    but are not supported by ArduPilot.
 
 .. raw:: html
@@ -643,7 +643,7 @@ explicitly set by the operator before or after.
    </table>
 
 The protocol definition for this command is here:
-`SET_HOME_POSITION <http://mavlink.org/messages/common#SET_HOME_POSITION>`__
+`SET_HOME_POSITION <https://mavlink.io/en/messages/common.html#SET_HOME_POSITION>`__
 
 
 .. _copter-commands-in-guided-mode_set_attitude_target:
@@ -733,4 +733,4 @@ Sets a desired vehicle attitude. Used by an external controller to command the v
    </table>
 
 The protocol definition for this command is here:
-`SET_ATTITUDE_TARGET <http://mavlink.org/messages/common#SET_ATTITUDE_TARGET>`__
+`SET_ATTITUDE_TARGET <https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET>`__

--- a/dev/source/docs/copter-sitl-mavproxy-tutorial.rst
+++ b/dev/source/docs/copter-sitl-mavproxy-tutorial.rst
@@ -187,7 +187,7 @@ In addition to ``takeoff``, you can send the following commands in
    :ref:`MAV_CMD_NAV_TAKEOFF <copter:mav_cmd_nav_takeoff>`,
    :ref:`MAV_CMD_DO_CHANGE_SPEED <copter:mav_cmd_do_change_speed>`,
    :ref:`MAV_CMD_CONDITION_YAW <copter:mav_cmd_condition_yaw>`,
-   `SET_POSITION_TARGET_LOCAL_NED <http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED>`__.
+   `SET_POSITION_TARGET_LOCAL_NED <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__.
 
    At time of writing, the other :ref:`Copter Commands <copter-commands-in-guided-mode>`
    are not supported (`MAVProxy #150 <https://github.com/ArduPilot/MAVProxy/issues/150>`__)

--- a/dev/source/docs/gsoc-ideas-list.rst
+++ b/dev/source/docs/gsoc-ideas-list.rst
@@ -127,7 +127,7 @@ This project involves using machine vision and/or machine learning to add a new 
 
 - would likely require a high powered `companion computer <http://ardupilot.org/dev/docs/companion-computers.html>`__ (perhaps an NVidia TX1/TX2).
 - recognise the road, landing spot or return path to home using machine vision or learning (perhaps using `TensorFlow <https://www.tensorflow.org/>`__)
-- send velocity commands (probably using the `SET_GLOBAL_POSITION_INT <http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED>`__ or `SET_POSITION_TARGET_GLOBAL_INT <http://mavlink.org/messages/common#SET_POSITION_TARGET_GLOBAL_INT>`__) to move the vehicle in the correct direction
+- send velocity commands (probably using the `SET_GLOBAL_POSITION_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__ or `SET_POSITION_TARGET_GLOBAL_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT>`__) to move the vehicle in the correct direction
 - add solution to `APSync <http://ardupilot.org/dev/docs/apsync-intro.html>`__
 - document the solution
 

--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -31,7 +31,7 @@ MAV_CMDs
 =========
 
 These MAV_CMDs can be processed if packaged within a
-`COMMAND_LONG <http://mavlink.org/messages/common#COMMAND_LONG>`__ message.
+`COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
 
 :ref:`MAV_CMD_NAV_LOITER_UNLIM <plane:mav_cmd_nav_loiter_unlim>`
 
@@ -100,27 +100,27 @@ GUIDED mode.
    Most of these commands are not relevant to DroneKit-Python apps or
    are already provided through the API.
 
-`SET_MODE <http://mavlink.org/messages/common#SET_MODE>`__
+`SET_MODE <https://mavlink.io/en/messages/common.html#SET_MODE>`__
 
-`MISSION_REQUEST_LIST <http://mavlink.org/messages/common#MISSION_REQUEST_LIST>`__
+`MISSION_REQUEST_LIST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST_LIST>`__
 
-`MISSION_REQUEST <http://mavlink.org/messages/common#MISSION_REQUEST>`__
+`MISSION_REQUEST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST>`__
 
 MISSION_ACK:
 
-`PARAM_REQUEST_LIST <http://mavlink.org/messages/common#PARAM_REQUEST_LIST>`__
+`PARAM_REQUEST_LIST <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_LIST>`__
 
-`PARAM_REQUEST_READ <http://mavlink.org/messages/common#PARAM_REQUEST_READ>`__
+`PARAM_REQUEST_READ <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_READ>`__
 
-`MISSION_CLEAR_ALL <http://mavlink.org/messages/common#MISSION_CLEAR_ALL>`__
+`MISSION_CLEAR_ALL <https://mavlink.io/en/messages/common.html#MISSION_CLEAR_ALL>`__
 
-`MISSION_SET_CURRENT <http://mavlink.org/messages/common#MISSION_SET_CURRENT>`__
+`MISSION_SET_CURRENT <https://mavlink.io/en/messages/common.html#MISSION_SET_CURRENT>`__
 
-`MISSION_COUNT <http://mavlink.org/messages/common#MISSION_COUNT>`__
+`MISSION_COUNT <https://mavlink.io/en/messages/common.html#MISSION_COUNT>`__
 
-`MISSION_WRITE_PARTIAL_LIST <http://mavlink.org/messages/common#MISSION_WRITE_PARTIAL_LIST>`__
+`MISSION_WRITE_PARTIAL_LIST <https://mavlink.io/en/messages/common.html#MISSION_WRITE_PARTIAL_LIST>`__
 
-`MISSION_ITEM <http://mavlink.org/messages/common#MISSION_ITEM>`__
+`MISSION_ITEM <https://mavlink.io/en/messages/common.html#MISSION_ITEM>`__
 
 MAVLINK_MSG_ID_FENCE_POINT
 
@@ -130,36 +130,36 @@ RALLY_POINT
 
 RALLY_FETCH_POINT
 
-`PARAM_SET <http://mavlink.org/messages/common#PARAM_SET>`__
+`PARAM_SET <https://mavlink.io/en/messages/common.html#PARAM_SET>`__
 
 GIMBAL_REPORT
 
-`RC_CHANNELS_OVERRIDE <http://mavlink.org/messages/common#RC_CHANNELS_OVERRIDE>`__
+`RC_CHANNELS_OVERRIDE <https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE>`__
 
-`HEARTBEAT <http://mavlink.org/messages/common#HEARTBEAT>`__
+`HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__
 
-`HIL_STATE <http://mavlink.org/messages/common#HIL_STATE>`__
+`HIL_STATE <https://mavlink.io/en/messages/common.html#HIL_STATE>`__
 
 RADIO
 
-`RADIO_STATUS <http://mavlink.org/messages/common#RADIO_STATUS>`__
+`RADIO_STATUS <https://mavlink.io/en/messages/common.html#RADIO_STATUS>`__
 
-`LOG_REQUEST_DATA <http://mavlink.org/messages/common#LOG_REQUEST_DATA>`__
+`LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__
 
-`LOG_ERASE <http://mavlink.org/messages/common#LOG_ERASE>`__
+`LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__
 
-`LOG_REQUEST_LIST <http://mavlink.org/messages/common#LOG_REQUEST_LIST>`__
+`LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__
 
-`LOG_REQUEST_END <http://mavlink.org/messages/common#LOG_REQUEST_END>`__
+`LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__
 
-`SERIAL_CONTROL <http://mavlink.org/messages/common#SERIAL_CONTROL>`__
+`SERIAL_CONTROL <https://mavlink.io/en/messages/common.html#SERIAL_CONTROL>`__
 
-`GPS_INJECT_DATA <http://mavlink.org/messages/common#GPS_INJECT_DATA>`__
+`GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
 
-`TERRAIN_DATA <http://mavlink.org/messages/common#TERRAIN_DATA>`__
+`TERRAIN_DATA <https://mavlink.io/en/messages/common.html#TERRAIN_DATA>`__
 
-`TERRAIN_CHECK <http://mavlink.org/messages/common#TERRAIN_CHECK>`__
+`TERRAIN_CHECK <https://mavlink.io/en/messages/common.html#TERRAIN_CHECK>`__
 
 AUTOPILOT_VERSION_REQUEST
 
-`REQUEST_DATA_STREAM <http://mavlink.org/messages/common#REQUEST_DATA_STREAM>`__
+`REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__

--- a/dev/source/docs/ros-distance-sensors.rst
+++ b/dev/source/docs/ros-distance-sensors.rst
@@ -7,7 +7,7 @@ ROS distance sensor usage
 Distance sensor message
 =======================
 
-ArduPilot support `distance sensor message <http://mavlink.org/messages/common#DISTANCE_SENSOR>`__ both as input and output.
+ArduPilot support `distance sensor message <https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR>`__ both as input and output.
 The following chapters will explain you how to use distance sensor with ROS for :
 
 - Rangefinder : how to receive data from rangefinder plug in a FCU (e.g. pixhawk) and how to send data from ROS to FCU

--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -184,7 +184,7 @@ SITL can simulate a virtual gimbal.
 .. note::
 
    Gimbal simulation causes SITL to start sending
-   `MOUNT_STATUS <http://mavlink.org/messages/ardupilotmega#MOUNT_STATUS>`__
+   `MOUNT_STATUS <https://mavlink.io/en/messages/ardupilotmega.html#MOUNT_STATUS>`__
    messages. These messages contain the orientation according to the last
    commands sent to the gimbal, not actual measured values. As a result, it
    is possible that the true gimbal position will not match - i.e. a

--- a/plane/source/docs/flight-features.rst
+++ b/plane/source/docs/flight-features.rst
@@ -7,7 +7,7 @@ Flight Features
 Plane has a lot of advanced features which can be accessed either via
 configuration parameters or via mission commands. The list below will
 give you some information on some of the more widely used features. For
-a full set of features see the :doc:`full parameter list <parameters>` and the `MAVLink protocol definition <http://mavlink.org>`__.
+a full set of features see the :doc:`full parameter list <parameters>` and the `MAVLink protocol definition <https://mavlink.io/en/>`__.
 
 .. toctree::
     :maxdepth: 1

--- a/rover/source/docs/guided-mode.rst
+++ b/rover/source/docs/guided-mode.rst
@@ -25,10 +25,10 @@ Other controls
 
 These additional mavlink messages are supported in Guided mode.  These are listed mostly for developers of ground stations or :ref:`companion computers <common-companion-computers>` applications:
 
--  `SET_ATTITUDE_TARGET <http://mavlink.org/messages/common#SET_ATTITUDE_TARGET>`__
--  `SET_POSITION_TARGET_LOCAL_NED <http://mavlink.org/messages/common#SET_POSITION_TARGET_LOCAL_NED>`__
--  `SET_POSITION_TARGET_GLOBAL_INT <http://mavlink.org/messages/common#SET_POSITION_TARGET_GLOBAL_INT>`__
--  ``MAV_CMD_NAV_SET_YAW_SPEED`` commands within a `COMMAND_LONG <http://mavlink.org/messages/common#COMMAND_LONG>`__
+-  `SET_ATTITUDE_TARGET <https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET>`__
+-  `SET_POSITION_TARGET_LOCAL_NED <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__
+-  `SET_POSITION_TARGET_GLOBAL_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT>`__
+-  ``MAV_CMD_NAV_SET_YAW_SPEED`` commands within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__
 
 
 

--- a/rover/source/docs/rover-failsafes.rst
+++ b/rover/source/docs/rover-failsafes.rst
@@ -39,7 +39,7 @@ The second stage failsafe action will be taken once the battery falls below thes
 GCS Failsafe (aka Telemetry Failsafe)
 -------------------------------------
 
-This failsafe is triggered if the vehicle stops receiving `heartbeat messages <http://mavlink.org/messages/common#HEARTBEAT>`__ from the ground station for at least :ref:`FS_TIMEOUT <FS_TIMEOUT>` seconds.
+This failsafe is triggered if the vehicle stops receiving `heartbeat messages <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__ from the ground station for at least :ref:`FS_TIMEOUT <FS_TIMEOUT>` seconds.
 
 - set :ref:`FS_GCS_ENABLE <FS_GCS_ENABLE>` to "1" to enable this failsafe
 - if :ref:`FS_ACTION <FS_ACTION>` is "1", the vehicle will :ref:`RTL <rtl-mode>` to home, if "2" the vehicle will :ref:`Hold <hold-mode>`


### PR DESCRIPTION
The mavlink.org links are supposed to be redirected to mavlink.io (currently they are just broken). This fixes the links to point to the correct locations.