### PR TITLE
change inline markup

### DIFF
--- a/plane/source/docs/airframe-disco.rst
+++ b/plane/source/docs/airframe-disco.rst
@@ -28,8 +28,8 @@ To build the ArduPilot firmware yourself you should use the waf build
 system, which is included as part of ArduPilot. The command to build
 APM:Plane for Disco is:
 
-* ./waf configure --board disco
-* ./waf plane
+* ``./waf configure --board disco``
+* ``./waf plane``
 
 this will give you a file build/disco/bin/arduplane that needs to be
 installed on your Disco.


### PR DESCRIPTION
The double negative is interpreted by sphinx as a one-line I added backwards quotes to correct this.