### PR TITLE
Update common-autopilots.rst

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -39,7 +39,6 @@ Closed hardware
     OmnibusNanoV6 <common-omnibusnanov6>
     Omnibus F7 <common-omnibusf7>
     Parrot C.H.U.C.K (for the Parrot Disco) <common-CHUCK-overview>
-    Qualcomm Snapdragon Flight Kit <common-qualcomm-snapdragon-flight-kit>
 [site wiki="copter"]
     Parrot Bebop Autopilot <parrot-bebop-autopilot>
 [/site]


### PR DESCRIPTION
remove Snapdragon Flight.  Board is no longer supported.