### PR TITLE
Fix building with waf using cygwin

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -107,7 +107,7 @@ Set up directories/paths and extra packages in Cygwin
 ::
 
     pip2 install empy
-    pip install pyserial
+    pip2 install pyserial
     pip2 install pymavlink
 
 Build with Waf

--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -33,6 +33,8 @@ Install Cygwin
    +----------------+----------------------------------------------------------------------------------+
    | ccache         | Devel \| ccache: A C compiler cache for improving recompilation                  |
    +----------------+----------------------------------------------------------------------------------+
+   | cmake          | Devel \| cmake: Cross-platform makefile generation system                        |
+   +----------------+----------------------------------------------------------------------------------+
    | gcc-g++        | Devel \| gcc-g++ GNU Compiler Collection (C++)                                   |
    +----------------+----------------------------------------------------------------------------------+
    | git            | Devel \| git: Distributed version control system                                 |
@@ -67,7 +69,7 @@ Install Cygwin
    +----------------+----------------------------------------------------------------------------------+   
    Or you can run 
    ::
-      setup-x86_64.exe -P autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,libxslt-devel,python2-devel,python2-future,python2-libxml2,python2-pip,procps-ng,gdb,ddd,zip
+      setup-x86_64.exe -P autoconf,automake,ccache,cmake,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,libxslt-devel,python2-devel,python2-future,python2-libxml2,python2-pip,procps-ng,gdb,ddd,zip
 
 #. When all the packages are selected, click through the rest of the
    prompts and accept all other default options (including


### PR DESCRIPTION
"pip install pyserial" -> "pip2 install pyserial"
I think cmake is also needed.

But still fail to build with waf...
It always shows an error: task in 'uavcan' failed (exit status 1).