### PR TITLE
Update common-simplebgc-gimbal.rst

### DIFF
--- a/common/source/docs/common-simplebgc-gimbal.rst
+++ b/common/source/docs/common-simplebgc-gimbal.rst
@@ -24,6 +24,21 @@ Connecting the gimbal to the Flight Controller
 
 Although the SimpleBGC can be connected using PWM (similar to the Tarot gimbal) we recommend using the serial interface connected to one of the flight controller's Serial/Telemetry ports like Telem2 as shown above.
 
+However, if you connect the gimbal as shown in the above diagram it is NOT possible to establish a connection to the GUI on a PC via USB and have it connected simultaneously to the flight controller since the UART1 ("serial" in the picture above, present on "Regular", "Extended" and "Tiny" controllers) is "paralleled to the onboard USB-UART converter (excepting the "Tiny" board that has a dedicated USB). Simultaneous operation of the GUI and the external IMU is not possible for that reason" (https://www.basecamelectronics.com/files/v3/SimpleBGC_32bit_manual_2_6x_eng.pdf). If you accidentially connect both the GUI via USB and a flight controller via UART1 you might end up with corrupt data on the flash of the gimbal. This can result in unexpected motor movement!
+
+**Option 2:** If you want to connect to the GUI while a flight controller via MavLink is also connected (firmware version 2.60 or above needed). Connect the flight controller as shown above but connect the rx wire (orange) to the RC-R an the tx wire (green) to the RC-Y pin on the gimbal. The ground wire (black) can be connected to any GND pin. In this connection set-up you have to take care of the following options in the GUI: - Activate RC_SERIAL by setting "RC_ROLL pin mode" = "Serial port (Serial API, etc.)" on the RC tab On the tab "External IMU" in the field "External IMU configuration" - Select the Model: "MavLin FC vhannel 1 - Connection: disabled On the same tab in the field "MavLink connection" for Channel 1 (leave Channel 2 disabled) - Serial port: "RC_serial" - System Id/Component Id: 1, 154 - Port setting: 115200, none parity - Options: Send heartbeat (checked), Query RC data (checked) - MavLink control mode: "Controls ROLL and PITCH axes only" If everything is set correctly you should see something like the following in the next field: AHRS: OK (40ms), GPS: OK (106ms), RC: OK, Control: OK CH1: Packets received: 257502, lost: 0, parse errors: 3 CH2: Packets received: 0, lost: 0, parse errors: 0
+
+In Ardupilot/APM Planner/Mission planner set the following variables:
+- :ref:`MNT_TYPE <MNT_TYPE>` to 4 / "Mount Type (None, Servo or MavLink)"
+- :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 1 / "MavLink" (Notee "SERIAL2" should be "SERIAL1" if using Telem1 port, SERIAL4 if using Serial4/5, etc)
+- :ref:`SR2_EXTRA1 <SR2_EXTRA1>` to 20
+- :ref:`SR2_POSITION <SR2_POSITIOIN>` to 10
+- :ref:`SR2_RC_CHAN <SR2_RC_CHAN>` to 20 and all other SR2_* variables to 0.
+
+If you wish to control the pitch angle manually you can set
+- :ref:`MNT_RC_IN_TILT <MNT_RC_IN_TILT>` to 6
+- In the SimpleBCG GUI in the tab "RC Settings" in the field "Input Configuration" set PITCH to "API_VIRT_CH6".
+
 Setup through the Ground Station
 ================================
 


### PR DESCRIPTION
Added another option for wiring which can be used in parallel to USB connection which is not possible with the original wiring proposal. Included: Settings for SimpleBCG32 GUI and Ardupilot/MissionPlanner/APMPlanner.