### PR TITLE
Common: Add note

### DIFF
--- a/common/source/docs/common-vl53l0x-lidar.rst
+++ b/common/source/docs/common-vl53l0x-lidar.rst
@@ -41,7 +41,7 @@ Testing the sensor
 ==================
 
 Distances read by the sensor can be seen in the Mission Planner's Flight
-Data screen's Status tab. Look closely for "sonarrange".
+Data screen's Status tab. Look closely for "sonarrange".(The value of this image is not a real value.)
 
 .. image:: ../../../images/mp_rangefinder_lidarlite_testing.jpg
     :target: ../_images/mp_rangefinder_lidarlite_testing.jpg


### PR DESCRIPTION
I do not show this device's value for this image. 
The unit of this value is meters. 
The setting explanation is centimeters. 
I thought that I was misunderstood.