### PR TITLE
Common: update external baro note

### DIFF
--- a/common/source/docs/common-baro-external.rst
+++ b/common/source/docs/common-baro-external.rst
@@ -5,7 +5,7 @@ Barometer (external)
 
 .. warning::
 
-   Support for external barometers will be released with Copter-3.6.1.  The instructions below have only been verified for the Drotek MS5611 barometer. The Adafruit BMP280 has not been verified to work yet.
+   Support for external barometers was released with Copter-3.6.  The instructions below have been verified for the Drotek MS5611 barometer but the Adafruit BMP280 has not been verified to work.
 
 .. image:: ../../../images/baro-top-image.png
     :width: 450px


### PR DESCRIPTION
Copter-3.6 has been released so "will be" becomes "was"

This is partially a test to ensure the "quick edit" instructions are ok on the wiki editing guide