### PR TITLE
Dev - add warning about different gcc-arm versions

### DIFF
--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -66,6 +66,8 @@ To build for a Cube/Pixhawk target on Linux you need the
 following tools and git repositories:
 
 -  The gcc-arm cross-compiler from `here <http://firmware.ardupilot.org/Tools/STM32-tools/>`__
+   (Ardupilot is only built and tested on these specific versions of gcc-arm; if installed
+   with ``apt-get`` gcc-arm will not produce a working binary in many cases)
 -  gnu make, gawk and associated standard Linux build tools
 -  On a 64 bit system you will also need to have installed libc6-i386.
 


### PR DESCRIPTION
Add a small warning about not using distribution-repo-provided gcc-arm versions. Just in case a user (like myself) goes and does exactly that.

Turns out that the gcc-arm in the Ubuntu 18.04 repo, although is a very close version to the one in http://firmware.ardupilot.org/Tools/STM32-tools/, produces bad binaries as per https://github.com/ArduPilot/ardupilot/issues/8663