### PR TITLE
Update JSBSim repo location which moved

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -117,7 +117,7 @@ In the same directory (your home directory) run these commands:
 
 ::
 
-    git clone git://jsbsim.git.sourceforge.net/gitroot/jsbsim/jsbsim
+    git clone git://github.com/JSBSim-Team/jsbsim.git
     sudo apt-get install cmake
     cd jsbsim
     mkdir build


### PR DESCRIPTION
Based on https://sourceforge.net/projects/jsbsim/ project moved to the new location.