### PR TITLE
Dev: move deprecated documentation to appendix

### DIFF
--- a/common/source/docs/common-archived-topics.rst
+++ b/common/source/docs/common-archived-topics.rst
@@ -53,6 +53,16 @@ value to users with old hardware.
     Updating the APM2.x BootLoader <updating-the-apm2-x-bootloade>
     Mission Planner Terminal <mission-planner-terminal>
     Debugging using JTAG <jtag>
+    Building for Pixhawk on Windows with Make <building-px4-with-make>
+    Building ArduPilot with Arduino for Windows <building-ardupilot-with-arduino-windows>
+    Editing & Building with Atmel Studio or Visual Studio <building-ardupilot-apm-with-visual-studio-visual-micro>
+    Building for APM2.x with Make (Win, Mac, Linux) <building_with_make>
+    APM2.x on MacOS with Arduino <building-the-code-on-mac>
+    APM2.x on Linux with Make <building-the-code-onlinux>
+    Building for Flymaple on Linux <building-apm-for-flymaple>
+    Building for Pixhawk on Windows or Linux with QtCreator <building-px4-with-qtcreator>
+    Building for NAVIO+ on RPi2 <building-for-navio-on-rpi2>
+    Building for Qualcomm Snapdragon <building-for-qualcomm-snapdragon-flight-kit>
 [/site]
 
 

--- a/dev/source/docs/building-apm-for-flymaple.rst
+++ b/dev/source/docs/building-apm-for-flymaple.rst
@@ -1,8 +1,14 @@
 .. _building-apm-for-flymaple:
 
-========================================
-Building ArduPilot for Flymaple on Linux
-========================================
+==================================================
+Archived: Building ArduPilot for Flymaple on Linux
+==================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports FlyMaple.
 
 .. note::
 

--- a/dev/source/docs/building-ardupilot-apm-with-visual-studio-visual-micro.rst
+++ b/dev/source/docs/building-ardupilot-apm-with-visual-studio-visual-micro.rst
@@ -1,8 +1,14 @@
 .. _building-ardupilot-apm-with-visual-studio-visual-micro:
 
-========================================================================
-Building ArduPilot with Atmel Studio or Visual Studio &amp; Visual Micro
-========================================================================
+==================================================================================
+Archived: Building ArduPilot with Atmel Studio or Visual Studio &amp; Visual Micro
+==================================================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Arduino or AVR.
 
 This tutorial provides instructions for how to set up and build AMP
 using Atmel Studio 6.2 or Microsoft Visual Studio with the `Visual Micro <https://www.visualmicro.com/>`__ plugin.

--- a/dev/source/docs/building-ardupilot-with-arduino-windows.rst
+++ b/dev/source/docs/building-ardupilot-with-arduino-windows.rst
@@ -1,8 +1,14 @@
 .. _building-ardupilot-with-arduino-windows:
 
-=====================================================
-Building ArduPilot for APM2.x on Windows with Arduino
-=====================================================
+===============================================================
+Archived: Building ArduPilot for APM2.x on Windows with Arduino
+===============================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Arduino or AVR.
 
 This article shows how to build ArduPilot for APM2.x targets on Windows,
 using the Arduino toolchain.

--- a/dev/source/docs/building-for-navio-on-rpi2.rst
+++ b/dev/source/docs/building-for-navio-on-rpi2.rst
@@ -1,8 +1,14 @@
 .. _building-for-navio-on-rpi2:
 
-===========================
-Building for NAVIO+ on RPi2
-===========================
+=====================================
+Archived: Building for NAVIO+ on RPi2
+=====================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports NAVIO+ on Rpi2.
 
 Overview
 ========

--- a/dev/source/docs/building-for-qualcomm-snapdragon-flight-kit.rst
+++ b/dev/source/docs/building-for-qualcomm-snapdragon-flight-kit.rst
@@ -1,8 +1,14 @@
 .. _building-for-qualcomm-snapdragon-flight-kit:
 
-===========================================
-Building for Qualcomm Snapdragon Flight Kit
-===========================================
+=====================================================
+Archived: Building for Qualcomm Snapdragon Flight Kit
+=====================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Qualcomm Snapdragon Flight Kit.
 
 This article shows how to build ArduPilot for 
 :ref:`Qualcomm® Snapdragon Flight™ Kit (Developer’s Edition) <copter:common-qualcomm-snapdragon-flight-kit>`

--- a/dev/source/docs/building-px4-with-make.rst
+++ b/dev/source/docs/building-px4-with-make.rst
@@ -1,8 +1,14 @@
 .. _building-px4-with-make:
 
-=========================================
-Building for Pixhawk on Windows with Make
-=========================================
+===================================================
+Archived: Building for Pixhawk on Windows with Make
+===================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports make.
 
 This article shows how to build ArduPilot for The Cube, Pixhawk, PixRacer on Windows with *Make*.  These instructions assume you have already :ref:`setup the build environment <building-setup-windows>`
 

--- a/dev/source/docs/building-px4-with-qtcreator.rst
+++ b/dev/source/docs/building-px4-with-qtcreator.rst
@@ -1,8 +1,15 @@
 .. _building-px4-with-qtcreator:
 
-=================================================================
-Building ArduPilot for Pixhawk on Windows or Linux with QtCreator
-=================================================================
+===========================================================================
+Archived: Building ArduPilot for Pixhawk on Windows or Linux with QtCreator
+===========================================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Qt Creator.
+
 
 This article shows how you can set up Qt Creator for editing ArduPilot code
 and building for Pixhawk targets on Windows and Linux.

--- a/dev/source/docs/building-the-code-on-mac.rst
+++ b/dev/source/docs/building-the-code-on-mac.rst
@@ -1,8 +1,14 @@
 .. _building-the-code-on-mac:
 
-===================================================
-Building ArduPilot for APM2.x on MacOS with Arduino
-===================================================
+=============================================================
+Archived: Building ArduPilot for APM2.x on MacOS with Arduino
+=============================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Arduino or AVR.
 
 .. warning::
 

--- a/dev/source/docs/building-the-code-onlinux.rst
+++ b/dev/source/docs/building-the-code-onlinux.rst
@@ -1,8 +1,14 @@
 .. _building-the-code-onlinux:
 
-================================================
-Building ArduPilot for APM2.x on Linux with Make
-================================================
+==========================================================
+Archived: Building ArduPilot for APM2.x on Linux with Make
+==========================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports make, Arduino or AVR.
 
 Quick start
 ===========

--- a/dev/source/docs/building-the-code.rst
+++ b/dev/source/docs/building-the-code.rst
@@ -32,7 +32,6 @@ Windows users have 3 or 4 options for setting up the build environment. All of t
 - :ref:`Setup the waf Build Environment on Windows using Cygwin <building-setup-windows-cygwin>`
 - :ref:`Setup the waf Build Environment on Windows10 using WSL <building-setup-windows10>`
 - :ref:`Setup Eclipse on Windows for building with waf <building-setup-windows-eclipse>`
-- :ref:`Setup the Make Build on Windows (not recommended) <building-px4-with-make>`
 
 **Board specific instructions:**
 
@@ -70,22 +69,4 @@ Links to current build pages
     Building for BeagleBone Black <building-for-beaglebone-black-on-linux>
     Building Mission Planner with Visual Studio <buildin-mission-planner>
     ArduPilot Pre-Built Binaries <pre-built-binaries>
-
-Deprecated Instructions
------------------------
-
-.. toctree::
-    :maxdepth: 1
-
-    Deprecated: Building for Pixhawk on Windows with Make <building-px4-with-make>
-    Deprecated: Building ArduPilot with Arduino for Windows <building-ardupilot-with-arduino-windows>
-    Deprecated: Editing & Building with Atmel Studio or Visual Studio <building-ardupilot-apm-with-visual-studio-visual-micro>
-    Deprecated: Building for APM2.x with Make (Win, Mac, Linux) <building_with_make>
-    Deprecated: APM2.x on MacOS with Arduino <building-the-code-on-mac>
-    Deprecated: APM2.x on Linux with Make <building-the-code-onlinux>
-    Deprecated: Building for Flymaple on Linux <building-apm-for-flymaple>
-    Deprecated: Building for Pixhawk on Windows or Linux with QtCreator <building-px4-with-qtcreator>
-    Deprecated: Building for NAVIO+ on RPi2 <building-for-navio-on-rpi2>
-    Deprecated: Building for Qualcomm Snapdragon <building-for-qualcomm-snapdragon-flight-kit>
-
 

--- a/dev/source/docs/building_with_make.rst
+++ b/dev/source/docs/building_with_make.rst
@@ -1,8 +1,14 @@
 .. _building_with_make:
 
-=======================================
-Building ArduPilot for APM2.x with Make
-=======================================
+=================================================
+Archived: Building ArduPilot for APM2.x with Make
+=================================================
+
+.. warning::
+
+   **ARCHIVED ARTICLE**
+
+   Ardupilot no longer supports Arduino or AVR.
 
 This article explains how to build the code for APM2.x with Make on
 Windows, Mac and Linux.


### PR DESCRIPTION
As per conversation in #1599 and the Ardupilot Wiki guide (http://ardupilot.org/dev/docs/common-wiki-editing-archiving.html), I've moved the deprecated build documentation to the appendix.