### PR TITLE
Create common-seagull-gpk-rtk-ppk-gnss-receiver.rst

### DIFF
--- a/common/source/docs/common-seagull-gpk-rtk-ppk-gnss-receiver.rst
+++ b/common/source/docs/common-seagull-gpk-rtk-ppk-gnss-receiver.rst
@@ -1,8 +1,8 @@
 .. _common-seagull-gpk-rtk-ppk-gnss-receiver:
 
-==========================================================================
+======================================
 Seagull UAV #GPK RTK/PPK GNSS Receiver
-==========================================================================
+======================================
 
 This article provides a brief overview of Seagull UAV #GPK RTK/PPK GNSS receiver and highlights it's features. 
 
@@ -12,7 +12,7 @@ This article provides a brief overview of Seagull UAV #GPK RTK/PPK GNSS receiver
    Seagull #GPK from - Seagull UAV
 
 #GPK – Extreme Positioning
-========
+==========================
 
 `Seagull #GPK <https://www.seagulluav.com/product/seagull-gpk/>`__ is a high precision GNSS receiver which can operate in **multiple modes** in order to give you the utmost flexibility and precision for your UAV platform!
 
@@ -31,7 +31,7 @@ This article provides a brief overview of Seagull UAV #GPK RTK/PPK GNSS receiver
    Representation of two `#GPK <https://www.seagulluav.com/product/seagull-gpk/>`__ modules operating in RTK mode with `#RADIO <https://www.seagulluav.com/product/seagull-radio/>`__ modules used for data transmission
 
 What it does
-==============================
+============
 **Seagull #GPK supports the following functions**
 
 - **BASE / ROVER** ( #GPK can operate either as a BASE or ROVER )
@@ -40,8 +40,8 @@ What it does
 - **MB** ( Moving Baseline navigation and logging, requires 2 x #GPK modules – at 4Hz )
 - **GNSS** ( Non-Kinematic mode navigation and logging – at 10Hz )
 
-
-===============================================
+What it supports
+================
 
 +------------------------+-----------------+
 | **Flight Controllers** | **Seagull UAV** |
@@ -60,7 +60,7 @@ What it does
 – all of the **ardupilot based FCs’** are supported as well any FC that is capable of utilizing **UBX/NMEA messages** for navigation
 
 Specifications
-===============
+==============
 
 - Ublox NEO-M8P-2, L1/B1, GPS/GLONASS/BEIDOU GNSS receiver – **update rate up to 10Hz**
 - Voltage: 3.9 – 12V (5 volts recommended – **do NOT exceed 12V!**)

--- a/common/source/docs/common-seagull-gpk-rtk-ppk-gnss-receiver.rst
+++ b/common/source/docs/common-seagull-gpk-rtk-ppk-gnss-receiver.rst
@@ -1,0 +1,75 @@
+.. _common-seagull-gpk-rtk-ppk-gnss-receiver:
+
+==========================================================================
+Seagull UAV #GPK RTK/PPK GNSS Receiver
+==========================================================================
+
+This article provides a brief overview of Seagull UAV #GPK RTK/PPK GNSS receiver and highlights it's features. 
+
+.. figure:: https://www.seagulluav.com/wp-content/uploads/2018/11/SGPK-1001_01.png
+   :target: https://www.seagulluav.com/wp-content/uploads/2018/11/SGPK-1001_01.png
+
+   Seagull #GPK from - Seagull UAV
+
+#GPK – Extreme Positioning
+========
+
+`Seagull #GPK <https://www.seagulluav.com/product/seagull-gpk/>`__ is a high precision GNSS receiver which can operate in **multiple modes** in order to give you the utmost flexibility and precision for your UAV platform!
+
+`#GPK <https://www.seagulluav.com/product/seagull-gpk/>`__ features an on-board SD card which gives the user ability to easily configure the module in order to suit the functionality required – on the go!
+
+- **Multiple modes** – Real Time Kinematic, Post Processed Kinematic, Moving Baseline
+- **High refresh rate** – 4Hz MB, 5Hz RTK, 10Hz RAW, 10Hz GNSS
+- **High position accuracy** – up to 1 cm!
+- **Easy configuration** – via SD card 
+- **Two operational modes** – BASE or ROVER
+- **On-board PPK logging, #MAP-X2 compatible, Multiple Flight Controllers supported!** 
+
+.. figure:: https://www.seagulluav.com/wp-content/uploads/2018/09/GPK-COMPLETE-1.png
+   :target: https://www.seagulluav.com/wp-content/uploads/2018/09/GPK-COMPLETE-1.png
+   
+   Representation of two `#GPK <https://www.seagulluav.com/product/seagull-gpk/>`__ modules operating in RTK mode with `#RADIO <https://www.seagulluav.com/product/seagull-radio/>`__ modules used for data transmission
+
+What it does
+==============================
+**Seagull #GPK supports the following functions**
+
+- **BASE / ROVER** ( #GPK can operate either as a BASE or ROVER )
+- **RTK** ( Real Time Kinematic navigation for your drone and logging – at 5Hz )
+- **PPK** ( Post Processed Kinematic BASE logging and ROVER logging+navigation with #MAP-X2 – at 10Hz )
+- **MB** ( Moving Baseline navigation and logging, requires 2 x #GPK modules – at 4Hz )
+- **GNSS** ( Non-Kinematic mode navigation and logging – at 10Hz )
+
+
+===============================================
+
++------------------------+-----------------+
+| **Flight Controllers** | **Seagull UAV** |
++------------------------+-----------------+
+| Pixhawk 1              | #RADIO          |
++------------------------+-----------------+
+| Pixhawk 2.1            | #MAP-X2         |
++------------------------+-----------------+
+| Pixracer               |                 |
++------------------------+-----------------+
+| APM 2.6                |                 |
++------------------------+-----------------+
+| APM 2.5                |                 |
++------------------------+-----------------+
+
+– all of the **ardupilot based FCs’** are supported as well any FC that is capable of utilizing **UBX/NMEA messages** for navigation
+
+Specifications
+===============
+
+- Ublox NEO-M8P-2, L1/B1, GPS/GLONASS/BEIDOU GNSS receiver – **update rate up to 10Hz**
+- Voltage: 3.9 – 12V (5 volts recommended – **do NOT exceed 12V!**)
+- Current draw: 80mA MIN, 100mA AVERAGE, 120mA MAX
+- Dimensions: 45mm x 41mm x 11mm
+- Weight: 16 gram
+
+References
+==========
+
+-  `Purchase Seagull #GPK <https://www.seagulluav.com/product/seagull-gpk/>`__
+-  Links to `#GPK SUPPORT <https://www.seagulluav.com/seagull-gpk-support//>`__ and `#GPK MANUAL <https://www.seagulluav.com/manuals/Seagull_GPK-Manual.pdf>`__


### PR DESCRIPTION
Added Seagull #GPK RTK / PPK GNSS receiver. The product is designed for navigational and logging purposes, which is integrate-able with Ardupilot based platforms.