### PR TITLE
Changing from px4-v2 to Pixhawk1

### DIFF
--- a/dev/source/docs/learning-ardupilot-the-example-sketches.rst
+++ b/dev/source/docs/learning-ardupilot-the-example-sketches.rst
@@ -26,7 +26,7 @@ sketch on a Pixhawk:
 ::
 
     cd $ARDUPILOT_HOME # the top-level of an AruPilot repository
-    ./waf configure --board=px4-v2
+    ./waf configure --board=Pixhawk1
     ./waf build --target examples/INS_generic --upload
 
 waf can list the examples it can build:


### PR DESCRIPTION
Because of this error message:
"The board target px4-v2 has been removed from ArduPilot with the removal of NuttX support and HAL_PX4."