### PR TITLE
Copter: Update Mavproxy commands in Guided Mode

### DIFF
--- a/dev/source/docs/copter-sitl-mavproxy-tutorial.rst
+++ b/dev/source/docs/copter-sitl-mavproxy-tutorial.rst
@@ -177,8 +177,8 @@ In addition to ``takeoff``, you can send the following commands in
 
 ::
 
-    yaw ANGLE ANGULAR_SPEED MODE  (MODE is 0 for "absolute" or 1 for "relative")
-    speed SPEED_VALUE
+    setyaw ANGLE ANGULAR_SPEED MODE  (MODE is 0 for "absolute" or 1 for "relative")
+    setspeed SPEED_VALUE
     velocity x y z   (m/s)
 
 .. note::


### PR DESCRIPTION
The ```speed``` and  ```yaw``` commands are not recognised by Mavproxy.
The current Mavproxy command for setting speed and yaw in Guided Mode are  ```setspeed``` and ```setyaw``` respectively.