### PR TITLE
source/docs/gitb-branch.rst : correctred the given file name from Git_Success.txt to GIT_Success.txt

### DIFF
--- a/dev/source/docs/git-branch.rst
+++ b/dev/source/docs/git-branch.rst
@@ -45,7 +45,7 @@ Creating a Branch
 
    ::
 
-       git add Tools/GIT_Test/Git_Success.txt
+       git add Tools/GIT_Test/GIT_Success.txt
        git commit -m 'Tools: added name to GIT_Success.txt'
 
    In this case, the subject line of the commit is simply "Tools: added name to GIT_Success.txt" but see


### PR DESCRIPTION
Initially the path written in doc was : Tools/GIT_Test/Git_Success.txt
Whereas actually the filename is GIT_Success.txt
This PR rectifies this mistake by renaming the path as: Tools/GIT_Test/GIT_Success.txt