### PR TITLE
Dev: Extracted out JSBSim as a seperate simulator page

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -96,46 +96,6 @@ this command
 
     sudo pip install --upgrade pymavlink MAVProxy
 
-Using JSBSim
-------------
-
-For ArduPlane you can choose several possible simulators. A popular
-choice is JSBSim, which you can enable with the -f jsbsim option to SITL.
-
-JSBSim is a sophisticated flight
-simulator that is used as the core flight dynamics system for several
-well known flight simulation systems.
-
-In the past ArduPilot required a special version of JSBSim. As of
-December 2018 that is no longer the case, and we can use the
-standard JSBSim releases.
-
-In order to build JSBSIM, you need Cmake, install it with :
-
-::
-
-    sudo apt-get install cmake
-
-In the same directory (your home directory) run these commands:
-
-::
-
-    git clone git://github.com/JSBSim-Team/jsbsim.git
-    cd jsbsim
-    mkdir build
-    cd build
-    cmake -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_BUILD_TYPE=Release ..
-    make -j2
-
-If using the JSBSim plane simulator you can specify a different JSBSim
-model than the default Rascal110 by specifying the model name using the
--f parameter to sim_vehicle.py, like this:
-
-::
-
-    sim_vehicle.py -v ArduPlane -f jsbsim:MyModel --console --map
-
-the model should be in the **Tools/autotest/aircraft/** directory.
 
 FlightGear 3D View (Optional)
 -----------------------------

--- a/dev/source/docs/simulation-2.rst
+++ b/dev/source/docs/simulation-2.rst
@@ -14,12 +14,13 @@ Simulation allows for safe testing of experimental code and settings and crashin
 
 The most commonly used simulators are:
 
--  :ref:`SITL (Software In The Loop) <sitl-simulator-software-in-the-loop>` is the simulator most commonly used by developers.  It is used by the :ref:`autotester <the-ardupilot-autotest-framework>` and other simulators below are actually built on top of SITL
+-  :ref:`SITL (Software In The Loop) <sitl-simulator-software-in-the-loop>` is the simulator most commonly used by developers. It is a simple simulator that is built within all SITL builds of ArduPilot. It is used by the :ref:`autotester <the-ardupilot-autotest-framework>` and other simulators below are actually built on top of SITL
 -  :ref:`Gazebo <using-gazebo-simulator-with-sitl>` is the official DARPA virtual robotics simulator
 -  :ref:`XPlane-10 <sitl-with-xplane>` a commercial flight simulator with a rich 3D interface
 -  :ref:`RealFlight <sitl-with-realflight>` a commercial flight simulator with a rich 3D interface and ability to design custom vehicles
 -  :ref:`Morse <sitl-with-morse>` a robotics simulation environment commonly used in research
--  :ref:`Replay <testing-with-replay>` has no graphical interfacde but allows re-running master from a dataflash log
+-  :ref:`Replay <testing-with-replay>` has no graphical interface but allows re-running master from a dataflash log
+-  :ref:`JSBSim <sitl-with-jsbsim>` is a sophisticated open-source plane and multicopter simulator with no graphical interface. It can be used with a wide variety of airframes.
 
 Less often used simulators include:
 
@@ -38,6 +39,7 @@ List of simulators (so they can appear in the menu):
     RealFlight <sitl-with-realflight>
     Morse <sitl-with-morse>
     Replay <testing-with-replay>
+    JSBSim <sitl-with-jsbsim>
     Last Letter <using-last_letter-as-an-external-sitl-simulator>
     CRRCSim <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>
     HITL Simulators <hitl-simulators>

--- a/dev/source/docs/sitl-native-on-windows.rst
+++ b/dev/source/docs/sitl-native-on-windows.rst
@@ -271,8 +271,6 @@ Updating ArduPilot
 
 See advice on :ref:`this wiki page <git-rebase>` regarding how to "Rebase" on ArduPilot's master branch.
 
-The JSBSim source can be updated by calling ``git pull`` in the **jsbsim/** directory.
-
 Updating MAVProxy
 =================
 

--- a/dev/source/docs/sitl-with-jsbsim.rst
+++ b/dev/source/docs/sitl-with-jsbsim.rst
@@ -1,0 +1,45 @@
+.. _sitl-with-jsbsim:
+
+======================
+Using SITL with JSBSim
+======================
+
+JSBSim is a sophisticated flight
+simulator that is used as the core flight dynamics system for several
+well known flight simulation systems.
+
+In the past ArduPilot required a special version of JSBSim. As of
+December 2018 that is no longer the case, and we can use the
+standard JSBSim releases.
+
+In order to build JSBSIM, you need Cmake, install it with :
+
+::
+
+    sudo apt-get install cmake
+
+.. tip::
+
+   The build commands below are contained within ``Tools/scripts/build-jsbsim.sh``.
+
+In the same directory (your home directory) run these commands:
+
+::
+
+    git clone git://github.com/JSBSim-Team/jsbsim.git
+    cd jsbsim
+    mkdir build
+    cd build
+    cmake -DCMAKE_CXX_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_C_FLAGS_RELEASE="-O3 -march=native -mtune=native" -DCMAKE_BUILD_TYPE=Release ..
+    make -j2
+
+If using the JSBSim plane simulator you can specify a different JSBSim
+model than the default Rascal110 by specifying the model name using the
+-f parameter to sim_vehicle.py, like this:
+
+::
+
+    sim_vehicle.py -v ArduPlane -f jsbsim:MyModel --console --map
+
+The model should be in the **Tools/autotest/aircraft/** directory.
+


### PR DESCRIPTION
JSBSim is now has a dedicated page in the SITL section, making it easier to find, and keeping it consistent with all the other SITL backends.