### PR TITLE
Update apmcopter-programming-libraries.rst

### DIFF
--- a/dev/source/docs/apmcopter-programming-libraries.rst
+++ b/dev/source/docs/apmcopter-programming-libraries.rst
@@ -32,8 +32,8 @@ libraries and their function.
    a library to more convert pwm input/output from APM_RC into internal
    units such as angles
 -  `AP_HAL <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL>`__,
-   `AP_HAL_AVR <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_AVR>`__,
-   `AP_HAL_PX4 <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_PX4>`__
+   `AP_HAL_ChibiOS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_ChibiOS>`__,
+   `AP_HAL_Linux <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_Linux>`__
    - libraries to implement the "Hardware abstraction layer" which
    presents an identical interface to the high level code so that it can
    more easily be ported to different boards.


### PR DESCRIPTION
The earlier mentioned HAL libraries don't exist anymore. Changed the names and updated the links.

Not sure if the other HAL libraries, [AP_HAL_Empty](https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_Empty) and [AP_HAL_SITL](https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_SITL) should also be added or if all three of these are even required.

Please comment if any extra changes need to be made