### PR TITLE
Split Partners page and change logo list into table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,16 @@
 /antennatracker/source/docs/common-*
 /dev/source/docs/common-*
 
+# Common CSS except under Common
+/ardupilot/source/_static/common_*
+/copter/source/_static/common_*
+/plane/source/_static/common_*
+/rover/source/_static/common_*
+/planner/source/_static/common_*
+/planner2/source/_static/common_*
+/antennatracker/source/_static/common_*
+/dev/source/_static/common_*
+
 # Any build directory
 */build/*
 

--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -387,3 +387,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -388,3 +388,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/common/source/_static/common_theme_override.css
+++ b/common/source/_static/common_theme_override.css
@@ -34,3 +34,9 @@ table.partners-table td {
         display: block;
     }
 }
+
+/* wiki top menu makes anchor links disappear under it, this hack fixes it */
+.section {
+    padding-top: 40px;
+    margin-top: -40px;
+}

--- a/common/source/_static/common_theme_override.css
+++ b/common/source/_static/common_theme_override.css
@@ -1,0 +1,36 @@
+/* custom CSS for ArduPilot wiki */
+
+/* CSS for Partners logo list */
+table.partners-table {
+    width: 100%;
+}
+
+table.partners-table img {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: contain;
+}
+
+table.partners-table td {
+    background-color: #fff !important;
+    height: 15vw;
+}
+
+@media screen and (min-width: 1660px) {
+    table.partners-table td {
+        height: 250px;
+    }
+}
+
+@media screen and (max-width: 600px) {
+    table.partners-table td {
+        width: 100%;
+        display: block;
+        height: 20vw;
+        border: 1px solid #e1e4e5 !important;
+    }
+
+    table.partners-table, table.partners-table tbody {
+        display: block;
+    }
+}

--- a/common/source/docs/common-donation.rst
+++ b/common/source/docs/common-donation.rst
@@ -8,7 +8,7 @@ There are several ways of donating to ArduPilot and all donations large and smal
 
 - Direct `PayPal Donation <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__
 - By Credit Card using `ClickAndPledge <https://co.clickandpledge.com/advanced/default.aspx?wid=34115>`__.  Be sure to enter the amount in the ArduPilot section, other sections are for other `SPI projects <http://www.spi-inc.org/>`__.  Other methods can be found on the `SPI donations page <http://www.spi-inc.org/donations/>`__.
-- Become a `Corporate Partner <http://ardupilot.org/about/Partners>`__
+- Become a :doc:`Corporate Partner <common-partners>`
  
 Support Merchandise
 ===================  

--- a/common/source/docs/common-partners-program.rst
+++ b/common/source/docs/common-partners-program.rst
@@ -1,0 +1,48 @@
+.. image:: ../../../logos/ArduPilotPartners2.png
+    :width: 480px
+
+==========================
+ArduPilot Partners Program
+==========================
+
+The ArduPilot Project is the result of an immense amount of effort from software and hardware engineers, beta testers, web developers, documenters, researchers and many others.  A vast number of individuals, institutions and companies use and contribute to ArduPilot - in the spirit of Free and Open Source Software we freely and openly welcome their involvement in the project.  There is no cost to use, or contribute to, any software provided by ArduPilot.
+The Project does incur costs though, so this page explains our Partners Program for :ref:`corporate sponsors <common-partners>`.
+
+Why a Partners Program
+======================
+ArduPilot is a free and open-source software project that includes:
+
+- Embedded firmware that is designed to serve as the control system for autonomous vehicles, and supports many different hardware targets listed on the Supported Hardware page
+- A number of Ground Control Station software applications that allow management of vehicles running ArduPilot firmware, e.g. more convenient settings editing on an often more comfortable interface, firmware download and transfer, upgrading and conversion of settings between different devices and versions, fleet management, operations monitoring and more
+- The http://ardupilot.org website, http://discuss.ardupilot.org forum and this wiki
+- Server infrastructure dedicated to distributing software and firmware, and testing/building/distributing of the different variants for all the different supported platforms and options
+- A global community of users with an enormous variety of goals and expectations
+- A global team of developers with varying degrees of knowledge of the different aspects of the project’s code and of its management
+
+In order to continue providing, maintaining and improving the rich ArduPilot ecosystem, the Project relies heavily on generous donations of time from many people - but we also incur financial costs that must be covered.  Simplistically, meeting these costs is what the Partners Program achieves.
+
+How does my company become a partner?
+=====================================
+We ask for an annual donation of at least `$1000 USD through PayPal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__  per year. For large companies or those who rely on ArduPilot as part of their core business, annual donations of `$5,000 <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__ , `$10,000 <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__  or more are greatly appreciated. If this is your first time, please email partners@ardupilot.org to express your desire to become a partner and include your company logo if you would like it to appear on :ref:`Partners page <common-partners>`.  We will send you a reminder in a year and if all goes well, you may choose to extend for another year.
+
+In some countries it is not possible to donate through PayPal in which case you can donate by Credit Card using `Click&Pledge <https://co.clickandpledge.com/advanced/default.aspx?wid=34115>`__.  Be sure to enter the amount in the ArduPilot section, other sections are for other `SPI projects <http://www.spi-inc.org/>`__. Other methods can be found on the `SPI donations page <http://www.spi-inc.org/donations/>`__.
+
+What do I get for becoming an ArduPilot Partner?
+================================================
+Beyond a warm feeling in your heart for helping a worthy project, we will coordinate an "Onboarding Meeting" and direct contact methods for the core Development Team members, so we can discuss your objectives, identify a unique engagement strategy for each Partner, and maintain good communication with you.  Your company can also attend the ArduPilot Partners monthly meeting.  This is a meeting held online, via our Mumble Server, on the first Wednesday or Thursday (depending upon your timezone) of each month.  It is attended by the core devs and presents an opportunity to get high-level updates on the project and influence how funds are spent (via proposals to the Funding Committee).  This update is recorded, and available to Partners shortly after it is held.  You may also find like-minded companies with whom you can cooperate in various ways.  
+
+How are collected funds spent?
+==============================
+Funds are first used to cover fixed costs including servers to host the wiki, forum, autotest and build servers, other running expenses, plus a part-time employee who oversees code quality (amongst other things).
+Any remaining funds will be used to pay for documentation efforts, hardware/software costs for developers working on ArduPilot related enhancements, and subsidise the annual Developers Conference.  A Funding Committee of 3 people is voted on annually from within the Development Team to oversee and control financial matters. 
+
+I'm not a company, but I love your stuff, how can I help?
+=========================================================
+Please see our more general, :ref:`how-to-donate <common-donation>` page but in short, we accept donations of any amount from individuals as well.  Also please consider helping out with documentation, beta testing or code development.  Tell your friends and post videos of your successes with ArduPilot! 
+
+I want a new feature, do I have to be a partner to get it?
+==========================================================
+No.  ArduPilot is, and always will be, open source.  Contributions to the code base, wherever they come from, are accepted based on their technical merits.  If you're not in a position to make the changes yourself, please add it to the `Issues list <https://github.com/ArduPilot/ardupilot/issues>`__ or consider contracting one of the companies listed on the :ref:`Commercial Support page <common-commercial-support>` to make the change.
+
+[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot"]
+

--- a/common/source/docs/common-partners.rst
+++ b/common/source/docs/common-partners.rst
@@ -1,14 +1,11 @@
 .. _common-partners:
 
-========
-Partners
-========
-
-The project is the result of an immense amount of effort from software and hardware engineers, beta testers, web developers, documenters and many others.  A vast number of individuals and companies use ArduPilot and we welcome their involvement in the project.  This page highlights some of our main corporate partners and clarifies how it all works.
-
-
+==================
 Corporate Partners
 ==================
+
+The ArduPilot Project is greatly appreciative of our Corporate Partners.  
+Details on the Partners Program and how to join can be found on the :doc:`Partners Program <common-partners-program>` page.
 
 .. image:: ../../../images/supporters/supporters_logo_elab.png
     :width: 250px
@@ -237,28 +234,5 @@ Corporate Partners
 .. image:: ../../../images/supporters/supporters_logo_ALTI.jpg
     :width: 250px
     :target:  https://www.altiuas.com
-
-How does my company become a partner?
-=====================================
-We ask for an annual donation of at least `$1000 USD through PayPal <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__  per year. For large companies or those who rely on ArduPilot as part of their core business, annual donations of `$5,000 <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__ , `$10,000 <https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=BBF28AFAD58B2>`__  or more are greatly appreciated. If this is your first time, please email partners@ardupilot.org to express your desire to become a partner and include your company logo if you would like it to appear on this page.  We will send you a reminder in a year and if all goes well, you may choose to extend for another year.
-
-In some countries it is not possible to donate through PayPal in which case you can donate by Credit Card using `ClickAndPledge <https://co.clickandpledge.com/advanced/default.aspx?wid=34115>`__.  Be sure to enter the amount in the ArduPilot section, other sections are for other `SPI projects <http://www.spi-inc.org/>`__.  Other methods can be found on the `SPI donations page <http://www.spi-inc.org/donations/>`__.
-
-What do I get for becoming an ArduPilot partner?
-================================================
-Beyond a warm feeling in your heart for helping a worthy project, your company can send a representative to the "ArduPilot Advisory Board" meeting.  This is a meeting held on the first Wednesday or Thursday (depending upon your timezone) of each month.  It is attended by the core devs and presents an opportunity to get high-level updates on the project and influence how funds are spent (via proposals to the Funding Committee).  You may also find like-minded companies with whom you can cooperate in various ways.
-
-How are collected funds spent?
-==============================
-Funds are first used to cover fixed costs including servers to host the wiki, autotest and build servers and other running expenses.
-Any remaining funds will be used to pay for documentation efforts and hardware/software costs for developers working on ArduPilot related enhancements, and subsidise the annual Developers Conference.  A Funding Committee of 3 people is voted on annually from within the Development Team to oversee and control financial matters.
-
-I'm not a company, but I love your stuff, how can I help?
-=========================================================
-Please see our more general, :ref:`how-to-donate <common-donation>` page but in short, we accept donations of any amount from individuals as well.  Also please consider helping out with documentation, beta testing or code development.  Tell your friends and post videos of your successes with ArduPilot!
-
-I want a new feature, do I have to be a partner to get it?
-==========================================================
-No.  ArduPilot is, and always will be, open source.  Contributions to the code base, wherever they come from, are accepted based on their technical merits.  If you're not in a position to make the changes yourself, please add it to the `Issues list <https://github.com/ArduPilot/ardupilot/issues>`__ or consider contracting one of the companies listed on the :ref:`Commercial Support page <common-commercial-support>` to make the change.
 
 [copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot"]

--- a/common/source/docs/common-partners.rst
+++ b/common/source/docs/common-partners.rst
@@ -7,232 +7,323 @@ Corporate Partners
 The ArduPilot Project is greatly appreciative of our Corporate Partners.  
 Details on the Partners Program and how to join can be found on the :doc:`Partners Program <common-partners-program>` page.
 
-.. image:: ../../../images/supporters/supporters_logo_elab.png
-    :width: 250px
-    :target:  http://elab.co.jp
+.. list-table::
+    :class: partners-table
 
-.. image:: ../../../images/supporters/supporters_logo_jDrones.png
-    :width: 250px
-    :target:  http://jdrones.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_elab.png
+            :width: 250px
+            :align: center
+            :target:  http://elab.co.jp
 
-.. image:: ../../../images/supporters/supporters_logo_ProfiCNC.png
-    :width: 250px
-    :target:  http://proficnc.com/stores
+      - .. image:: ../../../images/supporters/supporters_logo_jDrones.png
+            :width: 250px
+            :align: center
+            :target:  http://jdrones.com
 
-.. image:: ../../../images/supporters/supporters_logo_mRobotics.png
-    :width: 250px
-    :target:  http://mrobotics.io
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_ProfiCNC.png
+            :width: 250px
+            :align: center
+            :target:  http://proficnc.com/stores
 
-.. image:: ../../../images/supporters/supporters_logo_Emlid.png
-    :width: 250px
-    :target:  https://emlid.com
+      - .. image:: ../../../images/supporters/supporters_logo_mRobotics.png
+            :width: 250px
+            :align: center
+            :target:  http://mrobotics.io
 
-.. image:: ../../../images/supporters/supporters_logo_CUAV.jpg
-    :width: 250px
-    :target:  http://www.cuav.net
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Emlid.png
+            :width: 250px
+            :align: center
+            :target:  https://emlid.com
 
-.. image:: ../../../images/supporters/supporters_logo_Craft_and_Theory.png
-    :width: 250px
-    :target:  http://craftandtheoryllc.com
+      - .. image:: ../../../images/supporters/supporters_logo_CUAV.jpg
+            :width: 250px
+            :align: center
+            :target:  http://www.cuav.net
 
-.. image:: ../../../images/supporters/supporters_logo_LaserNavigation.png
-    :width: 250px
-    :target:  https://lasernavigation.it
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Craft_and_Theory.png
+            :width: 250px
+            :align: center
+            :target:  http://craftandtheoryllc.com
 
-.. image:: ../../../images/supporters/supporters_logo_LightWare.png
-    :width: 250px
-    :target:  https://lightware.co.za
+      - .. image:: ../../../images/supporters/supporters_logo_LaserNavigation.png
+            :width: 250px
+            :align: center
+            :target:  https://lasernavigation.it
 
-.. image:: ../../../images/supporters/supporters_logo_SpektreWorks.png
-    :width: 250px
-    :target:  https://spektreworks.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_LightWare.png
+            :width: 250px
+            :align: center
+            :target:  https://lightware.co.za
 
-.. image:: ../../../images/supporters/supporters_logo_Hex.png
-    :width: 250px
-    :target:  http://hex.aero
+      - .. image:: ../../../images/supporters/supporters_logo_SpektreWorks.png
+            :width: 250px
+            :align: center
+            :target:  https://spektreworks.com
 
-.. image:: ../../../images/supporters/supporters_logo_Dronebility.png
-    :width: 250px
-    :target:  http://dronebility.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Hex.png
+            :width: 250px
+            :align: center
+            :target:  http://hex.aero
 
-.. image:: ../../../images/supporters/supporters_logo_Drone_Japan.jpg
-    :width: 250px
-    :target:  https://drone-j.com
+      - .. image:: ../../../images/supporters/supporters_logo_Dronebility.png
+            :width: 250px
+            :align: center
+            :target:  http://dronebility.com
 
-.. image:: ../../../images/supporters/supporters_logo_RobSense.png
-    :width: 250px
-    :target:  http://robsense.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Drone_Japan.jpg
+            :width: 250px
+            :align: center
+            :target:  https://drone-j.com
 
-.. image:: ../../../images/supporters/supporters_logo_BlueRobotics.png
-    :width: 250px
-    :target:  https://bluerobotics.com
+      - .. image:: ../../../images/supporters/supporters_logo_RobSense.png
+            :width: 250px
+            :align: center
+            :target:  http://robsense.com
 
-.. image:: ../../../images/supporters/supporters_logo_Skyrocket.jpg
-    :width: 250px
-    :target:  https://sky-viper.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_BlueRobotics.png
+            :width: 250px
+            :align: center
+            :target:  https://bluerobotics.com
 
-.. image:: ../../../images/supporters/supporters_logo_Drotek.png
-    :width: 250px
-    :target:  https://drotek.com
+      - .. image:: ../../../images/supporters/supporters_logo_Skyrocket.jpg
+            :width: 250px
+            :align: center
+            :target:  https://sky-viper.com
 
-.. image:: ../../../images/supporters/supporters_logo_Harris_Aerial.jpg
-    :width: 250px
-    :target:  https://www.harrisaerial.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Drotek.png
+            :width: 250px
+            :align: center
+            :target:  https://drotek.com
 
-.. image:: ../../../images/supporters/supporters_logo_AltiGator.jpg
-    :width: 250px
-    :target:  https://altigator.com/en
+      - .. image:: ../../../images/supporters/supporters_logo_Harris_Aerial.jpg
+            :width: 250px
+            :align: center
+            :target:  https://www.harrisaerial.com
 
-.. image:: ../../../images/supporters/supporters_logo_Event_38.png
-    :width: 250px
-    :target:  https://event38.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_AltiGator.jpg
+            :width: 250px
+            :align: center
+            :target:  https://altigator.com/en
 
-.. image:: ../../../images/supporters/supporters_logo_Skeyetech.png
-    :width: 250px
-    :target:  https://skeyetech.fr
+      - .. image:: ../../../images/supporters/supporters_logo_Event_38.png
+            :width: 250px
+            :align: center
+            :target:  https://event38.com
 
-.. image:: ../../../images/supporters/supporters_logo_3DRX.jpg
-    :width: 250px
-    :target: https://3dxr.co.uk
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Skeyetech.png
+            :width: 250px
+            :align: center
+            :target:  https://skeyetech.fr
 
-.. image:: ../../../images/supporters/supporters_logo_Carbonix.png
-    :width: 250px
-    :target: https://carbonix.com.au
+      - .. image:: ../../../images/supporters/supporters_logo_3DRX.jpg
+            :width: 250px
+            :align: center
+            :target: https://3dxr.co.uk
 
-.. image:: ../../../images/supporters/supporters_logo_AgEagle.png
-    :width: 250px
-    :target:  https://ageagle.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Carbonix.png
+            :width: 250px
+            :align: center
+            :target: https://carbonix.com.au
 
-.. image:: ../../../images/supporters/supporters_logo_enRoute.jpg
-    :width: 250px
-    :target:  https://enroute.co.jp
+      - .. image:: ../../../images/supporters/supporters_logo_AgEagle.png
+            :width: 250px
+            :align: center
+            :target:  https://ageagle.com
 
-.. image:: ../../../images/supporters/supporters_logo_Drones_Center.png
-    :width: 250px
-    :target:  http://drones-center.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_enRoute.jpg
+            :width: 250px
+            :align: center
+            :target:  https://enroute.co.jp
 
-.. image:: ../../../images/supporters/supporters_logo_Wurzbach_Electronics.png
-    :width: 250px
-    :target:  https://wurzbachelectronics.com
+      - .. image:: ../../../images/supporters/supporters_logo_Drones_Center.png
+            :width: 250px
+            :align: center
+            :target:  http://drones-center.com
 
-.. image:: ../../../images/supporters/supporters_logo_TT_Robotix.jpg
-    :width: 250px
-    :target:  http://ttrobotix.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Wurzbach_Electronics.png
+            :width: 250px
+            :align: center
+            :target:  https://wurzbachelectronics.com
 
-.. image:: ../../../images/supporters/supporters_logo_NOVAerial.png
-    :width: 250px
-    :target:  https://novaerial.com
+      - .. image:: ../../../images/supporters/supporters_logo_TT_Robotix.jpg
+            :width: 250px
+            :align: center
+            :target:  http://ttrobotix.com
 
-.. image:: ../../../images/supporters/supporters_logo_Air_Supply_Aerial.png
-    :width: 250px
-    :target:  https://www.airsupplyaerial.net/shop
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_NOVAerial.png
+            :width: 250px
+            :align: center
+            :target:  https://novaerial.com
 
-.. image:: ../../../images/supporters/supporters_logo_Terraplane.png
-    :width: 250px
-    :target:  http://terraplanellc.com
+      - .. image:: ../../../images/supporters/supporters_logo_Air_Supply_Aerial.png
+            :width: 250px
+            :align: center
+            :target:  https://www.airsupplyaerial.net/shop
 
-.. image:: ../../../images/supporters/supporters_logo_IR_Lock.jpg
-    :width: 250px
-    :target:  https://irlock.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Terraplane.png
+            :width: 250px
+            :align: center
+            :target:  http://terraplanellc.com
 
-.. image:: ../../../images/supporters/supporters_logo_Benewake.png
-    :width: 250px
-    :target:  http://en.benewake.com
+      - .. image:: ../../../images/supporters/supporters_logo_IR_Lock.jpg
+            :width: 250px
+            :align: center
+            :target:  https://irlock.com
 
-.. image:: ../../../images/supporters/supporters_logo_Foxtech.jpg
-    :width: 250px
-    :target:  https://foxtechfpv.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Benewake.png
+            :width: 250px
+            :align: center
+            :target:  http://en.benewake.com
 
-.. image:: ../../../images/supporters/supporters_logo_BFD_Systems.jpg
-    :width: 250px
-    :target:  https://bfdsystems.com
+      - .. image:: ../../../images/supporters/supporters_logo_Foxtech.jpg
+            :width: 250px
+            :align: center
+            :target:  https://foxtechfpv.com
 
-.. image:: ../../../images/supporters/supporters_logo_Unmanned_Tech.jpg
-    :width: 250px
-    :target:  https://unmannedtechshop.co.uk
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_BFD_Systems.jpg
+            :width: 250px
+            :align: center
+            :target:  https://bfdsystems.com
 
-.. image:: ../../../images/supporters/supporters_logo_Rubidium_Light.jpg
-    :width: 250px
-    :target:  https://rubidiumlight.com.au/rubidium-rover
+      - .. image:: ../../../images/supporters/supporters_logo_Unmanned_Tech.jpg
+            :width: 250px
+            :align: center
+            :target:  https://unmannedtechshop.co.uk
 
-.. image:: ../../../images/supporters/supporters_logo_Makeflyeasy.jpg
-    :width: 250px
-    :target:  http://makeflyeasy.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Rubidium_Light.jpg
+            :width: 250px
+            :align: center
+            :target:  https://rubidiumlight.com.au/rubidium-rover
 
-.. image:: ../../../images/supporters/supporters_logo_Hexsoon.jpg
-    :width: 250px
-    :target: http://ardupilot.org/about/Partners
+      - .. image:: ../../../images/supporters/supporters_logo_Makeflyeasy.jpg
+            :width: 250px
+            :align: center
+            :target:  http://makeflyeasy.com
 
-.. image:: ../../../images/supporters/supporters_logo_Micro_Aerial_Projects.png
-    :width: 250px
-    :target:  https://microaerialprojects.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Hexsoon.jpg
+            :width: 250px
+            :align: center
+            :target: http://ardupilot.org/about/Partners
 
-.. image:: ../../../images/supporters/supporters_logo_ARACE_UAS.png
-    :width: 250px
-    :target:  https://longrangefpv.com
+      - .. image:: ../../../images/supporters/supporters_logo_Micro_Aerial_Projects.png
+            :width: 250px
+            :align: center
+            :target:  https://microaerialprojects.com
 
-.. image:: ../../../images/supporters/supporters_logo_Eagle_Pride.png
-    :width: 250px
-    :target:  https://eaglepridedrones.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_ARACE_UAS.png
+            :width: 250px
+            :align: center
+            :target:  https://longrangefpv.com
 
-.. image:: ../../../images/supporters/supporters_logo_KDE_Direct.png
-    :width: 250px
-    :target:  https://kdedirect.com
+      - .. image:: ../../../images/supporters/supporters_logo_Eagle_Pride.png
+            :width: 250px
+            :align: center
+            :target:  https://eaglepridedrones.com
 
-.. image:: ../../../images/supporters/supporters_logo_Qifei.png
-    :width: 250px
-    :target:  https://agrobot.en.alibaba.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_KDE_Direct.png
+            :width: 250px
+            :align: center
+            :target:  https://kdedirect.com
 
-.. image:: ../../../images/supporters/supporters_logo_Mateksys.png
-    :width: 250px
-    :target:  http://mateksys.com
+      - .. image:: ../../../images/supporters/supporters_logo_Qifei.png
+            :width: 250px
+            :align: center
+            :target:  https://agrobot.en.alibaba.com
 
-.. image:: ../../../images/supporters/supporters_logo_Tiho_Aviation.png
-    :width: 250px
-    :target:  http://ardupilot.org/about/Partners
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Mateksys.png
+            :width: 250px
+            :align: center
+            :target:  http://mateksys.com
 
-.. image:: ../../../images/supporters/supporters_logo_Freespace.png
-    :width: 250px
-    :target:  https://freespace.solutions
+      - .. image:: ../../../images/supporters/supporters_logo_Tiho_Aviation.png
+            :width: 250px
+            :align: center
+            :target:  http://ardupilot.org/about/Partners
 
-.. image:: ../../../images/supporters/supporters_logo_Holybro.png
-    :width: 250px
-    :target:  http://holybro.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_Freespace.png
+            :width: 250px
+            :align: center
+            :target:  https://freespace.solutions
 
-.. image:: ../../../images/supporters/supporters_logo_ASW.png
-    :width: 250px
-    :target:  https://aerosystemswest.com
+      - .. image:: ../../../images/supporters/supporters_logo_Holybro.png
+            :width: 250px
+            :align: center
+            :target:  http://holybro.com
 
-.. image:: ../../../images/supporters/supporters_logo_Bask_Aerospace.jpg
-    :width: 250px
-    :target:  https://baskaerospace.com.au
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_ASW.png
+            :width: 250px
+            :align: center
+            :target:  https://aerosystemswest.com
 
-.. image:: ../../../images/supporters/supporters_logo_D_Makers.png
-    :width: 250px
-    :target:  http://itmakers.co.kr
+      - .. image:: ../../../images/supporters/supporters_logo_Bask_Aerospace.jpg
+            :width: 250px
+            :align: center
+            :target:  https://baskaerospace.com.au
 
-.. image:: ../../../images/supporters/supporters_logo_Hitec.png
-    :width: 250px
-    :target:  https://hitecnology.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_D_Makers.png
+            :width: 250px
+            :align: center
+            :target:  http://itmakers.co.kr
 
-.. image:: ../../../images/supporters/supporters_logo_AeroScanTech.png
-    :width: 250px
-    :target:  https://aeroscantech.com
+      - .. image:: ../../../images/supporters/supporters_logo_Hitec.png
+            :width: 250px
+            :align: center
+            :target:  https://hitecnology.com
 
-.. image:: ../../../images/supporters/supporters_logo_Quaternium.png
-    :width: 250px
-    :target:  https://quaternium.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_AeroScanTech.png
+            :width: 250px
+            :align: center
+            :target:  https://aeroscantech.com
 
-.. image:: ../../../images/supporters/supporters_logo_NP_UAS_TS.png
-    :width: 250px
-    :target:  http://npuasts.com
+      - .. image:: ../../../images/supporters/supporters_logo_Quaternium.png
+            :width: 250px
+            :align: center
+            :target:  https://quaternium.com
 
-.. image:: ../../../images/supporters/supporters_logo_AION_ROBOTICS.png
-    :width: 250px
-    :target:  https://aionrobotics.com
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_NP_UAS_TS.png
+            :width: 250px
+            :align: center
+            :target:  http://npuasts.com
 
-.. image:: ../../../images/supporters/supporters_logo_ALTI.jpg
-    :width: 250px
-    :target:  https://www.altiuas.com
+      - .. image:: ../../../images/supporters/supporters_logo_AION_ROBOTICS.png
+            :width: 250px
+            :align: center
+            :target:  https://aionrobotics.com
+
+    *
+      - .. image:: ../../../images/supporters/supporters_logo_ALTI.jpg
+            :width: 250px
+            :align: center
+            :target:  https://www.altiuas.com
+
+      -
 
 [copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot"]

--- a/common_conf.py
+++ b/common_conf.py
@@ -56,3 +56,6 @@ if disable_non_local_image_warnings:
 
     sphinx.environment.BuildEnvironment.warn_node = _warn_node
 ############ ENDPATH
+
+def setup(app):
+   app.add_stylesheet("common_theme_override.css")

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -387,3 +387,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -386,3 +386,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -386,3 +386,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -386,3 +386,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -388,4 +388,5 @@ epub_exclude_files = ['search.html']
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
 
-
+def setup(app):
+   common_conf.setup(app)

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -380,3 +380,6 @@ epub_exclude_files = ['search.html']
 
 #Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping
+
+def setup(app):
+   common_conf.setup(app)

--- a/update.py
+++ b/update.py
@@ -30,6 +30,7 @@ import re
 import os
 from codecs import open
 import subprocess
+import shutil
 
 
 DEFAULT_COPY_WIKIS =['copter', 'plane', 'rover']
@@ -183,6 +184,11 @@ def generate_copy_dict(start_dir=COMMON_DIR):
         except:
             pass
 
+        try:
+            os.mkdir('%s/source/_static' % wiki)
+        except:
+            pass
+
 
     for root, dirs, files in os.walk(start_dir):
         for file in files:
@@ -202,6 +208,9 @@ def generate_copy_dict(start_dir=COMMON_DIR):
                     destination_file = open(targetfile, 'w', 'utf-8')
                     destination_file.write(content)
                     destination_file.close()
+            elif file.endswith(".css"):
+                for wiki in ALL_WIKIS:
+                    shutil.copy2(os.path.join(root, file), '%s/source/_static/' % wiki)
 
 
 def get_copy_targets(content):


### PR DESCRIPTION
The PR might be divided into three topics:

- the split into 2 pages (started by @auturgy on #1737/#1738 that this superseeds)
- converting list of partner logos to be a table with custom CSS
- other fixes

Regarding 1st: please check the language and whether you think the split is good (the page with instructions is just linked once in the normal page; I have my doubts on the effectiveness of this, but the old end of page text didn't work either)

Regarding 2nd: note that because this is now a table, we need to be more careful when adding and removing partners since we need to keep a specific format - namely:
- this is a table of two columns so every two lines there needs to be an `*` to signal a new line
- a line can't have only one element, in that case, an empty `-` element needs to be added

Regarding 3rd: fixes donation page to point to wiki partners page (no need to get out of the wiki, plus website version doesn't work correctly on mobile) and a fix that is a different way of my PR https://github.com/ArduPilot/sphinx_rtd_theme/pull/8 (which will be closed by this)

Anyone is invited to test (in multiple devices) a temporary deployed version at http://oxinarf.pt/wiki/ardupilot/docs/common-partners.html