### PR TITLE
[fix] Google groups link updated to forums link.

### DIFF
--- a/ardupilot/source/index.rst
+++ b/ardupilot/source/index.rst
@@ -108,7 +108,7 @@ Developer Community:
 
 `Developers Portal <http://ardupilot.org/dev/index.html>`__
 
-All things for those who want to get into the nuts and bolts of ArduPilot development can be found in the developer portal. ie. `meeting times <http://ardupilot.org/dev/docs/ardupilot-mumble-server.html#ardupilot-mumble-server>`__, `Gitter Chat <https://gitter.im/ArduPilot/ardupilot/>`__ and `email groups <https://groups.google.com/forum/#!forum/drones-discuss>`__
+All things for those who want to get into the nuts and bolts of ArduPilot development can be found in the developer portal. ie. `meeting times <http://ardupilot.org/dev/docs/ardupilot-mumble-server.html#ardupilot-mumble-server>`__, `Gitter Chat <https://gitter.im/ArduPilot/ardupilot/>`__ and `on the forums <http://discuss.ardupilot.org/>`__
 
 
 History:


### PR DESCRIPTION
Fix on the main index.html.

(rendering checked with the recommended Vagrant environment)