### PR TITLE
[minor insertion] Adding ArduSub in Dev list of projects.

### DIFF
--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -65,6 +65,9 @@ ArduPilot dev team.
 -  Rover (`wiki <http://rover.ardupilot.com/>`__,
    `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
    ground vehicles
+-  Sub (`wiki <https://www.ardusub.com/>`__,
+   `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
+   submersible vehicles
 -  Antenna Tracker (`wiki <http://ardupilot.org/antennatracker/index.html>`__,
    `code <https://github.com/ArduPilot/ardupilot>`__) - for automatically aiming an antenna at a vehicle
 -  Mission Planner (`wiki <http://planner.ardupilot.com/>`__,


### PR DESCRIPTION

On the main Dev page, there is a list of projects. I added arduSub with repo and wiki links.

(render tested with vagrant env.)