### PR TITLE
[fix] MAV_CMD_DO_SET_HOME description fix.

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -2866,7 +2866,7 @@ specified in the command.
 
    1=Set home as current location.
 
-   2=Use location specified in message parameters.
+   0=Use location specified in message parameters.
    </td>
    </tr>
    <tr style="color: #c0c0c0">


### PR DESCRIPTION
Issue #1752 pointed the error and the source of correct information: https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_HOME

I tried to check it in the code. These were my findings:

The two files above refer to command 179 regarding the name MAV_CMD_DO_SET_HOME and have the comments as 1=use current location, 0=use specified location.

\Ardupilot\modules\mavlink\message_definitions\v1.0
\Ardupilot\modules\mavlink\pymavlink\generator\swift\Tests\MAVLinkTests\Testdata\common.xml 

In the file "GCS_Common.cpp" the function "handle_command_do_set_home()" expects 1 or 0 as appears on the code.

In the file "GCS_Mavlink.cpp" of expects 1 or 0 as appears on the code.

In the file "AP_Mission.cpp" the "cmd.p1 = packet.param1" expects 1 or 0 as said in comment.

In the file "commands_logic.cpp" of ArduSub the command mentioned is the MAVLINK 179. 

In the file "commands_logic.cpp" of ArduPlane expects 1 or not 1 as appears on the code.

In the file "mode_auto.cpp" of ArduCopter expects 1 or not 1 as appears on the code.

In the file "mode_auto.cpp" of ArduRover2 expects 1 or not 1 as appears on the code.

So, I do believe this fix is correct.