### PR TITLE
plane-configuration-landing-page: link to updated arming page

### DIFF
--- a/plane/source/docs/plane-configuration-landing-page.rst
+++ b/plane/source/docs/plane-configuration-landing-page.rst
@@ -33,6 +33,6 @@ components, including those required for the operation of the autopilot.
     Automatic Flaps <automatic-flaps>
     Center of Gravity <guide-center-of-gravity>
     RC Input Throw and Trim <rc-throw-trim>
-    Throttle Arming in Plane <arming-throttle>
+    Arming your Plane <arming-your-plane>
     Advanced Failsafe Configuration <advanced-failsafe-configuration>
     Sensor Testing <common-sensor-testing>


### PR DESCRIPTION
currently referenced arming-throttle page contains outdated version-specific information, unfortunate advice ("ARMING_CHECK parameter should probably be left at 0 when at the an airfield without a ground control station") and is a duplicate of the more up-to-date arming-your-plane page. 
i suggest to link arming-your-plane here and retire arming-throttle