### PR TITLE
Rover last version of firmware for APM2

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -56,7 +56,7 @@ Discontinued boards
 The following boards are end-of-life. The documentation is archived, but
 available if you're still working on those platforms:
 
--  :ref:`APM 2.x <common-apm25-and-26-overview>` - APM 2.x (APM 2.6 and later) are no longer supported for Copter, Plane or Rover. The last firmware builds that fit on this board are Copter 3.2.1, and Plane 3.3.0, and Rover 3.4.2.
+-  :ref:`APM 2.x <common-apm25-and-26-overview>` - APM 2.x (APM 2.6 and later) are no longer supported for Copter, Plane or Rover. The last firmware builds that fit on this board are Copter 3.2.1, and Plane 3.3.0, and Rover 3.1.0.
 -  :ref:`NAVIO+ <common-navio-overview>`
 -  :ref:`PX4FMU <common-px4fmu-overview>` and (:ref:`PX4IO <common-px4io-overview>`)
 -  :ref:`Qualcomm Snapdragon Flight Kit <common-qualcomm-snapdragon-flight-kit>`

--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -56,7 +56,7 @@ Discontinued boards
 The following boards are end-of-life. The documentation is archived, but
 available if you're still working on those platforms:
 
--  :ref:`APM 2.x <common-apm25-and-26-overview>` - APM 2.x (APM 2.6 and later) are no longer supported for Copter or Plane. The last firmware builds that fit on this board are Copter 3.2.1 and Plane 3.3.0.
+-  :ref:`APM 2.x <common-apm25-and-26-overview>` - APM 2.x (APM 2.6 and later) are no longer supported for Copter, Plane or Rover. The last firmware builds that fit on this board are Copter 3.2.1, and Plane 3.3.0, and Rover 3.4.2.
 -  :ref:`NAVIO+ <common-navio-overview>`
 -  :ref:`PX4FMU <common-px4fmu-overview>` and (:ref:`PX4IO <common-px4io-overview>`)
 -  :ref:`Qualcomm Snapdragon Flight Kit <common-qualcomm-snapdragon-flight-kit>`


### PR DESCRIPTION
I discover in the forums that APM2 is no longer support newer Rover firmwares. Based on firmwares repo I beleive that the last firmware that fits on the APM2 is the 3.4.2.

PR to provide same information on the wiki.