### PR TITLE
Remove step 4 from new MAVLINK messages.

### DIFF
--- a/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
+++ b/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
@@ -4,8 +4,8 @@
 Adding a new MAVLink Message
 ============================
 
-Data and commands are passed between the ground station (i.e Mission Planner, QGroundControl, MAVProxy etc) using the `MAVLink protocol <https://mavlink.io/en/>`__ over a serial
-interface. This page provides some high level advice for adding a new
+Data and commands are passed between the ground station (i.e. Mission Planner, QGroundControl, MAVProxy, etc.) using the `MAVLink protocol <https://mavlink.io/en/>`__ over a serial
+interface. This page provides some high-level advice for adding a new
 MAVLink message.
 
 These instructions have only been tested on Linux (to be precise a VM
@@ -14,7 +14,7 @@ are on the :ref:`SITL page <setting-up-sitl-on-windows>`. If you can
 run SITL, you should be able to follow the advice here. These
 instructions will not run natively on Windows or a Mac.
 
-**Step #1:** Ensure you have the latest ArduPilot code installed. Also
+**Step #1:** Ensure you have the latest ArduPilot code installed. Also,
 check mavproxy. Mavproxy can be updated by running this command in a
 Terminal window:
 
@@ -25,13 +25,14 @@ Terminal window:
 **Step #2:** Decide what type of message you want to add and how it will
 fit in with the existing `MAVLink messages <https://mavlink.io/en/>`__.
 
-For example you might want to send a new new navigation command to the
+
+For example, you might want to send a new navigation command to the
 vehicle so that it can perform a trick (like a flip) in the middle of a
-mission (i.e. in AUTO mode).  In this case you would need a new
+mission (i.e. in AUTO mode).  In this case, you would need a new
 MAV_CMD_NAV_TRICK similar to the MAV_CMD_NAV_WAYPOINT definition
 (search for "MAV_CMD_NAV_WAYPOINT" in the \ `MAVLink messages <https://mavlink.io/en/messages/common.html>`__ page).
 
-Alternatively you may want to send down a new type of sensor data from
+Alternatively, you may want to send down a new type of sensor data from
 the vehicle to the ground station.  Perhaps similar to the
 `SCALED_PRESSURE <https://mavlink.io/en/messages/common.html#SCALED_PRESSURE>`__
 message.
@@ -45,22 +46,18 @@ file in the mavlink submodule.
 If this command is generally useful, and will hopefully be added to the MAVLink protocol, then it
 should be added to the
 ../modules/mavlink/message_definitions/v1.0/common.xml
-file. If it is only for your personal use or only applicable to ArduPilot then it should be added to the ardupilotmega.xml file.
+file. If it is only for your personal use or only applicable to ArduPilot, then it should be added to the ardupilotmega.xml file.
 
-**Step #4:** Generate MAVLink source.  The source code is automatically generated when you compile the project, but for testing and debugging it may be useful cd to the ardupilot directory and then run this command to manually generate it.
+**Step #4:** Add functions to the main vehicle code to handle sending or receiving the command to/from the ground station. A compile will be needed (ie. ./waf copter) to generate the mavlink packet code so make sure to do that after editing the XML file. The mavlink generation happens first, so it doesn't matter if the project compilation is successful or not due to other source code changes.
 
-``./libraries/GCS_MAVLink/generate.sh``
-
-**Step #5:** Add functions to the main vehicle code to handle sending or receiving the command to/from the ground station. A compile will be needed (ie. ./waf copter) to generate the mavlink packet code so make sure to do that after editing the xml file. The mavlink generation happens first so it doesn't matter if the project compilation is successful or notdue to other source code changes.
-
-The top level of this code will most likely be in the vehicle's
+The top-level of this code will most likely be in the vehicle's
 `GCS_MAVLink.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_Mavlink.cpp>`__
 file or in the
 `../libraries/GCS_MAVLink/GCS <https://github.com/ArduPilot/ardupilot/blob/master/libraries/GCS_MAVLink/GCS.h>`__
 class.
 
 In the first example where we want to add support for a new navigation
-command (i.e. a trick) the following would be required:
+command (i.e., a trick) the following would be required:
 
 -  Extend the
    `AP_Mission <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Mission>`__
@@ -84,11 +81,11 @@ command (i.e. a trick) the following would be required:
    complete.  The ``verify_trick()`` function should return true when
    the trick has been completed.
    
-**Step #6:** Decide how you are going to handle the message at the GCS. One of the
+**Step #5:** Decide how you are going to handle the message at the GCS. One of the
 simplest ways is to use Mavproxy. MavProxy uses pymavlink to define the MAVLink messages,
 so you will need to rebuild pymavlink to include your custom message. 
  
- - Remove the currently install version of pymavlink. ``pip uninstall pymavlink``
+ - Remove the currently installed version of pymavlink. ``pip uninstall pymavlink``
  - Install the updated version. CD to ``ardupilot/modules/mavlink/pymavlink``
    and run ``python setup.py install --user``
  - Mavproxy is now capable of sending or receiving the new message. To ask it
@@ -131,7 +128,7 @@ so you will need to rebuild pymavlink to include your custom message.
    If the message you added has an ID greater that 255 you will need to enable Mavlink 2 support. 
    This can be done by setting the relevant ``SERIALn_PROTOCOL`` parameters (e.g. ``SERIAL1_PROTOCOL``) to 2 and starting Mavproxy with the ``--mav20`` argument.
 
-**Step #7:** Consider contributing your code back to the main code base.
+**Step #6:** Consider contributing your code back to the main code base.
 Discuss this with other developers on `Gitter <https://gitter.im/ardupilot/ardupilot>`__ and/or
 :ref:`raise a pull request <submitting-patches-back-to-master>`. If
 you raise a pull request it is best to separate the change into at least


### PR DESCRIPTION
Basically removing step 4.

Please, needs reviews! 

The change was done without coding knowledge. I did it only based on #354 and on #1805 request interlacing.