### PR TITLE
Raspbian buster version to use python-wxgtk3.0

### DIFF
--- a/dev/source/docs/raspberry-pi-via-mavlink.rst
+++ b/dev/source/docs/raspberry-pi-via-mavlink.rst
@@ -151,6 +151,11 @@ packages:
 
 .. note::
 
+   For raspbian versions buster use:
+   sudo apt-get install screen python-wxgtk3.0 python-matplotlib python-opencv python-pip python-numpy python-dev libxml2-dev libxslt-dev    python-lxml
+
+.. note::
+
    The packages are :ref:`mostly the same as when setting up SITL <setting-up-sitl-on-windows>`. Reply Reply 'y' when
    prompted re additional disk space.
 


### PR DESCRIPTION
Added a note for new Raspberry Pi users to use the new python-wxgtk3.0 version. 

Trying to use python-wxgtk2.8 is giving this error in newer releases:  
Package 'python-wxgtk2.8' has no installation candidate