### PR TITLE
Update common-autopilots.rst

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -4,59 +4,74 @@
 Autopilot Hardware Options
 ==========================
 
-This section provides information about the main ArduPilot Flight Controller Hardware options:
+This section provides information about ArduPilot Flight Controller Hardware options:
 
 Open hardware 
 -------------
 
 .. toctree::
     :maxdepth: 1
-
-    Pixhawk <common-pixhawk-overview>
-    The Cube <common-thecube-overview>
-    Pixracer <common-pixracer-overview>
-    CUAV v5 <common-pixhackV5-overview>
+    
+    BBBMini <https://github.com/mirkix/BBBMINI>
     Beagle Bone Blue <common-beagle-bone-blue>
-    Erle-Brain <common-erle-brain-linux-autopilot>
+    CUAV v5 and v5+ <common-pixhackV5-overview>
+    CUAV v5 Nano <https://store.cuav.net/index.php?id_product=98&id_product_attribute=0&rewrite=cuav-new-pixhack-v5-nano-small-flight-controller-for-ardupilot-px4-drone-parts-free-shipping-whole-sale-&controller=product&id_lang=3>
+    Drotek Pixhawk3 <https://drotek.gitbook.io/pixhawk-3-pro/>
     F4BY <common-f4by>
+    Hex/ProfiCNC Cube Black <common-thecube-overview>
+    Hex/ProfiCNC Cube Green <http://www.proficnc.com/all-products/79-the-cube.html>
+    Hex/ProfiCNC Cube Orange <http://www.proficnc.com/all-products/188-the-cube.html>
+    Hex/ProfiCNC Cube Purple <http://www.proficnc.com/all-products/176-the-cube.html>
+    Hex/ProfiCNC Cube Yellow <http://www.proficnc.com/all-products/187-the-cube.html>
+    mRo Pixracer <common-pixracer-overview>
+    MRo X2.1 <https://store.mrobotics.io/mRo-X2-1-Rev-2-p/mro-x2.1rv2-mr.htm>
+    MRo X2.1-777 <https://store.mrobotics.io/mRo-X2-1-777-p/mro-x2.1-777-mr.htm>
     OpenPilot Revolution <common-openpilot-revo-mini>
-    PXFmini RPi Zero Shield <common-pxfmini>
+    Pixhawk <common-pixhawk-overview>
+    PocketPilot <https://github.com/PocketPilot/PocketPilot>
     TauLabs Sparky2 <common-taulabs-sparky2>
-
+    
 Closed hardware
 ---------------
 
 .. toctree::
     :maxdepth: 1
 
+    Aerotenna Ocpoc-Zynq <https://aerotenna.com/shop/ocpoc-zynq-mini/>
     Emlid Edge <common-emlid-edge>
-    NAVIO2 <common-navio2-overview>
+    Emlid NAVIO2 <common-navio2-overview>
     Furious FPV F-35 Lightning and Wing FC-10 <common-furiousfpv-f35>
     Holybro Kakute F4 <common-holybro-kakutef4>
     Holybro Kakute F7 AIO <common-holybro-kakutef7aio>
     Holybro Pixhawk 4 <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/README.md>
     Holybro Pixhawk 4 Mini <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/PH4-mini/README.md>
-    Intel Aero <common-intel-aero-overview>
-    Intel Aero RTF vehicle <common-intel-aero-rtf>
     Mateksys F405-STD and variants <common-matekf405>
     Mateksys F405-Wing <common-matekf405-wing>
-    Omnibus F4 Pro <common-omnibusf4pro>
+    mRo ControlZero F7 <https://store.mrobotics.io/mRo-Control-Zero-F7-p/mro-ctrl-zero-f7.htm>
+    Omnibus F4 AIO/Pro <common-omnibusf4pro>
     OmnibusNanoV6 <common-omnibusnanov6>
-    Omnibus F7 <common-omnibusf7>
-    Parrot C.H.U.C.K (for the Parrot Disco) <common-CHUCK-overview>
-[site wiki="copter"]
+    Omnibus F7V2 <common-omnibusf7>
     Parrot Bebop Autopilot <parrot-bebop-autopilot>
-[/site]
+    Parrot C.H.U.C.K <common-CHUCK-overview>
     RadioLink MiniPix <common-radiolink-minipix>
     SpeedyBee F4 <common-speedybeef4>
+    VR Brain 5 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrain5-detail>
+    VR uBrain 5.1 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrainmicro51-detail>
 
 Discontinued boards
 -------------------
+The following boards are no longer produced, however documentation is still available in the wiki or online, and recent builds are still expected to work.  These boards are not recommended for new projects.
 
-The following boards are end-of-life. The documentation is archived, but
+    Erle PXFmini RPi Zero Shield <common-pxfmini>
+    Erle ErleBrain <common-erle-brain-linux-autopilot>
+    Intel Aero <common-intel-aero-overview>
+    Intel Aero RTF vehicle <common-intel-aero-rtf>
+
+The following boards are no longer supported. The documentation is archived, but
 available if you're still working on those platforms:
 
 -  :ref:`APM 2.x <common-apm25-and-26-overview>` - APM 2.x (APM 2.6 and later) are no longer supported for Copter, Plane or Rover. The last firmware builds that fit on this board are Copter 3.2.1, and Plane 3.3.0, and Rover 2.5.1.
 -  :ref:`NAVIO+ <common-navio-overview>`
 -  :ref:`PX4FMU <common-px4fmu-overview>` and (:ref:`PX4IO <common-px4io-overview>`)
 -  :ref:`Qualcomm Snapdragon Flight Kit <common-qualcomm-snapdragon-flight-kit>`
+


### PR DESCRIPTION
Partial remedy for https://github.com/ArduPilot/ardupilot_wiki/issues/1844
I've used the best weblinks I could find for the boards added, but we'll need to work with vendors to improve them / add dedicated pages.  I've also re-organised into alphabetical order (which was partially already the case).
The valid waf targets that I believe are available to consumers but I haven't added are (boards, not rtf's which I excluded): airbotf4, bhat, crazyflie2, dark, erleboard, mindpx-v2,  omnibusf4v6, rst_zynq, VRCore-v10, zynq
Those targets I'm either not familiar with, couldn't find reasonable links for, and/or we don't have OEM datasheets/pages.  There are also a few boards we build for that aren't available anymore, so I've ignored them for now.