### PR TITLE
Dev: add documentation of sitl with scrimmage

### DIFF
--- a/dev/source/docs/simulation-2.rst
+++ b/dev/source/docs/simulation-2.rst
@@ -28,6 +28,7 @@ Less often used simulators include:
 -  :ref:`Last Letter <using-last_letter-as-an-external-sitl-simulator>` is a simpler simulator (fixed wing only) with lower CPU requirements than most other simulators.
 -  :ref:`CRRCSim <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>` is a less commonly used simulator for fixed wing and helictopers.
 -  :ref:`Hardware In the Loop <hitl-simulators>` (HITL) simulation runs ArduPilot on the flight controller using raw sensor data fed in from the simulated environment running on the desktop PC.  HITL is only supported for Plane.
+-  :ref:`SCRIMMAGE <sitl-with-scrimmage>` is an open-source vehicle simulator focused on collaborative robotics
 
 List of simulators (so they can appear in the menu):
 
@@ -46,3 +47,4 @@ List of simulators (so they can appear in the menu):
     CRRCSim <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>
     HITL Simulators <hitl-simulators>
     Autotest Framework <the-ardupilot-autotest-framework>
+    SCRIMMAGE <sitl-with-scrimmage>

--- a/dev/source/docs/sitl-with-scrimmage.rst
+++ b/dev/source/docs/sitl-with-scrimmage.rst
@@ -1,0 +1,54 @@
+.. _sitl-with-scrimmage:
+
+===================================
+Using SCRIMMAGE as a SITL simulator
+===================================
+`Simulating Collaborative Robots in Massive Mulit-Agent Game Execution (SCRIMMAGE) <http://www.scrimmagesim.org/>`__
+provides a flexible simulation environment for the experimentation and testing of novel mobile robotics algorithms.
+SCRIMMAGE provides a three-dimensional robotics environment that can simulate varying levels of sensor and motion model
+fidelity due to its flexible plugin interface. This allows a robotics researcher to simulate hundreds of aircraft with
+low-fidelity motion models or tens of aircraft with high-fidelity motion models on a standard consumer laptop.
+
+Installing SCRIMMAGE
+====================
+
+To install SRIMMAGE for use in Ardupilot follow the build instructions in the
+`SCRIMMAGE README on Github. <https://github.com/gtri/scrimmage/blob/master/README.md>`__
+
+
+Starting an ArduPlane Simulation
+================================
+
+To start an ArduPlane simulation use the ``-f`` argument in sim_vehicle.py:
+::
+
+    cd ArduPlane
+    ../Tools/autotest/sim_vehicle.py -f scrimmage-plane
+
+Starting an ArduCopter Simulation
+=================================
+
+To start an ArduCopter simulation use the ``-f`` argument in sim_vehicle.py:
+::
+
+    cd ArduCopter
+    ../Tools/autotest/sim_vehicle.py -f scrimmage-copter
+
+Additional SCRIMMAGE Parameters
+===============================
+
+Additional parameters can be passed into SCRIMMAGE using the ``-A`` and ``--config`` arguments. These parameters can be used to
+overwrite the defaults in the SCRIMMAGE mission file such as the motion model, visual model, or terrain.
+::
+
+    cd ArduPlane
+    ../Tools/autotest/sim_vehicle.py -f scrimmage-plane -A "--config visual_model=zephyr-red,motion_model=FixedWing6DOF"
+
+Valid Arduplane motion models include FixedWing6DOF and JSBSimControl. Valid visual models are zephyr-blue,
+zephyr-red, and zephyr-green. Currently the only valid copter motion model is Multirotor and the iris visual model.
+Additional visual and terrain models can be installed using the scrimmage apt repository added during installation.
+
+::
+
+    sudo apt install scrimmage-extra-visual-models
+    sudo apt install scrimmage-extra-terrain


### PR DESCRIPTION
Documentation for using Scrimmage as SITL simulator. Relevant pull request: https://github.com/ArduPilot/ardupilot/pull/11887