### PR TITLE
Wiki build error fix: rangefinder labels

### DIFF
--- a/common/source/docs/common-benewake-tf02-lidar.rst
+++ b/common/source/docs/common-benewake-tf02-lidar.rst
@@ -28,14 +28,14 @@ For a serial connection you can use any spare Serial/UART port.  The diagram bel
 
 .. image:: ../../../images/benewake-tf02-pixhawk.png
 
-If the SERIAL4/5 port on a Pixhawk is being used then the following parameters should be set:
+If the SERIAL4/5 port on a Pixhawk is being used then the following parameters should be set for the first rangefinder:
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 19 (Benewake TF02)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 30
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>`: for TF02 use **2000** for indoor, **1000** for outdoor.  For TF03 use **3500** for indoor, **12000** for outdoor.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 30
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>`: for TF02 use **2000** for indoor, **1000** for outdoor.  For TF03 use **3500** for indoor, **12000** for outdoor.  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If instead the Telem2 port was used then the serial parameters listed above should instead be:
 

--- a/common/source/docs/common-benewake-tfmini-lidar.rst
+++ b/common/source/docs/common-benewake-tfmini-lidar.rst
@@ -26,14 +26,14 @@ For a serial connection you can use any spare Serial/UART port.  The diagram bel
 
 .. image:: ../../../images/benewake-tfmini-pixhawk.png
 
-If the SERIAL4/5 port on a Pixhawk is being used then the following parameters should be set:
+If the SERIAL4/5 port on a Pixhawk is being used then the following parameters should be set for the first rangefinder:
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 20 (Benewake TFmini)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 30
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **1000** for indoor use OR **600** for outdoors.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 20 (Benewake TFmini)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 30
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **1000** for indoor use OR **600** for outdoors.  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If instead the Telem2 port was used then the serial parameters listed above should instead be:
 

--- a/common/source/docs/common-echologger-ect400.rst
+++ b/common/source/docs/common-echologger-ect400.rst
@@ -27,7 +27,7 @@ Connecting and Configuring
 
 The ECT400 provides distance measurements using the NMEA protocol over serial at 115200 baud.
 
-The sensor can be connected to any available serial/uart port on the flight controller.  In the diagram below the sensor is connected to SERIAL2.
+The sensor can be connected to any available serial/uart port on the flight controller.  In the diagram below the first sensor is connected to SERIAL2.
 
 .. image:: ../../../images/echologger-ect400-pixhawk.png
     :target: ../_images/echologger-ect400-pixhawk.png
@@ -39,10 +39,10 @@ If the SERIAL2 is used then the following parameters should be set:
 
 Then the following range finder related parameters should be set:
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 13
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = 10000 (i.e. 100m).  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_ORIENT <RNGFND_ORIENT>` = 25 (i.e. down) if mounted on a boat
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 13
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = 10000 (i.e. 100m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 Configuring the sensor
 ----------------------

--- a/common/source/docs/common-leddar-one-lidar.rst
+++ b/common/source/docs/common-leddar-one-lidar.rst
@@ -27,16 +27,16 @@ The sensor's serial connection can be connected to any spare serial port (i.e. T
 
 You then need to setup the serial port and rangefinder parameters. If
 you have used the SERIAL4/5 port on the Pixhawk then you would set the
-following parameters (this is done on the Mission Planner's
+following parameters for the first rangefinder (this is done on the Mission Planner's
 **Config/Tuning \| Full Parameter List** page):
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115200
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 12 (LeddarOne)
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **4000** (40m) *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 12 (LeddarOne)
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **4000** (40m) *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115200
 

--- a/common/source/docs/common-lightware-lw20-lidar.rst
+++ b/common/source/docs/common-lightware-lw20-lidar.rst
@@ -27,16 +27,16 @@ If using the caseless SF20 ensure the cable looks like below:
 
 You then need to setup the serial port and rangefinder parameters. If
 you have used the SERIAL4/5 port on the Pixhawk then you would set the
-following parameters (this can be done using the *Mission Planner*
+following parameters if its the first rangefinder in the system (this can be done using the *Mission Planner*
 **Config/Tuning \| Full Parameter List** page):
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud) for newer sensors, 19 (19200 baud) for sensors manufactured before mid 2018
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 8 (LightWareSerial)
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 8 (LightWareSerial)
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to 115 (115200 baud) or 19 (19200 baud)
 
@@ -56,12 +56,12 @@ If using the caseless SF20 ensure the cable looks like below:
 You then need to configure the rangefinder parameters as shown below
 (this cn be done suing the *Mission Planner* **Config/Tuning \| Full Parameter List** page):
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 7 (LightWareI2C)
--  :ref:`RNGFND_ADDR <RNGFND_ADDR>` = 102 (I2C Address of lidar in decimal).  *Note that this setting is in decimal. The default address is 0x66 hexademical which is 102 in decimal.*
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 7 (LightWareI2C)
+-  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 102 (I2C Address of lidar in decimal).  *Note that this setting is in decimal. The default address is 0x66 hexademical which is 102 in decimal.*
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-lightware-sf10-lidar.rst
+++ b/common/source/docs/common-lightware-sf10-lidar.rst
@@ -51,16 +51,16 @@ The diagram below shows how to connect to SERIAL4.
 
 You then need to setup the serial port and rangefinder parameters. If
 you have used the SERIAL4/5 port on the Pixhawk then you would set the
-following parameters (this is done in the *Mission Planner*
+following parameters in the case of the first rangefinder(this is done in the *Mission Planner*
 **Config/Tuning \| Full Parameter List** page):
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud) 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 8 (LightWareSerial)
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 8 (LightWareSerial)
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115
 
@@ -86,12 +86,12 @@ You then need to configure the rangefinder parameters as shown below
 (this is done in the *Mission Planner* **Config/Tuning \| Full Parameter
 List** page):
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 7 (LightWareI2C)
--  :ref:`RNGFND_ADDR <RNGFND_ADDR>` = 102 (I2C Address of lidar in decimal).  *Please note that this setting is in decimal and not hexadecimal as shown in the lidar settings screen. The default address is 0x66 which is 102 in decimal.*
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 7 (LightWareI2C)
+-  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 102 (I2C Address of lidar in decimal).  *Please note that this setting is in decimal and not hexadecimal as shown in the lidar settings screen. The default address is 0x66 which is 102 in decimal.*
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 .. warning::
 
@@ -118,20 +118,20 @@ You then need to setup the ADC and rangefinder parameters as shown below
 (this is done in the *Mission Planner* **Config/Tuning \| Full Parameter
 List** page):
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 1 (Analog)
--  :ref:`RNGFND_PIN <RNGFND_PIN>` = 14 (2nd pin of 3.3V ADC connector)
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = **9.76** (for SF10A), **19.531** (for SF10B), **39.06** (for SF10C), **46.87** (for SF11C)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **2000** (for SF10A), **4500** (for SF10B), **9500** (for SF10C) or **11500** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.  Note the range is 5m less than using Serial or I2C protocols so that out-of-range can be reliably detected*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 1 (Analog)
+-  :ref:`RNGFND1_PIN <RNGFND1_PIN>` = 14 (2nd pin of 3.3V ADC connector)
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = **9.76** (for SF10A), **19.531** (for SF10B), **39.06** (for SF10C), **46.87** (for SF11C)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **2000** (for SF10A), **4500** (for SF10B), **9500** (for SF10C) or **11500** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.  Note the range is 5m less than using Serial or I2C protocols so that out-of-range can be reliably detected*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
-The :ref:`RNGFND_SCALING <RNGFND_SCALING>` value depends on the voltage on the rangefinders output pin at the maximum range. By default the SF10/B will output 2.56V at 50m, so the scaling factor is 50m / 2.56v ≈ 19.53 (the analog
+The :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` value depends on the voltage on the rangefinders output pin at the maximum range. By default the SF10/B will output 2.56V at 50m, so the scaling factor is 50m / 2.56v ≈ 19.53 (the analog
 distance range for each of the rangefinder variants can be found in the `SF10 Manual <http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%2011.pdf>`__).
 The manual explains how you can confirm and change the maximum output range/voltage.
 
 .. tip::
 
-   We highly recommend that you tune the ``RNGFND_SCALING`` value by
+   We highly recommend that you tune the ``RNGFND1_SCALING`` value by
    comparing the output against a known distance.
 
 Testing the sensor

--- a/common/source/docs/common-rangefinder-sf02.rst
+++ b/common/source/docs/common-rangefinder-sf02.rst
@@ -33,11 +33,11 @@ To configure Copter, Plane or Rover to use the LIDAR-Lite, please first
 connect with the Mission Planner and then open the Config/Tuning >> Full
 Parameter List page and set:
 
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = "3700" (i.e. 40m max range - 3m buffer.  This buffer is required so the flight code can detect when there is nothing in range)
--  :ref:`RNGFND_PIN <RNGFND_PIN>` = "14" (2nd pin of 3.3V ADC connector)
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = "12.12" (ie. 40m / 3.3v = 12.12) **
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = “1" (Analog)
--  :ref:`RNGFND_RMETRIC <RNGFND_RMETRIC>` = "0" (non-ratiometric, shown incorrectly in the
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = "3700" (i.e. 40m max range - 3m buffer.  This buffer is required so the flight code can detect when there is nothing in range)
+-  :ref:`RNGFND1_PIN <RNGFND1_PIN>` = "14" (2nd pin of 3.3V ADC connector)
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = "12.12" (ie. 40m / 3.3v = 12.12) **
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = “1" (Analog)
+-  :ref:`RNGFND1_RMETRIC <RNGFND1_RMETRIC>` = "0" (non-ratiometric, shown incorrectly in the
    diagram below)
 
 ** The default range for an SF02 is 33m / 3.3V = 10 m/V

--- a/common/source/docs/common-sensor-offset-compensation.rst
+++ b/common/source/docs/common-sensor-offset-compensation.rst
@@ -48,7 +48,7 @@ Although individual position offsets can be set for each IMU, the difference bet
 
 **Range Finder (Sonar or Lidar):**
 
-- :ref:`RNGFND_POS_X <RNGFND_POS_X>`, :ref:`RNGFND_POS_Y <RNGFND_POS_Z>`, :ref:`RNGFND_POS_Z <RNGFND_POS_Z>` the first RangeFinder's position from the vehicle's IMU or center of gravity
+- :ref:`RNGFND1_POS_X <RNGFND1_POS_X>`, :ref:`RNGFND1_POS_Y <RNGFND1_POS_Z>`, :ref:`RNGFND1_POS_Z <RNGFND1_POS_Z>` the first RangeFinder's position from the vehicle's IMU or center of gravity
 - :ref:`RNGFND2_POS_X <RNGFND2_POS_X>`, :ref:`RNGFND2_POS_Y <RNGFND2_POS_Z>`, :ref:`RNGFND2_POS_Z <RNGFND2_POS_Z>` the second RangeFinder's position from the vehicle's IMU or center of gravity
 
 **Optical Flow:**

--- a/common/source/docs/common-underwater-sonar-analog.rst
+++ b/common/source/docs/common-underwater-sonar-analog.rst
@@ -39,17 +39,17 @@ Next pins on the left side of the DST-2 (serial and RS-232 output) should be con
 
 .. image:: ../../../images/underwater-sonar-analog-wiring.png
 
-Connect with a ground station to the flight controller and set the following parameters (these settings assume the sensor is connected to Telem2/Serial2)
+Connect with a ground station to the flight controller and set the following parameters (these settings assume the first sensor is connected to Telem2/Serial2)
 
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 4 (4800 baud)
 
 Then the following range finder related parameters should be set:
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 13
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = 30000 (i.e. 300m).  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_ORIENT <RNGFND_ORIENT>` = 25 (i.e. down) if mounted on a boat
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 13
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = 30000 (i.e. 300m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-vl53l0x-lidar.rst
+++ b/common/source/docs/common-vl53l0x-lidar.rst
@@ -24,18 +24,18 @@ Where to Buy
 Connecting to the Flight Controller
 -----------------------------------
 
-Connect the VCC, GND, SDA ans SCL lines of the lidar to the I2C port on the flight controller as shown below.
+Connect the VCC, GND, SDA ans SCL lines of the lidar to the I2C port on the flight controller as shown below for the first rangefinder.
 
 .. image:: ../../../images/vl53l0x-pixhawk.jpg
 
 Please set the rangefinder parameters as shown below (this can be done using the *Mission Planner* **Config/Tuning \| Full Parameter List** page):
 
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 16 (VL53L0X)
--  :ref:`RNGFND_ADDR <RNGFND_ADDR>` = 41 (I2C Address of lidar in decimal).  *The sensor's default I2C address is 0x29 hexademical which is 41 in decimal.*
--  :ref:`RNGFND_SCALING <RNGFND_SCALING>` = 1
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 5
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = **120** for the VL53L0X, **360** for the VL53L1X.  *This is the distance in cm that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in cm from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 16 (VL53L0X)
+-  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 41 (I2C Address of lidar in decimal).  *The sensor's default I2C address is 0x29 hexademical which is 41 in decimal.*
+-  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 5
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = **120** for the VL53L0X, **360** for the VL53L1X.  *This is the distance in cm that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in cm from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-wasp200-lidar.rst
+++ b/common/source/docs/common-wasp200-lidar.rst
@@ -24,13 +24,13 @@ For a serial connection you can use any spare Serial/UART port.  The diagram bel
 
 .. image:: ../../../images/wasp200-pixhawk.jpg
 
-If the SERIAL4 port on a Pixhawk is being used then the following parameters should be set:
+If the SERIAL4 port on a Pixhawk is being used then the following parameters should be set for the first rangefinder:
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
--  :ref:`RNGFND_TYPE <RNGFND_TYPE>` = 18 (Wasp200)
--  :ref:`RNGFND_MIN_CM <RNGFND_MIN_CM>` = 200
--  :ref:`RNGFND_MAX_CM <RNGFND_MAX_CM>` = 20000.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND_GNDCLEAR <RNGFND_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 18 (Wasp200)
+-  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 200
+-  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>` = 20000.  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If instead the Telem2 port was used then the serial parameters listed above should instead be:
 


### PR DESCRIPTION
Eliminates rangefinder errors caused by moving to multiple rangefinders.....no content changes...