### PR TITLE
Wiki update for vectored thrust tailsitters

### DIFF
--- a/plane/source/docs/guide-tailsitter.rst
+++ b/plane/source/docs/guide-tailsitter.rst
@@ -100,6 +100,8 @@ servo is channel 6, then set:
 you also need to set the right SERVOn_REVERSED values, and the right
 SERVOn_TRIM, SERVOn_MIN and SERVOn_MAX values.
 
+Q_A_ANGLE_BOOST should be disabled for vectored thrust tailsitters. Failure to disable this will cause the throttle to decrease and the nose dips, making the nose dip even further and resulting in a crash. 
+
 Vectored Gains
 ==============
 

--- a/plane/source/docs/guide-tailsitter.rst
+++ b/plane/source/docs/guide-tailsitter.rst
@@ -100,7 +100,7 @@ servo is channel 6, then set:
 you also need to set the right SERVOn_REVERSED values, and the right
 SERVOn_TRIM, SERVOn_MIN and SERVOn_MAX values.
 
-Q_A_ANGLE_BOOST should be disabled for vectored thrust tailsitters. Failure to disable this will cause the throttle to decrease and the nose dips, making the nose dip even further and resulting in a crash. 
+Q_A_ANGLE_BOOST should be disabled for vectored thrust tailsitters. Failure to disable this will cause the throttle to decrease as the nose dips, making the nose dip even further and resulting in a crash. 
 
 Vectored Gains
 ==============


### PR DESCRIPTION
Added a sentence with guidance to disable Q_A_ANGLE_BOOST for vectored thrust tailsitters. Found this by crashing this weekend, and discovered this had been discussed some time ago. See tridge's advice below:
https://discuss.ardupilot.org/t/dual-motor-tailsitters/15302/500
