### PR TITLE
fix plane home wiki build errors

### DIFF
--- a/common/source/docs/common-3d-mapping.rst
+++ b/common/source/docs/common-3d-mapping.rst
@@ -21,7 +21,7 @@ the Feb 2014 T3 competition.
 Equipment you will need
 =======================
 
-:ref:`Plane <plane:home>` or
+`Plane <http://ardupilot.org/plane/index.html>`_ or
 :ref:`Multicopter <copter:home>`
 
 A digital still camera:

--- a/common/source/docs/common-choosing-a-ground-station.rst
+++ b/common/source/docs/common-choosing-a-ground-station.rst
@@ -24,7 +24,7 @@ Planner*, *APM Planner 2*, *MAVProxy*, *QGroundControl* and *UgCS*. For Tablet/S
 *Tower* (DroidPlanner 3), *MAVPilot*, *AndroPilot* and *SidePilot* that can be
 used to communicate with ArduPilot (i.e.
 :ref:`Copter <copter:home>`,
-:ref:`Plane <plane:home>`,
+`Plane <http://ardupilot.org/plane/index.html>`_,
 :ref:`Rover <rover:home>`,
 :ref:`AntennaTracker <antennatracker:home>`).
 

--- a/common/source/docs/common-multi-vehicle-flying.rst
+++ b/common/source/docs/common-multi-vehicle-flying.rst
@@ -19,7 +19,7 @@ single ground station. Although this capability has been demonstrated
 Equipment you will need
 =======================
 
--  Multiple :ref:`Planes <plane:home>` or
+-  Multiple `Planes <http://ardupilot.org/plane/index.html>`_ or
    :ref:`Copters <copter:home>` or
    :ref:`Rovers <rover:home>`
 -  An :ref:`Antenna Tracker <antennatracker:home>`\ (a.k.a. Tracker)


### PR DESCRIPTION
after Peter and I have failued to figure out why the ref plane:home doesnt work linking to the plane home page, I just added direct url links to get rid of the build errors....