### PR TITLE
Add CUAV V5 to discontinued list,resolving build error

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -68,6 +68,7 @@ The following boards are no longer produced, however documentation is still avai
 .. toctree::
     :maxdepth: 1
 
+    CUAV V5 <common-pixhackV5-overview>
     Erle PXFmini RPi Zero Shield <common-pxfmini>
     Erle ErleBrain <common-erle-brain-linux-autopilot>
     Intel Aero <common-intel-aero-overview>


### PR DESCRIPTION
Since CUAV no longer lists this, nor their distis, and CUAV V5plus and nano replace it....it should go in discontinued list and eliminate it as a floating document