### PR TITLE
Update in "adding a new drive mode" documentation

### DIFF
--- a/dev/source/docs/rover-adding-a-new-drive-mode.rst
+++ b/dev/source/docs/rover-adding-a-new-drive-mode.rst
@@ -121,7 +121,7 @@ As a reference the diagram below provides a high level view of Rover's architect
             friend class ModeManual;
             friend class ModeRTL;
 
-#. In `control_modes.cpp <https://github.com/ArduPilot/ardupilot/blob/master/APMrover2/control_modes.cpp>`__ add the new mode to the ``mode_from_mode_num()`` function to create the mapping between the mode's number and the instance of the class.
+#. In `mode.cpp <https://github.com/ArduPilot/ardupilot/blob/master/APMrover2/mode.cpp>`__ add the new mode to the ``mode_from_mode_num()`` function to create the mapping between the mode's number and the instance of the class.
 
    ::
 


### PR DESCRIPTION
Mapping between the mode's number and the instance of the class for rover now done in "mode.cpp" instead of 'control_modes.cpp'. This PR fixes it.