### PR TITLE
Non-GPS pages re-arrange.

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -46,7 +46,7 @@ tuning options for the vehicle.
     Magnetic Interference <common-magnetic-interference>
 [/site]
 [site wiki="copter,rover"]
-    Non-GPS Navigation <common-non-gps-navigation>
+    Non-GPS Navigation <common-non-gps-navigation-landing-page>
 [/site]
 [site wiki="copter"]
     Object Avoidance <copter-object-avoidance>

--- a/common/source/docs/common-non-gps-navigation-landing-page.rst
+++ b/common/source/docs/common-non-gps-navigation-landing-page.rst
@@ -1,4 +1,4 @@
-.. _common-non-gps-navigation:
+.. _common-non-gps-navigation-landing-page:
 
 [copywiki destination="copter,rover"]
 
@@ -11,14 +11,19 @@ Non-GPS Navigation
 
 These are the available options that allow a vehicle to estimate its position without a GPS.  Once enabled this allows all autonomous and semi-autonomous modes just as they do would a GPS is available.
 
-- :ref:`MarvelMind Beacons <common-marvelmind>`
-- :ref:`Optical Flow <common-optical-flow-sensors-landingpage>`
-- :ref:`OptiTrack motion capture system <common-optitrack>`
-- :ref:`Pozyx Beacons <common-pozyx>`
-- :ref:`ROS cartographer <ros-cartographer-slam>`
-- :ref:`Visual Odometry with OpenKai and ZED <common-zed>`
-- :ref:`Visual Odometry with VIO tracking camera <common-vio-tracking-camera>`
-- :ref:`Visual Odometry with VIO tracking camera and ROS <ros-vio-tracking-camera>`
+.. toctree::
+    :maxdepth: 1
+  
+    MarvelMind Beacons <common-marvelmind>
+[site wiki="copter"]
+	Optical Flow <common-optical-flow-sensors-landingpage>
+    OptiTrack motion capture system <common-optitrack>
+[/site]	
+    Pozyx Beacons <common-pozyx>
+    Vicon Positioning System <common-vicon-for-nongps-navigation>
+    Visual Odometry with OpenKai and ZED <common-zed>
+    Visual Odometry with VIO tracking camera <common-vio-tracking-camera>
+
 
 .. note::
 

--- a/common/source/docs/common-optional-hardware.rst
+++ b/common/source/docs/common-optional-hardware.rst
@@ -47,7 +47,7 @@ information related to Autopilot selection see :ref:`Autopilot Hardware Options 
 [/site]
     LEDs (external) <common-external-leds>
 [site wiki="copter,rover"]
-    Marvelmind for Non-GPS Navigation <common-marvelmind>
+	Non-GPS navigation <common-non-gps-navigation-landing-page>
 [/site]
     On-Screen Display (OSD) <common-osd-boards-on-screen-display>
 [site wiki="copter,plane"]
@@ -58,12 +58,6 @@ information related to Autopilot selection see :ref:`Autopilot Hardware Options 
 [/site]
     Power Tether <common-power-tether>
     PPM Encoder <common-ppm-encoder>
-[site wiki="copter,rover"]
-    Pozyx for Non-GPS navigation <common-pozyx>
-[/site]
-[site wiki="copter"]
-    OptiTrack for Non-GPS navigation <common-optitrack>
-[/site]
 [site wiki="copter"]
     Precision Landing and Loiter (IRLock) <precision-landing-with-irlock>
 [/site]
@@ -78,13 +72,7 @@ information related to Autopilot selection see :ref:`Autopilot Hardware Options 
 [/site]
     Telemetry Radio <common-telemetry-landingpage>
     Video <common-video-landingpage>
-[site wiki="copter,rover"]
-    VIO tracking camera for Non-GPS navigation <common-vio-tracking-camera>
-[/site]
 [site wiki="rover"]
     Wind Vane <wind-vane>
     Wheel Encoders <wheel-encoder>
-[/site]
-[site wiki="copter,rover"]
-    ZED for Non-GPS navigation <common-zed>
 [/site]

--- a/common/source/docs/common-use-cases-and-applications.rst
+++ b/common/source/docs/common-use-cases-and-applications.rst
@@ -16,8 +16,9 @@ Indoor Flying, and Web Applications.
     First Person View (FPV) <common-fpv-first-person-view>
     Multi-Vehicle Flying <common-multi-vehicle-flying>
 
+[site wiki="copter,rover"]
+    Non-GPS Positioning Systems. <common-non-gps-navigation-landing-page>
+[/site]
 [site wiki="copter"]
     Indoor Flying Guidelines <indoor-flying>
-    Using a Vicon Positioning System <vicon-setup>
 [/site]
-

--- a/common/source/docs/common-vicon-for-nongps-navigation.rst
+++ b/common/source/docs/common-vicon-for-nongps-navigation.rst
@@ -1,4 +1,6 @@
-.. _vicon-setup:
+.. _common-vicon-for-nongps-navigation:
+
+[copywiki destination="copter,rover"]
 
 =======================================
 Using a Vicon indoor positioning system
@@ -6,9 +8,9 @@ Using a Vicon indoor positioning system
 
 Robotics labs commonly have an indoor flying facility using a Vicon
 indoor positioning system. These systems use infra-red cameras to give
-high rate (200Hz) position and attitude via a network
+a high rate (200Hz) position and attitude via a network
 connection. ArduPilot can use this positioning information for precise
-indoor flight.
+indoor flight. 
 
 .. youtube:: XMb4MKi2HSQ
     :width: 100%

--- a/copter/source/docs/ac2_guidedmode.rst
+++ b/copter/source/docs/ac2_guidedmode.rst
@@ -74,4 +74,4 @@ This variation of Guided mode does not require a GPS but it only accepts `attitu
 
 .. note::
 
-   Guided_NoGPS does not allow a vehicle to hold position without a GPS (i.e. non-GPS navigation).  For information on :ref:`non-GPS navigation see this wiki page <common-non-gps-navigation>`
+   Guided_NoGPS does not allow a vehicle to hold position without a GPS (i.e. non-GPS navigation).  For information on :ref:`non-GPS navigation see this wiki page <common-non-gps-navigation-landing-page>`


### PR DESCRIPTION
This intends to re-arrange the Non-GPS pages, as discussed in issue #1983.

ros-vio-tracking-camera and ros-cartographer-slam were removed from because in already in DEV environment.

The pages are filtered for Rover and Copter only.
