### PR TITLE
Fix spelling of "telemetry"

### DIFF
--- a/common/source/docs/common-f4by.rst
+++ b/common/source/docs/common-f4by.rst
@@ -35,7 +35,7 @@ Specifications
 
 -  **Interfaces**
 
-   -  5x UART serial ports, 1 with inverter for frsky telemertry
+   -  5x UART serial ports, 1 with inverter for frsky telemetry
    -  Up to 12x PWM outputs
    -  Spektrum DSM/DSM2/DSM-X Satellite input
    -  Futaba S.BUS input support (with external inverter)


### PR DESCRIPTION
This fixes a spelling error in the F4BY FMU information.