### PR TITLE
Dev: Changed to correct path for script

### DIFF
--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -31,7 +31,7 @@ Install some required packages
 If you are on a debian based system (such as Ubuntu or Mint), we provide `a script <https://github.com/ArduPilot/ardupilot/blob/master/Tools/environment_install/install-prereqs-ubuntu.sh>`__ that will do it for you. From ardupilot directory :
 ::
 
-    Tools/environment_install/install-prereqs-ubuntu.sh -y
+    Tools/scripts/install-prereqs-ubuntu.sh -y
 
 Reload the path (log-out and log-in to make permanent):
 


### PR DESCRIPTION
Directory Tools/environment_install/ no longer exists. At least on master and the latest stable version of copter. https://github.com/ArduPilot/ardupilot/blob/Copter-3.6.10/Tools/scripts/install-prereqs-ubuntu.sh