### PR TITLE
Update quadplane-flying.rst

### DIFF
--- a/plane/source/docs/quadplane-flying.rst
+++ b/plane/source/docs/quadplane-flying.rst
@@ -39,9 +39,6 @@ The one exception to the forward motor stopping in QuadPlane VTOL
 modes is if you have the :ref:`Q_VFWD_GAIN <Q_VFWD_GAIN>` parameter set to a non-zero
 value. In that case the forward motor will be used to hold the
 aircraft level in a wind. See the description of :ref:`Q_VFWD_GAIN <Q_VFWD_GAIN>`.
-
-.. note::
- Tilt-Rotor Quadplanes do not have the capability of using Q_VFWD_GAIN, since there is no separate foward motor.
  
 Assisted fixed-wing flight
 ==========================


### PR DESCRIPTION
@Hwurzburg tiltrotors do implement "forward throttle" in QLOITER mode (the new text is taken from a comment in QuadPlane::tiltrotor_continuous_update() in tiltrotor.cpp), but I seem to have screwed up syntax for the note::
The preview shows the "Note" notation as deleted.