### PR TITLE
Plane: Update AFS with MAX_RANGE param, correct wrong param names, format edits

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -22,6 +22,7 @@ tuning options for the vehicle.
     Boats with Vectored Thrust <rover-vectored-thrust>
 [/site]
 [site wiki="plane"]
+    Advanced Failsafe <advanced-failsafe-configuration>
     Auxiliary Functions <common-auxiliary-functions>
 [/site]
     CAN Bus Setup <common-canbus-setup-advanced>

--- a/plane/source/docs/advanced-failsafe-configuration.rst
+++ b/plane/source/docs/advanced-failsafe-configuration.rst
@@ -56,13 +56,10 @@ should use the standard failsafe options.
 Enabling the AFS failsafe system
 --------------------------------
 
-To enable the AFS failsafe system you need to set the AFS_ENABLE
-parameter to 1. The default is zero, which means all the other options
-are disabled.
+To enable the AFS failsafe system you need to set the :ref:`AFS_ENABLE<AFS_ENABLE>` parameter to 1. The default is zero, which means all the other options are disabled.
 
 Note that the AFS system is only built into Plane by default on higher
-end autopilot boards like the PX4 and Pixhawk. On the APM2 you must
-recompile the firmware yourself to use the AFS system.
+end autopilot boards like the PX4 and Pixhawk.
 
 AFS Termination
 ---------------
@@ -70,23 +67,23 @@ AFS Termination
 The concept of "flight termination" is key to understanding the AFS
 failsafe system. Termination is where the aircraft deliberately dives
 into the ground by setting all control surfaces to maximum and throttle
-to zero so as to enter a spin.
+is disarmed so as to enter a spin, or in the case of QuadPlane, there is also the option to immediately QLAND instead.
 
-The AFS system will only start a termination if the AFS_TERM_ACTION is
-set to the magic value 42. For any other value the AFS system will print
+The AFS system will only start a termination if the :ref:`AFS_TERM_ACTION<AFS_TERM_ACTION>` is
+set to the magic value 42 or 43. For any other value the AFS system will print
 a message on the GCS console saying that it wants to terminate, but
 won't actually change the control surfaces at all. Using a value other
-than 42 is useful for test flights where you don't want the aircraft to
-terminate on a failsafe event.
+than 42 or 43 is useful for test flights where you don't want the aircraft to
+terminate on a failsafe event. A value of 42 immediately crashed the plane, while, if a QuadPlane, a value of 43 will immediately execute a QLAND.
 
-Note that if AFS_TERM_ACTION is not set to 42 then other normal
+Note that if :ref:`AFS_TERM_ACTION<AFS_TERM_ACTION>` is not set to 42 then other normal
 failsafe code is still active, for example if you have a geofence
 enabled then the aircraft will fly back to the geofence return point.
 
 When enabled, the AFS termination system also sets up the secondary IO
-microcontroller on the Pixhawk autopilot to terminate the aircraft if
-communication is interrupted between the main FMU microcontroller and
-the IO microcontroller, for example if the flight firmware crashes.
+micro-controller on the Pixhawk autopilot to terminate the aircraft if
+communication is interrupted between the main FMU micro-controller and
+the IO micro-controller, for example if the flight firmware crashes.
 
 An AFS flight termination is not recoverable. Once your aircraft starts
 a termination, there is no way to recover.
@@ -114,6 +111,8 @@ will monitor the aircraft for a breach of the boundaries of the geofence
 then the AFS system will immediately terminate the flight (see
 termination above).
 
+In addition, if the total straight-line distance from arming point exceeds the :ref:`AFS_MAX_RANGE<AFS_MAX_RANGE>` distance, then termination will occur.
+
 Maximum pressure altitude breach
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -128,30 +127,30 @@ that QNH pressure, which gives them an altitude reference which all
 aircraft in the area should be using.
 
 The AFS system is able to enforce a pressure altitude limit
-by setting the QNH pressure in the AFS_QNH_PRESSURE parameter, as a
+by setting the QNH pressure in the :ref:`AFS_QNH_PRESSURE<AFS_QNH_PRESSURE>` parameter, as a
 value in millibars. The pilot should then also set a pressure altitude
-limit using the AFS_AMSL_LIMIT parameter (in meters). Note that this
+limit using the :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>` parameter (in meters). Note that this
 pressure altitude limit is relative to sea level (AMSL stands for "above
 mean sea level").
 
 If both of these parameters are set then the AFS system fill monitor
 pressure altitude and will initiate a termination if the pressure
-altitude rises above the AFS_AMSL_LIMIT.
+altitude rises above the :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>`.
 
-You need to be very careful to set the right AFS_QNH_PRESSURE for your
+You need to be very careful to set the right :ref:`AFS_QNH_PRESSURE<AFS_QNH_PRESSURE>` for your
 local conditions on the day of your flight, as the QNH pressure can be
 very different on different days.
 
 In addition to the QNH pressure limit, the AFS system also monitors the
 health of your barometer. If the barometer is unhealthy for 5 seconds
-then the AFS system will check the AFS_AMSL_ERR_GPS parameter. If it
+then the AFS system will check the :ref:`AFS_AMSL_ERR_GPS<AFS_AMSL_ERR_GPS>` parameter. If it
 is -1 (the default) then the aircraft will terminate immediately. If it
-is not -1 then the AFS system will use the AFS_AMSL_ERR_GPS value as
+is not -1 then the AFS system will use the :ref:`AFS_AMSL_ERR_GPS<AFS_AMSL_ERR_GPS>` value as
 a margin to add to the GPS height, and will allow the flight to continue
-if the GPS altitude plus the AFS_AMSL_ERR_GPS value (in meters) is
-below the AFS_AMSL_LIMIT value. The purpose of this margin is to
+if the GPS altitude plus the :ref:`AFS_AMSL_ERR_GPS<AFS_AMSL_ERR_GPS>` value (in meters) is
+below the :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>` value. The purpose of this margin is to
 account for the inaccuracy of GPS altitudes. A value of 200 is
-reasonable for safety to ensure the AFS_AMSL_LIMIT pressure altitude
+reasonable for safety to ensure the :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>` pressure altitude
 is not breached.
 
 GPS Loss
@@ -162,15 +161,14 @@ flight. If all of your available GPS receivers lose position lock then
 this initiates a GPS failure failsafe.
 
 When a GPS failure occurs (which is defined as loss of GPS lock for 3
-seconds) the AFS system will look at the AFS_WP_GPS_LOSS parameter.
+seconds) the AFS system will look at the :ref:`AFS_GPS_LOSS<AFS_GPS_LOSS>` parameter.
 This parameter species a waypoint number in your mission to use when a
-GPS failure occurs. If AFS_WP_GPS_LOSS is non-zero the aircraft will
-change current waypoint to the waypoint number specified in
-AFS_WP_GPS_LOSS. You should setup your mission so that the aircraft
+GPS failure occurs. If :ref:`AFS_GPS_LOSS<AFS_GPS_LOSS>` is non-zero the aircraft will
+change current waypoint to the waypoint number specified in :ref:`AFS_GPS_LOSS<AFS_GPS_LOSS>` . You should setup your mission so that the aircraft
 will perform whatever actions you want on GPS loss. For example, you
 could have a set of waypoints starting at number 10 which first loiter
 on the spot for 30 seconds, and then proceed back to the airfield. You
-would then set AFS_WP_GPS_LOSS to 10 to enable that part of the
+would then set ::ref:`AFS_GPS_LOSS<AFS_GPS_LOSS>` to 10 to enable that part of the
 mission on loss of GPS lock.
 
 When setting up mission items for GPS lock it is sometimes useful to
@@ -181,15 +179,15 @@ zero.
 If the GPS recovers after a GPS failsafe has started, then the aircraft
 will automatically resume its mission where it left off.
 
-If during a period of GPS loss the aircraft also loses communications
-with the ground station then this is termed a "dual loss", and the
-aircraft will terminate.
-
-If AFS_MAX_GPS_LOSS is set to a non-zero number, then it is used as a
+If :ref:`AFS_MAX_GPS_LOSS<AFS_MAX_GPS_LOSS>` is set to a non-zero number, then it is used as a
 maximum count of the number of GPS failures that will be allowed while
 returning to the mission after GPS lock is re-established. This counter
 is only incremented if the 2nd GPS failure happens at least 30 seconds
 after the previous one (to account for a short period of GPS failure).
+
+If during a period of GPS loss the aircraft also loses communications
+with the ground station then this is termed a "dual loss", and the
+aircraft will terminate if :ref:`AFS_DUAL_LOSS<AFS_DUAL_LOSS>` is 1.
 
 Ground station communications loss
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -200,8 +198,8 @@ messages coming from the ground station.
 
 If the aircraft does not receive a HEARTBEAT message for a period of 10
 seconds then it enters a GCS failsafe state. It then looks for a
-AFS_WP_COMMS parameter, and if that is non-zero it will change the
-current target waypoint to the one given in AFS_WP_COMMS. You should
+:ref:`AFS_WP_COMMS<AFS_WP_COMMS>` parameter, and if that is non-zero it will change the
+current target waypoint to the one given in :ref:`AFS_WP_COMMS<AFS_WP_COMMS>`. You should
 set up a section of your mission with whatever actions you want to take
 on loss of communications.
 
@@ -215,20 +213,24 @@ ground station can see messages from the aircraft. So it is quite
 possible for your ground station to be reporting loss of communication
 while the aircraft is still receiving HEARTBEAT messages.
 
-If AFS_MAX_COM_LOSS is set to a non-zero number, then it is used as a
+If :ref:`AFS_MAX_COM_LOSS<AFS_MAX_COM_LOSS>` is set to a non-zero number, then it is used as a
 maximum count of the number of communication failures that will be
 allowed while returning to the mission after communications is
-re-established. This counter is only incremented if the 2nd comms
+re-established. This counter is only incremented if the 2nd communication
 failure happens at least 30 seconds after the previous one (to account
 for a short period of communications failure).
+
+If during a period of GPS loss the aircraft also loses communications
+with the ground station then this is termed a "dual loss", and the
+aircraft will terminate if :ref:`AFS_DUAL_LOSS<AFS_DUAL_LOSS>` is 1.
 
 RC Loss
 ~~~~~~~
 
-If RC control is lost in a manual control mode for more than
-AFS_RC_FAIL_MS milliseconds, flight termination is activated.
-This termination mode is only enabled if AFS_RC_FAIL_MS is non-zero.
+If RC control is lost in for more than :ref:`AFS_RC_FAIL_TIME<AFS_RC_FAIL_TIME>` milliseconds, flight termination is activated. This termination mode is only enabled if :ref:`AFS_RC_FAIL_TIME<AFS_RC_FAIL_TIME>` is non-zero and :ref:`AFS_ENABLE<AFS_ENABLE>` is 1.
 For the OBC rules it should be set to 1500 (giving 1.5 seconds).
+
+If :ref:`AFS_RC_MAN_ONLY<AFS_RC_MAN_ONLY>` is set to 1 then this will only occur if in a manual mode. Otherwise, it will occur in any flight mode.
 
 Monitoring the AFS system
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -239,14 +241,14 @@ monitor the health of the failsafe system using external electronics
 
 The key parameters are:
 
--  **AFS_TERM_PIN**: This is a digital pin which is set to a high
+-  :ref:`AFS_TERM_PIN<AFS_TERM_PIN>` : This is a digital pin which is set to a high
    voltage if termination is started. Note that this pin will go high on
-   termination even if the AFS_TERM_ACTION parameter is not set to 42.
--  **AFS_HB_PIN**: This is a digital pin number for a pin which is
+   termination even if the :ref:`AFS_TERM_ACTION<AFS_TERM_ACTION>` parameter is not set to 42.
+-  :ref:`AFS_HB_PIN<AFS_HB_PIN>` : This is a digital pin number for a pin which is
    toggled at a rate of 10Hz by the failsafe system. If termination
-   occurs and a AFS_TERM_PIN value is not set then the heartbeat pin
+   occurs and a :ref:`AFS_TERM_PIN<AFS_TERM_PIN>` value is not set then the heartbeat pin
    will stop toggling.
--  **AFS_MAN_PIN**: This is a digital pin number for a pin which goes
+-  :ref:`AFS_MAN_PIN<AFS_MAN_PIN>` : This is a digital pin number for a pin which goes
    high when the aircraft is in MANUAL mode. It may be useful with some
    external failsafe boards to detect manual mode and behave
    differently.
@@ -254,10 +256,10 @@ The key parameters are:
 Manual Termination
 ------------------
 
-Apart from automatic termination it is also important for the aircrafts
+Apart from automatic termination it is also important for the aircraft's
 operator to be able to terminate the aircraft immediately if they think
 the aircraft is a danger to people or other aircraft. To force an
-immediate termination you should use the AFS_TERMINATION parameter. By
+immediate termination you should use the :ref:`AFS_TERMINATE<AFS_TERMINATE>` parameter. By
 setting that parameter to 1 the aircraft will immediately terminate.
 
 Example AFS failsafe mission
@@ -292,14 +294,14 @@ The key parameters for failsafe testing in SITL are:
 -  Test RC failure: param set SIM_RC_FAIL 1
 -  Test comms failure: set heartbeat 0
 -  Test fence failure: switch to CRUISE mode and fly across boundary
--  Test QNH failure: param set AFS_AMSL_LIMIT 100
+-  Test QNH failure: param set :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>` = 100
 
 Additional tips for AFS failsafe users
 --------------------------------------
 
 You need to ensure that your geofence is enabled before takeoff. This
 can either be done as part of your preflight checklist, or you could set
-a FENCE_CHANNEL and enable it from within your transmitter.  This ensures
+a :ref:`FENCE_CHANNEL<FENCE_CHANNEL>` and enable it from within your transmitter.  This ensures
 that if your transmitter is out of range that the fence remains enabled.
 
 Settings for Outback Challenge 2014
@@ -308,14 +310,14 @@ Settings for Outback Challenge 2014
 To be compliant with the OBC 2014 rules you should have the following
 settings:
 
--  AFS_ENABLE: 1
--  AFS_WP_COMMS: waypoint number for OBC comms hold followed by two
+-  :ref:`AFS_ENABLE<AFS_ENABLE>` : 1
+-  :ref:`AFS_WP_COMMS<AFS_WP_COMMS>` : waypoint number for OBC comms hold followed by two
    minute loiter, then return to airfield home
--  AFS_WP_GPS_LOSS: waypoint number to loiter in place for 30
+-  :ref:`AFS_GPS_LOSS<AFS_GPS_LOSS>` : waypoint number to loiter in place for 30
    seconds, followed by return to airfield home
--  AFS_TERM_ACTION: 42
--  AFS_AMSL_LIMIT: 914
--  AFS_QNH_PRESSURE: correct QNH pressure for the day
--  AFS_RC_FAIL_MS: 1500
--  AFS_MAX_GPS_LOSS: 2
--  AFS_MAX_COM_LOSS: 2
+-  :ref:`AFS_TERM_ACTION<AFS_TERM_ACTION>` : 42
+-  :ref:`AFS_AMSL_LIMIT<AFS_AMSL_LIMIT>` : 914
+-  :ref:`AFS_QNH_PRESSURE<AFS_QNH_PRESSURE>` : correct QNH pressure for the day
+-  :ref:`AFS_RC_FAIL_TIME<AFS_RC_FAIL_TIME>` : 1500
+-  :ref:`AFS_MAX_GPS_LOSS<AFS_MAX_GPS_LOSS>` : 2
+-  :ref:`AFS_MAX_COM_LOSS<AFS_MAX_COM_LOSS>` : 2


### PR DESCRIPTION
for Plane 4.0...
added AFS_MAX_RANGE
fixed wrong param names
added hotlinks to params
added AFS_TERM_ACTION 43 for Quadplane


SHOULD THIS BE COMMON TO ROVER AND COPTER ALSO???