### PR TITLE
Expand tailsitter info in qplane frame and tailsitter docs

### DIFF
--- a/plane/source/docs/guide-tailsitter.rst
+++ b/plane/source/docs/guide-tailsitter.rst
@@ -89,7 +89,7 @@ Vectored Thrust
 
 If your tailsitter has vectored thrust then you should set the
 SERVOn_FUNCTION values for your two tilt servos for the left and right
-motors.
+motors and for the left and right motor throttles.
 
 For example, if your left tilt servo is channel 5 and your right tilt
 servo is channel 6, then set:
@@ -97,8 +97,13 @@ servo is channel 6, then set:
 - :ref:`SERVO5_FUNCTION<SERVO5_FUNCTION>` =75
 - :ref:`SERVO6_FUNCTION<SERVO6_FUNCTION>` =76
 
+and you need to assign left throttle to the left motor and right throttle to the right motor, for example using the SERVO 7 and SERVO 8 outputs, for left and right motor escs, respectively:
+
+- :ref:`SERVO7_FUNCTION<SERVO7_FUNCTION>` =73
+- :ref:`SERVO8_FUNCTION<SERVO8_FUNCTION>` =74
+
 you also need to set the right SERVOn_REVERSED values, and the right
-SERVOn_TRIM, SERVOn_MIN and SERVOn_MAX values.
+SERVOn_TRIM, SERVOn_MIN and SERVOn_MAX values, as appropriate.
 
 :ref:`Q_A_ANGLE_BOOST<Q_A_ANGLE_BOOST>` should be disabled for vectored thrust tailsitters. Failure to disable this will cause the throttle to decrease as the nose dips, making the nose dip even further and resulting in a crash. 
 

--- a/plane/source/docs/quadplane-frame-setup.rst
+++ b/plane/source/docs/quadplane-frame-setup.rst
@@ -9,6 +9,8 @@ hexacopter, octacopter and octaquad multicopter frames.
 The motor order and output channel is the same as for copter (see :ref:`Copter motor layout <copter:connect-escs-and-motors>`)
 except that the default output channel numbers start at 5 instead of 1.
 
+.. note:: :ref:`guide-tailsitter` configuration is a special case. See Tailsitter notes below
+
 For example, with the default Quad-X frame the motors are on outputs
 5 to 8. The arrangement is:
 
@@ -43,8 +45,8 @@ you like, just as with the normal Plane code.
 You can optionally move the quad motors to be on any other channel above
 4, using the procedure outlined below.
 
-To use a different frame type you can set Q_FRAME_CLASS and
-Q_FRAME_TYPE. Q_FRAME_CLASS can be:
+To use a different frame type you can set :ref:`Q_FRAME_CLASS<Q_FRAME_CLASS>` and
+:ref:`Q_FRAME_TYPE<Q_FRAME_TYPE>` . :ref:`Q_FRAME_CLASS<Q_FRAME_CLASS>` can be:
 
 -  1 for quad
 -  2 for hexa
@@ -54,7 +56,7 @@ Q_FRAME_TYPE. Q_FRAME_CLASS can be:
 -  7 for Tri
 -  10 for Tailsitter
 
-Within each of these frame classes the Q_FRAME_TYPE chooses the motor
+Within each of these frame classes the :ref:`Q_FRAME_TYPE<Q_FRAME_TYPE>` chooses the motor
 layout
 
 -  0 for plus frame
@@ -63,6 +65,12 @@ layout
 -  3 for H frame
 -  11 for FireFly6Y6 (for Y6 only)
 
+Tailsitter
+----------
+
+Tailsitters (:ref:`Q_FRAME_CLASS<Q_FRAME_CLASS>` =10) are a special case. Since this can be used on a conventional single motor plane for "3D" style flying, the standard single motor configuration with the Throttle (motor) output on SERVO3 is automatically configured. If you are using twin engines, then you may want to manually configure two outputs for Throttle Left and Throttle Right, instead of Throttle, if you want differential thrust. If you are using a twin, vectored thrust tailsitter, then you will need to manually configure four outputs for Throttle Left, Throttle Right, Left Motor Tilt and Right Motor Tilt. See :ref:`Tailsitter <guide-tailsitter>` section for more information
+
+
 Using different channel mappings
 --------------------------------
 
@@ -70,9 +78,8 @@ You can remap what output channels the quad motors are on by setting
 values for SERVOn_FUNCTION. This follows the same approach as :ref:`other output functions <channel-output-functions>`.
 
 .. note::
-
    Note that you do not need to set any of the SERVOn_FUNCTION values unless
-   you have a non-standard motor ordering. It is highly recommended that
+   you have a non-standard motor ordering, using vectored thrust, or are a Tailsitter. It is highly recommended that
    you use the standard ordering and do not set the SERVOn_FUNCTION
    parameters, leaving them at zero. They will be automatically set to
    the right values for your frame on boot.
@@ -91,8 +98,8 @@ The output function numbers are:
 So to put your quad motors on outputs 9 to 12 (the auxillary channels on
 a Pixhawk) you would use these settings in the advanced parameter list:
 
--  SERVO9_FUNCTION = 33
--  SERVO10_FUNCTION = 34
--  SERVO11_FUNCTION = 35
--  SERVO12_FUNCTION = 36
+-  :ref:`SERVO9_FUNCTION<SERVO9_FUNCTION>` = 33
+-  :ref:`SERVO10_FUNCTION<SERVO10_FUNCTION>` = 34
+-  :ref:`SERVO11_FUNCTION<SERVO11_FUNCTION>` = 35
+-  :ref:`SERVO12_FUNCTION<SERVO12_FUNCTION>` = 36
 


### PR DESCRIPTION
info on default outputs and how to setup motors in vectored tailsitter