### PR TITLE
Adding last updated date on all pages

### DIFF
--- a/insert_last_updated_date.sh
+++ b/insert_last_updated_date.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+#===========================================================================================
+#	Automatically add last modified date to .RST files according 
+#	to last commit date of each file.
+#
+#   Caution: do use while updating the Wiki in the server because it alters ALL .RST files.
+#
+#	Run: ./insert_last_updated_date.sh N (where N is the number is the parallel tasks
+#
+#===========================================================================================
+
+# Parallel runs in N-process batches. Default of $1 is 2 
+PARALLEL=${1:-2}
+
+# Insert last updated date from last commit date of each file
+update_file(){
+
+	commit_date=`git log -n 1 --date=short --pretty=format:%cd -- $1`
+
+	if [ "$commit_date" != "" ]
+	then
+		echo "Inserting $commit_date as last updated tag on $f"
+		echo "" >> $1
+		echo "" >> $1
+		echo '*Page last edited on ' "$commit_date"'*' >> $1		
+	else
+		echo "Git last commit date not found for $1"
+	fi
+	
+}
+
+# Runs for each file at PARALLEL at time 
+for f in `find . -iname "*.rst"`; do
+
+   ((i=i%PARALLEL)); ((i++==0)) && wait
+   update_file $f & 
+		
+done
+
+echo 'Finished to insert last edited date.'
+
+exit 0
+

--- a/update.sh
+++ b/update.sh
@@ -83,6 +83,7 @@ git fetch origin
 git submodule update
 git reset --hard origin/master
 git clean -f -f -x -d -d
+./insert_last_updated_date.sh 4
 popd
 
 echo "Updating sphinx_rtd_theme"


### PR DESCRIPTION
It automatically inserts the last date when such a page was edited on the bottom of each page. Two sites as examples: 

[http://www.olivieri.com.br/ardupilot/wiki_last_update_test/dev ](http://www.olivieri.com.br/ardupilot/wiki_last_update_test/dev )[http://www.olivieri.com.br/ardupilot/wiki_last_update_test/copter/](http://www.olivieri.com.br/ardupilot/wiki_last_update_test/copter/)

To respect the actual last edit date, I understand that we cannot update it on the .rst files and commit them because it would update such a time to such a commit date. 

Some thoughts:

1) It is not beautiful, but works. Could be more beautiful if insert it in the bottom of the .html file instead of the bottom of the .rst file. But:

- It might not get the necessary attention;
- I do not know how to do that yet. Would it be possible to insert the date in a variable inside the .rst file and use it in the sphinx theme?

2) I am not sure if the update.sh is the actual script that updates the Wiki in the server but looks like that it is something called by as a cron job.

3) It is yet another external small fix and not an architectural solution regarding versioning. However, it works with a minimal footprint, and it is effortless to remove or revert.
