### PR TITLE
Remove param file argument for AirSim launch

### DIFF
--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -157,7 +157,7 @@ First launch AirSim, after that launch the ArduPilot SITL using
 
 ::
 
-    sim_vehicle.py -v ArduCopter -f airsim-copter --add-param-file=libraries/SITL/examples/Airsim/quadX.parm --console --map
+    sim_vehicle.py -v ArduCopter -f airsim-copter --console --map
 
 .. note::
 


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot/pull/13060 has been merged which moves the parameters to the `default_params` folder and can be found by `sim_vehicle.py`