### PR TITLE
Gazebo sitl update

### DIFF
--- a/dev/source/docs/using-gazebo-simulator-with-sitl.rst
+++ b/dev/source/docs/using-gazebo-simulator-with-sitl.rst
@@ -11,7 +11,8 @@ Overview
 ========
 
 Gazebo is a well-known and respected robotics simulator, and is also the official DARPA Virtual Robotics Simulator.
-No current release has built-in support for ArduPilot,  however. (Previous PRs for built-in support were not merged as of April-2017).
+Built-in support for ArduPilot is available starting with gazebo8.
+If you are using gazebo8 or above, you should skip the following Plugin installation section.
 
 .. warning::
 
@@ -85,7 +86,13 @@ In a terminal window start Gazebo:
 
 ::
 
-    gazebo --verbose worlds/iris_arducopter_runway.world
+    gazebo --verbose worlds/iris_arducopter_demo.world
+
+.. warning::
+   If you are using the manually installed plugin, the command will be
+   ::
+   
+      gazebo --verbose worlds/iris_arducopter_runway.world
 
 
 In another terminal window, enter the ArduCopter directory and start the SITL simulation:

--- a/dev/source/docs/using-gazebo-simulator-with-sitl.rst
+++ b/dev/source/docs/using-gazebo-simulator-with-sitl.rst
@@ -58,6 +58,7 @@ It should open an empty world.
 Plugin Installation
 ===================
 
+This section can be skipped if you are using gazebo8 or above, however these plugins can be used instead of the built-in plugin.
 The following plugin is a pure Gazebo plugin, so ROS is not needed to use it. You can still use ROS with Gazebo with normal gazebo-ros packages.
 We have  two version of the plugin : khancyr and SwiftGust one's.
 The one from `khancyr <https://github.com/khancyr/ardupilot_gazebo>`__ is the original one. It is stable and only has necessary file to work.

--- a/dev/source/docs/using-gazebo-simulator-with-sitl.rst
+++ b/dev/source/docs/using-gazebo-simulator-with-sitl.rst
@@ -12,7 +12,7 @@ Overview
 
 Gazebo is a well-known and respected robotics simulator, and is also the official DARPA Virtual Robotics Simulator.
 Built-in support for ArduPilot is available starting with gazebo8.
-If you are using gazebo8 or above, you should skip the following Plugin installation section.
+If you are using gazebo8 or above, you should skip the following Plugin Installation section.
 
 .. warning::
 
@@ -55,7 +55,7 @@ The first time gazebo is executed requires the download of some models and it co
 
 It should open an empty world.
 
-Plugin installation
+Plugin Installation
 ===================
 
 The following plugin is a pure Gazebo plugin, so ROS is not needed to use it. You can still use ROS with Gazebo with normal gazebo-ros packages.


### PR DESCRIPTION
Removed claims that there is no built-in gazebo support for ardupilot. I have tested out the plugin for gazebo9 however the plugin seemed to be added in gazebo8 according to the source repository. I left the plugin installation instructions and considered moving them to the bottom but decided to leave them where they were and added a note that it could be skipped so it wouldn't throw off the flow since I am unsure which version is standard for Ubuntu 16.04.