### PR TITLE
Makes parameters versioning the default

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -101,8 +101,8 @@ cd ardupilot_wiki && python3 build_parameters.py
 
 echo "[Buildlog] Starting do build the wiki at $(date '+%Y-%m-%d-%H-%M-%S')"
 
-python update.py --clean --parallel 4 # Single parameters file style, as in use for a long time and should be used for most of users/wiki editors.
+# python update.py --clean --parallel 4 # Single parameters file style, as in use for a long time and should be used for most of users/wiki editors.
 
-# python update.py --clean --paramversioning # Enables parameters versioning, should be used only on the wiki server
+python update.py --clean --paramversioning # Enables parameters versioning, should be used only on the wiki server
 
 ) >> update.log 2>&1


### PR DESCRIPTION
The Wiki's server always rewrites its own update.sh with the git repo, so it is necessary to update it here.

General users should not be affected if they use update.py as indicated on the Wiki.