### PR TITLE
Fixes on versioning for parameters

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -75,14 +75,14 @@ vehicle_old_to_new_name = { # Used because git-version.txt use APMVersion with o
 def debug(str_to_print):
     """Debug output if verbose is set."""
     if args.verbose:
-        print(str_to_print)
+        print("[build_parameters.py] " + str_to_print)
 
 
 def error(str_to_print):
     """Show and count the errors."""
     global error_count
     error_count += 1
-    print("error: " + str_to_print)
+    print("[build_parameters.py][error]: " + str_to_print)
 
 
 def check_temp_folders():

--- a/update.sh
+++ b/update.sh
@@ -101,8 +101,8 @@ cd ardupilot_wiki && python3 build_parameters.py
 
 echo "[Buildlog] Starting do build the wiki at $(date '+%Y-%m-%d-%H-%M-%S')"
 
-# python update.py --clean --parallel 4 # Single parameters file style, as in use for a long time and should be used for most of users/wiki editors.
+# python update.py --clean --parallel 4 # Build without versioning for parameters
 
-python update.py --clean --paramversioning # Enables parameters versioning, should be used only on the wiki server
+python update.py --clean --paramversioning --parallel 2 # Enables parameters versioning, should be used only on the wiki server
 
 ) >> update.log 2>&1


### PR DESCRIPTION
List of not critial changes:

- Forces parameters.html redirection to the latest version does not matter the build time;
- Changes some debug messages;
- Makes error msgs the same way and readable accross parallel running;
- Makes debug msgs the same way and readable accross parallel running;
