### PR TITLE
Dev: Add note about Cygwin not wanting to do ARM builds

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -11,6 +11,11 @@ These setup instructions describe how to setup `Cygwin <http://www.cygwin.com/>`
 
       There is a pre-built script at `/ardupilot/Tools/environment_install/install-prereqs-windows.ps1 <https://github.com/ArduPilot/ardupilot/tree/master/Tools/environment_install/install-prereqs-windows.ps1>`__ that will automatically perform all of the below steps.
 
+.. note::
+
+      There have been user reports that recent (> Jan 2019) versions of Cygwin are not able to compile the ARM-based builds. It is recommended that Windows users instead use :ref:`WSL <building-setup-windows10>` for compiling ARM-based builds.
+
+
 Install Cygwin
 --------------
 


### PR DESCRIPTION
Based on recent comments in the Ardupilot Gitter chat, multiple people have reported issues building the ARM-based (ie using gcc-arm) builds under Cygwin.

Adding in this small message to suggest people use WSL instead (which does work), as will cut down on the number of "why is Cygwin not working" posts in the Gitter chat.