### PR TITLE
fix wiki build errors due to retired params

### DIFF
--- a/common/source/docs/common-flir-vue-pro.rst
+++ b/common/source/docs/common-flir-vue-pro.rst
@@ -38,7 +38,7 @@ To allow triggering the taking of pictures during a mission or from a transmitte
 
 - :ref:`SERVO9_FUNCTION <SERVO9_FUNCTION>` = 10 (Camera Trigger)
 - :ref:`CAM_SERVO_ON <CAM_SERVO_ON>` = 1900
-- :ref:`CH8_OPT <CH8_OPT>` or :ref:`RC8_OPTION <RC8_OPTION>` = 9 (Camera Trigger) to enable triggering from transmitter switch 8
+- `CH8_OPT`` or :ref:`RC8_OPTION <RC8_OPTION>` = 9 (Camera Trigger) to enable triggering from transmitter switch 8
 
 Configure the Phone
 -------------------

--- a/common/source/docs/common-gripper-servo.rst
+++ b/common/source/docs/common-gripper-servo.rst
@@ -36,11 +36,13 @@ Configuration
 Controlling Gripper from the transmitter
 ========================================
 
-The transmitter's auxiliary switch can control the gripper.  If using the mission planner, select Config/Tuning > Extended Tuning and set the Ch7 Opt or Ch8 Opt drop-down to "EPM" or "Gripper".
+The transmitter's auxiliary switch can control the gripper.
+
+If using a firmware version prior to 4.0. CH7_OPT or CH8_OPT can be used to control the gripper by setting it to 19. If using the mission planner, select Config/Tuning > Extended Tuning and set the Ch7 Opt or Ch8 Opt drop-down to "EPM" or "Gripper".
 
 .. image:: ../../../images/gripper_servo_auxswitch.png
 
-- or directly set :ref:`CH7_OPT <CH7_OPT>` or :ref:`CH8_OPT <CH8_OPT>` to 19
+- In firmware versions 4.0 later, use an RC channel for control by setting is ``RCx_OPTION`` parameter to 19.
 
 Controlling Gripper during a mission
 ====================================

--- a/copter/source/docs/autotune.rst
+++ b/copter/source/docs/autotune.rst
@@ -22,7 +22,7 @@ Setup before flying
 #. Remove the camera gimbal or any other parts of the frame that could wobble in flight
 #. Select which combination of axis (roll, pitch, yaw) you wish to tune using the :ref:`AUTOTUNE_AXES <AUTOTUNE_AXES>` parameter
 #. Set the autotune's aggressiveness using the :ref:`AUTOTUNE_AGGR <AUTOTUNE_AGGR>` parameter (0.1=agressive, 0.075=medium, 0.050=weak), normally start with the default 0.1.
-#. For large copters (with props at least 13inch or 33cm diameter) set the Rate Roll and Pitch filters to 10hz, these are: :ref:`ATC_RAT_RLL_FLTT <ATC_RAT_RLL_FLT__AC_AttitudeControl_MultiT>` , :ref:`ATC_RAT_RLL_FLTD<ATC_RAT_RLL_FLTD__AC_AttitudeControl_Multi>` , :ref:`ATC_RAT_PIT_FLTT <ATC_RAT_PIT_FLTT__AC_AttitudeControl_Multi>` , :ref:`ATC_RAT_PIT_FLTD <ATC_RAT_PIT_FLTD__AC_AttitudeControl_Multi>` , (in Copter-3.4 they are ATC_RAT_RLL_FILT and ATC_RAT_PIT_FILT) 
+#. For large copters (with props at least 13inch or 33cm diameter) set the Rate Roll and Pitch filters to 10hz, these are: :ref:`ATC_RAT_RLL_FLTT <ATC_RAT_RLL_FLTT__AC_AttitudeControl_Multi>` , :ref:`ATC_RAT_RLL_FLTD<ATC_RAT_RLL_FLTD__AC_AttitudeControl_Multi>` , :ref:`ATC_RAT_PIT_FLTT <ATC_RAT_PIT_FLTT__AC_AttitudeControl_Multi>` , :ref:`ATC_RAT_PIT_FLTD <ATC_RAT_PIT_FLTD__AC_AttitudeControl_Multi>` , (in Copter-3.4 they are ATC_RAT_RLL_FILT and ATC_RAT_PIT_FILT) 
 #. It is recommended to enable :ref:`battery voltage scaling of PID gains <current-limiting-and-voltage-scaling>`
 
 How to invoke AutoTune

--- a/copter/source/docs/heliquads.rst
+++ b/copter/source/docs/heliquads.rst
@@ -36,7 +36,7 @@ For other builds these are the standard params that should be set:
 - :ref:`FRAME_CLASS <FRAME_CLASS>` to 13 (HeliQuad)
 - :ref:`FRAME_TYPE <FRAME_CLASS>` to 1 ("X" if front right motors spins counter clockwise) or 3 ("H" if front right motor spins clockwise)
 
-Similar to a :ref:`traditional helicopter <traditional-helicopters>` an :ref:`auxiliary switch <channel-7-and-8-options>` should be set to "Motor Interlock" to turn on/off the motor.  Normally this is channel 8 so you could set :ref:`CH8_OPT <CH8_OPT>` to 32.
+Similar to a :ref:`traditional helicopter <traditional-helicopters>` an :ref:`auxiliary switch <common-auxiliary-functions>` should be set to "Motor Interlock" to turn on/off the motor.  Normally this is channel 8 so you could set :ref:`RC8_OPTION<RC8_OPTION>` to 32.
 
 Videos
 ======


### PR DESCRIPTION
@rmackay9 haven't the foggiest idea why these did not appear until today's build check....a build of master an hour ago did not produce them....maybe something to do with the new parameter versioning building process?