### PR TITLE
Fix toctree for parameters in versioning build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,10 +36,14 @@
 /plane/source/docs/parameters-Plane-*.rst
 /rover/source/docs/parameters-Rover-*.rst
 /antennatracker/source/docs/parameters-AntennaTracker-*.rst
-/copter/source/_static/parameters-*.json
-/plane/source/_static/parameters-*.json
-/rover/source/_static/parameters-*.json
-/antennatracker/source/_static/parameters-*.json
+/copter/source/docs/parameters-latest.rst
+/plane/source/docs/parameters-latest.rst
+/rover/source/docs/parameters-latest.rst
+/antennatracker/source/docs/parameters-latest.rst
+/copter/source/_static/parameters-Copter.json
+/plane/source/_static/parameters-Plane.json
+/rover/source/_static/parameters-Rover.json
+/antennatracker/source/_static/parameters-Antennatracker.json
 
 
 # Parameters files


### PR DESCRIPTION
Fixes the left toctree for the latest parameters page.  (Only and just only for the latest firmware version, the previous stable versions are not supposed to appear)

Obs.: it includes minimal enhances to debug better and present comparations of os.stat() and hash comparations for the cache.