### PR TITLE
Mission Planner

### DIFF
--- a/dev/source/docs/building-mission-planner.rst
+++ b/dev/source/docs/building-mission-planner.rst
@@ -1,4 +1,4 @@
-.. _buildin-mission-planner:
+.. _building-mission-planner:
 
 ===========================================
 Building Mission Planner with Visual Studio

--- a/dev/source/docs/building-mission-planner.rst
+++ b/dev/source/docs/building-mission-planner.rst
@@ -4,6 +4,10 @@
 Building Mission Planner with Visual Studio
 ===========================================
 
+.. warning::
+
+    This page is outdated and instructions should be adapted to make it work.
+
 Introduction
 ============
 

--- a/dev/source/docs/building-the-code.rst
+++ b/dev/source/docs/building-the-code.rst
@@ -43,7 +43,7 @@ Windows users have 3 or 4 options for setting up the build environment. All of t
 Mission Planner
 ---------------
 
-- :ref:`Building Mission Planner with Visual Studio <buildin-mission-planner>`
+- :ref:`Building Mission Planner with Visual Studio <building-mission-planner>`
 
 
 
@@ -65,6 +65,6 @@ Links to current build pages
     Building for Bebop 2 <building-for-bebop-2>
     Building for Bebop on Linux <building-for-bebop-on-linux>
     Building for BeagleBone Black <building-for-beaglebone-black-on-linux>
-    Building Mission Planner with Visual Studio <buildin-mission-planner>
+    Building Mission Planner with Visual Studio <building-mission-planner>
     ArduPilot Pre-Built Binaries <pre-built-binaries>
 

--- a/planner/source/docs/mission-planner-building.rst
+++ b/planner/source/docs/mission-planner-building.rst
@@ -1,0 +1,8 @@
+.. _mission-planner-building:
+
+========================
+Mission Planner Building
+========================
+
+Mission Planner source code can be downloaded and compiled (built) by those with programming skills in C# and who are familiar with
+Microsoft Visual Studio - see :ref:`Building Mission Planner with Visual Studio <dev:building-mission-planner>` (Dev Wiki).

--- a/planner/source/docs/other-mission-planner-features.rst
+++ b/planner/source/docs/other-mission-planner-features.rst
@@ -43,10 +43,6 @@ the menu:
 -  Mission Planner can give you audio speech alerts for events that you
    choose, such as hitting waypoints or low battery. Just go to
    **Configuration \| Planner \| Speech \| Enable Speech**
--  Mission Planner source code can be downloaded and compiled (built) by
-   those with programming skills in C# and who are familiar with
-   Microsoft Visual Studio - see :ref:`Building Mission Planner with Visual Studio <dev:buildin-mission-planner>`
-   (Dev Wiki).
 -  Mission Planner can be scripted - see :ref:`Using Python Scripts in Mission Planner <using-python-scripts-in-mission-planner>`
    (planner wiki)
 

--- a/planner/source/index.rst
+++ b/planner/source/index.rst
@@ -39,6 +39,7 @@ Full Table of Contents
    docs/common-connect-mission-planner-autopilot
    docs/common-mission-planning
    docs/mission-planner-features
+   docs/mission-planner-building
    docs/common-appendix
    docs/common-table-of-contents
     


### PR DESCRIPTION
Rename a page.
Add explicit link to Mission Planner building instruction on MP wiki. I struggled to build MP when we get instructions ... 
Add a warning that documentation is outdated. It will need some update to work properly, but I don't master enough C# to do it 