### PR TITLE
Change python2-future to python27-future for cygwin install

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -22,7 +22,7 @@ Install Cygwin
 
 ::
 
-    setup-x86_64.exe -P autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python27,python2-future,python27-libxml2,python27-pip,libxslt-devel,python27-devel,procps-ng,zip,gdb,ddd
+    setup-x86_64.exe -P autoconf,automake,ccache,gcc-g++,git,libtool,make,gawk,libexpat-devel,libxml2-devel,python27,python27-future,python27-libxml2,python27-pip,libxslt-devel,python27-devel,procps-ng,zip,gdb,ddd
     
 Or, for a stepped install:
 
@@ -69,7 +69,7 @@ Or, for a stepped install:
    +-----------------+----------------------------------------------------------------------------------+
    | python27-devel  | Python \| python27-devel: Python2 language interpreter                           |
    +-----------------+----------------------------------------------------------------------------------+
-   | python2-future  | Python \| python2-future: Clean single-source support for Python 3 and 2         |
+   | python27-future  | Python \| python27-future: Clean single-source support for Python 3 and 2         |
    +-----------------+----------------------------------------------------------------------------------+
    | python27-libxml2| Python \| python27-libxml2: Gnome XML Library (Python bindings)                  |
    +-----------------+----------------------------------------------------------------------------------+


### PR DESCRIPTION
Required after cygwin build changes and deprecation, python future module will not be found in waf otherwise.