### PR TITLE
Dev: Update Airsim page to point to Ardupilot's fork

### DIFF
--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -62,6 +62,8 @@ Installing AirSim
 Using the precompiled environments won't work, only environments whose source code is available such as Blocks or any other environments which you download from the Unreal Marketplace will work.
 Using the precompiled environemnts will be possible once AirSim has it's next stable release.
 
+ArduPilot also maintains it's own `fork of AirSim <https://github.com/ArduPilot/AirSim>`__ for faster development and usage of new features. All fixes and additions to ArduPilot's repo are contributed to the main AirSim repository as PRs.
+
 Build on Windows
 ----------------
 
@@ -69,9 +71,26 @@ The main page for Windows setup is `here <https://github.com/microsoft/AirSim/bl
 
 #. `Install Unreal Engine <https://github.com/microsoft/AirSim/blob/master/docs/build_windows.md#install-unreal-engine>`__
 
-#. Build AirSim - Follow the `steps on AirSim Setup <https://github.com/microsoft/AirSim/blob/master/docs/build_windows.md#build-airsim>`__ for Visual Studio packages and clone AirSim.
+#. **Build AirSim**
 
-Run ``build.cmd`` from the command line. This will create ready to use plugin bits in the ``Unreal\Plugins`` folder that can be dropped into any Unreal project.
+  #. Install Visual Studio 2017. Make sure to select VC++ and Windows SDK 8.1 while installing VS 2017.
+
+  #. Start ``x64 Native Tools Command Prompt for VS 2017``
+
+  #. Clone the repo:
+
+     ::
+
+         git clone https://github.com/ArduPilot/AirSim.git
+
+  #. Change to the Airsim directory and build it-
+
+     ::
+
+         cd AirSim
+         build.cmd
+
+This will create ready to use plugin bits in the ``Unreal\Plugins`` folder that can be dropped into any Unreal project.
 
 
 Build on Linux
@@ -85,17 +104,17 @@ AirSim's page on Linux Setup is `here <https://github.com/microsoft/AirSim/blob/
 
   #. Clone the repository
 
-        ::
+     ::
 
-            git clone https://github.com/Microsoft/AirSim.git
+         git clone https://github.com/ArduPilot/AirSim.git
 
   #. Build it
 
-        ::
+     ::
 
-            cd AirSim
-            ./setup.sh
-            ./build.sh
+         cd AirSim
+         ./setup.sh
+         ./build.sh
 
 
 Setup Unreal Environemt
@@ -176,14 +195,6 @@ You can restart by just pressing the Play button and then start the ArduPilot si
 
 Launch Rover SITL
 +++++++++++++++++
-For using ArduRover with AirSim, there are a couple of extra things which need to be done. First, you'll need to use a seperate branch of AirSim until the `PR <https://github.com/microsoft/AirSim/pull/2383>`__ gets merged. Run the following commands from the AirSim directory to fetch the checkout the branch -
-
-::
-
-    git fetch https://github.com/rajat2004/AirSim.git pr-ardurover3:<local-branch-name>
-    git checkout <local-branch-name>
-
-After this, you'll have to rebuild the AirSim plugin using `build.sh` or `build.cmd` as applicable, and setup the Unreal environment as described above.
 
 ``settings.json`` for using ArduRover-
 
@@ -421,9 +432,9 @@ Using AirSim APIs
 
 `AirSim's APIs document <https://github.com/microsoft/AirSim/blob/master/docs/apis.md>`__ explains the different APIs available and their usage.
 
-Currently, ArduCopter vehicle doesn't support controlling the drone through the AirSim APIs, however any method of controlling the movement which connects directly to ArduPilot rather than using AirSim’s API work, examples include DroneKit & ROS with Mavros
+Currently, Ardupilot vehicles don't support controlling the vehicle through the AirSim APIs, however any method of controlling the movement which connects directly to ArduPilot rather than using AirSim’s API work, examples include DroneKit & ROS with Mavros
 
-The `Image APIs <https://github.com/microsoft/AirSim/blob/master/docs/image_apis.md>`__ have been tested to work with Copter, for some ready-to-run sample codes, see the files in ``PythonClient/multirotor`` such as ``opencv_show.py``.
+The `Image APIs <https://github.com/microsoft/AirSim/blob/master/docs/image_apis.md>`__ have been tested to work with Ardupilot, for some ready-to-run sample codes, see the files in ``PythonClient/multirotor`` such as ``opencv_show.py``.
 
 A ROS wrapper has also been added. See `airsim_ros_pkgs <https://github.com/microsoft/AirSim/tree/master/ros/src/airsim_ros_pkgs>`__ for the ROS API, and `airsim_tutorial_pkgs <https://github.com/microsoft/AirSim/tree/master/ros/src/airsim_tutorial_pkgs>`__ for tutorials.
 

--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -154,7 +154,6 @@ For using ArduCopter, the settings are as follows-
 
     {
       "SettingsVersion": 1.2,
-      "LocalHostIp": "127.0.0.1",
       "LogMessagesVisible": true,
       "SimMode": "Multirotor",
       "OriginGeopoint": {
@@ -166,7 +165,7 @@ For using ArduCopter, the settings are as follows-
         "Copter": {
           "VehicleType": "ArduCopter",
           "UseSerial": false,
-          "DefaultVehicleState": "Disarmed",
+          "LocalHostIp": "127.0.0.1",
           "UdpIp": "127.0.0.1",
           "UdpPort": 9003,
           "ControlPort": 9002
@@ -202,7 +201,6 @@ Launch Rover SITL
 
     {
       "SettingsVersion": 1.2,
-      "LocalHostIp": "127.0.0.1",
       "SimMode": "Car",
       "OriginGeopoint": {
         "Latitude": -35.363261,
@@ -213,7 +211,7 @@ Launch Rover SITL
         "Rover": {
           "VehicleType": "ArduRover",
           "UseSerial": false,
-          "DefaultVehicleState": "Disarmed",
+          "LocalHostIp": "127.0.0.1",
           "UdpIp": "127.0.0.1",
           "UdpPort": 9003,
           "ControlPort": 9002,
@@ -253,7 +251,6 @@ Current `settings.json` file for launching ArduCopter with Lidar
 
     {
       "SettingsVersion": 1.2,
-      "LocalHostIp": "127.0.0.1",
       "SimMode": "Multirotor",
       "OriginGeopoint": {
         "Latitude": -35.363261,
@@ -264,7 +261,7 @@ Current `settings.json` file for launching ArduCopter with Lidar
         "Copter": {
           "VehicleType": "ArduCopter",
           "UseSerial": false,
-          "DefaultVehicleState": "Disarmed",
+          "LocalHostIp": "127.0.0.1",
           "UdpIp": "127.0.0.1",
           "UdpPort": 9003,
           "ControlPort": 9002,
@@ -327,7 +324,6 @@ For simulating 2 copters, an example script has been added which will create 2 c
 
     {
       "SettingsVersion": 1.2,
-      "LocalHostIp": "127.0.0.1",
       "SimMode": "Multirotor",
       "OriginGeopoint": {
         "Latitude": -35.363261,
@@ -338,7 +334,7 @@ For simulating 2 copters, an example script has been added which will create 2 c
         "Copter1": {
           "VehicleType": "ArduCopter",
           "UseSerial": false,
-          "DefaultVehicleState": "Disarmed",
+          "LocalHostIp": "127.0.0.1",
           "UdpIp": "127.0.0.1",
           "UdpPort": 9003,
           "ControlPort": 9002
@@ -346,7 +342,7 @@ For simulating 2 copters, an example script has been added which will create 2 c
         "Copter2": {
           "VehicleType": "ArduCopter",
           "UseSerial": false,
-          "DefaultVehicleState": "Disarmed",
+          "LocalHostIp": "127.0.0.1",
           "UdpIp": "127.0.0.1",
           "UdpPort": 9013,
           "ControlPort": 9012,
@@ -446,7 +442,11 @@ A ROS wrapper has also been added. See `airsim_ros_pkgs <https://github.com/micr
 Run on different machines
 +++++++++++++++++++++++++
 
-#. Change ``UdpIp`` in the ``settings.json`` file to the IP address of the machine running ArduPilot
+#. Change the following in the ``settings.json`` file-
+
+    #. ``UdpIp`` to the IP address of the machine running ArduPilot (Can be found using ``ipconfig`` on Windows, ``ifconfig`` on Linux.)
+    #. ``LocalHostIp`` to the IP address of the current machine which is running AirSim, specific to the network adapter being used such as Ethernet or WiFi. Can be set to ``0.0.0.0`` to receive messages on all networks
+
 
 #. Use ``-A`` argument in ``sim_vehicle.py`` (passes the arguments following it to the SITL instance), followed by ``--sim-address`` to specify Airsim's IP address
 
@@ -455,6 +455,10 @@ An example-
 ::
 
     sim_vehicle.py -v ArduCopter -f airsim-copter --console --map -A --sim-address=127.0.0.1
+
+.. note::
+
+    If using Windows, you might need to disable Windows Firewall to receive messages
 
 
 Using different ports
@@ -467,7 +471,11 @@ Using different ports
 - ``--sim-port-in`` should be equal to sensor port i.e. port specified in ``UdpPort``
 - ``--sim-port-out`` should be equal to motor control port i.e. port specified in ``ControlPort``
 
-Similar to changing the IP address as mentioned above, use ``-A`` to pass the arguments to the SITL instance.
+Similar to changing the IP address as mentioned above, use ``-A`` to pass the arguments to the SITL instance. Example-
+
+::
+
+    sim_vehicle.py -v ArduCopter -f airsim-copter --console --map -A "--sim-port-in=9003 --sim-port-out=9002"
 
 Development Workflow
 ++++++++++++++++++++


### PR DESCRIPTION
As the title mentions, AP now has it's fork of Airsim - https://github.com/ArduPilot/AirSim
Would be great if someone can have a look at enabling Travis and maybe issues for the repo!

Second commit updates the info about running on different machines, commit included from https://github.com/ArduPilot/ardupilot_wiki/pull/2501