### PR TITLE
Warn users about Spline WP with Dijkstras

### DIFF
--- a/common/source/docs/common-oa-dijkstras.rst
+++ b/common/source/docs/common-oa-dijkstras.rst
@@ -13,6 +13,10 @@ Copter and Rover 4.0 (and higher) support `Dijkstra's <https://en.wikipedia.org/
 
    Dijkstra's does not support avoiding objects sensed with lidar or proximity sensors
 
+.. warning::
+
+   Dijkstra's does not support Spline Waypoints. 
+   
 .. image:: ../../../images/oa-dijkstras.png
 
 Configuration


### PR DESCRIPTION
Related to: https://github.com/ArduPilot/ardupilot/issues/12691
I tested it out in SITL. The vehicle just breaches fence and does the fence breached fail-safe option. I feel we should warn the user's of this outcome until we solve this issue.