### PR TITLE
Re-org Simulation section and remove duplications

### DIFF
--- a/dev/source/docs/SITL-setup-landingpage.rst
+++ b/dev/source/docs/SITL-setup-landingpage.rst
@@ -1,0 +1,15 @@
+.. _SITL-setup-landingpage:
+
+===============
+Setting Up SITL
+===============
+
+These documents discuss how to install and setup the SITL environment in Linux and Windows
+
+.. toctree::
+    :maxdepth: 1
+
+    SITL setup on Linux <setting-up-sitl-on-linux>
+    SITL setup on Windows <sitl-native-on-windows>
+    SITL setup on Windows in a VM <setting-up-sitl-on-windows>
+    SITL setup using Vagrant <setting-up-sitl-using-vagrant>

--- a/dev/source/docs/simulation-2.rst
+++ b/dev/source/docs/simulation-2.rst
@@ -16,12 +16,14 @@ The most commonly used simulators are:
 
 -  :ref:`SITL (Software In The Loop) <sitl-simulator-software-in-the-loop>` is the simulator most commonly used by developers. It is a simple simulator that is built within all SITL builds of ArduPilot. It is used by the :ref:`autotester <the-ardupilot-autotest-framework>` and other simulators below are actually built on top of SITL
 -  :ref:`Gazebo <using-gazebo-simulator-with-sitl>` is the official DARPA virtual robotics simulator
--  :ref:`XPlane-10 <sitl-with-xplane>` a commercial flight simulator with a rich 3D interface
+-  :ref:`XPlane-10 <sitl-with-xplane>` a commercial flight simulator with a rich 3D interface   
+-  :ref:`XPlane-10 Soaring<soaring-sitl-with-xplane>` soaring on XPlane-10
 -  :ref:`RealFlight <sitl-with-realflight>` a commercial flight simulator with a rich 3D interface and ability to design custom vehicles
 -  :ref:`Morse <sitl-with-morse>` a robotics simulation environment commonly used in research
 -  :ref:`Replay <testing-with-replay>` has no graphical interface but allows re-running master from a dataflash log
 -  :ref:`JSBSim <sitl-with-jsbsim>` is a sophisticated open-source plane and multicopter simulator with no graphical interface. It can be used with a wide variety of airframes.
 -  :ref:`AirSim <sitl-with-airsim>` is an open-source, cross-platform simulator for drones & cars, built on Unreal Engine for physically and visually realistic simulations
+-  :ref:`Silent Wings Soaring<soaring-sitl-with-silentwings>` 
 
 Less often used simulators include:
 
@@ -38,11 +40,13 @@ List of simulators (so they can appear in the menu):
     SITL Simulator <sitl-simulator-software-in-the-loop>
     Gazebo <using-gazebo-simulator-with-sitl>
     XPlane-10 <sitl-with-xplane>
+    XPlane-10 Soaring<soaring-sitl-with-xplane>
     RealFlight <sitl-with-realflight>
     Morse <sitl-with-morse>
     Replay <testing-with-replay>
     JSBSim <sitl-with-jsbsim>
     AirSim <sitl-with-airsim>
+    Silent Wings Soaring<soaring-sitl-with-silentwings>
     Last Letter <using-last_letter-as-an-external-sitl-simulator>
     CRRCSim <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>
     HITL Simulators <hitl-simulators>

--- a/dev/source/docs/sitl-simulator-software-in-the-loop.rst
+++ b/dev/source/docs/sitl-simulator-software-in-the-loop.rst
@@ -47,8 +47,8 @@ Running SITL
 ============
 
 The ArduPilot SITL environment has been developed to run natively on both
-Linux and Windows. For instructions see :ref:`Setting up SITL on Linux <setting-up-sitl-on-linux>` and :ref:`Setting up SITL on Windows <sitl-native-on-windows>`
-for more information.
+Linux and Windows. For setup instructions see :ref:`Setting Up SITL <SITL-setup-landingpage>`
+for more information. For starting SITL for a particular vehicle see :ref:`Starting SITL <starting-sitl>`, while environment setup and how to use SITL is explained in :ref:`Using SITL <using-sitl-for-ardupilot-testing>`
 
 SITL Architecture
 =================
@@ -64,18 +64,7 @@ port numbers depending on your environment.
 .. toctree::
     :maxdepth: 1
 
-    SITL setup on Linux <setting-up-sitl-on-linux>
-    SITL setup on Windows <sitl-native-on-windows>
-    SITL setup on Windows in a VM <setting-up-sitl-on-windows>
-    SITL setup using Vagrant <setting-up-sitl-using-vagrant>
-    Copter SITL/MAVProxy Tutorial <copter-sitl-mavproxy-tutorial>
-    Plane SITL/MAVProxy Tutorial <plane-sitlmavproxy-tutorial>
-    Rover SITL/MAVProxy Tutorial <rover-sitlmavproxy-tutorial>
-    Balance Bot SITL/MAVProxy Tutorial <balance_bot-sitl-mavproxy-tutorial>
-    SITL Advanced Testing <using-sitl-for-ardupilot-testing>
-    Using Gazebo Simulator with SITL <using-gazebo-simulator-with-sitl>
-    Using Last_letter Simulator with SITL <using-last_letter-as-an-external-sitl-simulator>
-    Using the CRRCSim simulator <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>
-    Using X-Plane 10 with SITL <sitl-with-xplane>
-    Soaring SITL with X-Plane <soaring-sitl-with-xplane>
-    Soaring SITL with Silent Wings <soaring-sitl-with-silentwings>
+    Setting Up SITL <SITL-setup-landingpage>
+    Starting SITL <starting-sitl>
+    Using SITL <using-sitl-for-ardupilot-testing>
+

--- a/dev/source/docs/starting-sitl.rst
+++ b/dev/source/docs/starting-sitl.rst
@@ -1,0 +1,15 @@
+.. _starting-sitl:
+
+=============
+Starting SITL
+=============
+
+These documents discuss how to start SITL for specific vehicles and any vehicle specific SITL information
+
+.. toctree::
+    :maxdepth: 1
+
+    Copter SITL/MAVProxy Tutorial <copter-sitl-mavproxy-tutorial>
+    Plane SITL/MAVProxy Tutorial <plane-sitlmavproxy-tutorial>
+    Rover SITL/MAVProxy Tutorial <rover-sitlmavproxy-tutorial>
+    Balance Bot SITL/MAVProxy Tutorial <balance_bot-sitl-mavproxy-tutorial>

--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -1,8 +1,8 @@
 .. _using-sitl-for-ardupilot-testing:
 
-=====================
-SITL Advanced Testing
-=====================
+==========
+Using SITL
+==========
 
 This article describes how :ref:`SITL <sitl-simulator-software-in-the-loop>`
 and :ref:`MAVProxy <mavproxy-developer-gcs>` can be used to change the environment,


### PR DESCRIPTION
had to run SITL after not running for several months and was very hard for me to find the information I needed (some was missing, I will fix that next)....lots of duplicate TOC entries...
so this is to simplify the drill down to what someone is looking for rather than a long list of topics...

no substance changes, just re-organization...makes its quick to find what you have forgotten or easy(er) for a first time user....

next , I am going to add stuff to a couple of pages that I had to get Tridges help to run QuadPlane yesterday while its fresh in memory