### PR TITLE
Add more docs for UAVCAN AP_Periph rangefinder.

### DIFF
--- a/common/source/docs/common-uavcan-adapter-node.rst
+++ b/common/source/docs/common-uavcan-adapter-node.rst
@@ -28,3 +28,48 @@ The f103-GPS firmware enables its UART interface for GPS and provides I2C compas
 
 `Schematic <https://github.com/ArduPilot/Schematics/blob/master/mRobotics/mRo_CANnode_V1_R1.pdf>`__
 
+
+Features
+=========
+
+The AP_Periph firmware can be configured to enable a wide range of
+UAVCAN sensor types. Support is included for:
+
+ - GPS modules (including RTK GPS)
+ - Magnetometers (SPI or I2C)
+ - Barometers (SPI or I2C)
+ - Airspeed sensors (I2C)
+ - Rangefinders (UART or I2C)
+ - ADSB (Ping ADSB receiver on UART)
+ - LEDs (GPIO, I2C or WS2812 serial)
+ - Safety LED and Safety Switch
+ - Buzzer (tonealarm or simple GPIO)
+
+An AP_Periph UAVCAN firmware supports these UAVCAN features:
+
+ - dynamic or static CAN node allocation
+ - firmware upload
+ - automatically generated bootloader
+ - parameter storage in flash
+ - easy bootloader update
+ - high resiliance features using watchdog, CRC and board checks
+ - firmware update via MissionPlanner or uavcan-gui-tool
+
+
+Setup
+======
+
+Rangefinder
+------------
+
+ To use rangefinders, follow the instructions at  :ref:`UAVCAN Setup Advanced<common-uavcan-setup-advanced>` to set up the Ardupilot parameters. Using MissionPlanner or UAVCAN Gui, set the parameters on the adaptor node following the instructions for the relevant rangefinder.
+
+ .. note::
+
+ 	The orientation of the rangefinder (RNGFND1_ORIENT) must be set to 0 on the adaptor node.
+
+
+ .. note::
+
+ 	The RNGFNDx_ADDR Ardupilot parameter must be set to 0.
+

--- a/common/source/docs/common-uavcan-setup-advanced.rst
+++ b/common/source/docs/common-uavcan-setup-advanced.rst
@@ -94,6 +94,12 @@ UAVCAN LED configuration
 
 UAVCAN LEDs are enabled by setting bit 5 in the :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` bitmask.
 
+UAVCAN Rangefinder configuration
+================================
+
+Set ``RNGFNDx_TYPE`` = 24 to enable UAVCAN rangefinder type. Rangefinder data received over UAVCAN will only be used if the received sensor_id matches the parameter ``RNGFNDx_ADDR``. For AP_Periph firmware based adaptor nodes, this value is 0, so ``RNGFNDx_ADDR`` must be set to 0. Other UAVCAN rangefinders may differ. See also :ref:`UAVCAN Adaptor Node<common-uavcan-adapter-node>` instructions.
+
+
 SLCAN
 =====
 


### PR DESCRIPTION
Quite a few users not able to get rangefinder working with AP_Periph - there's some key params not documented elsewhere.