### PR TITLE
Fix parameters order in listbox

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -425,6 +425,8 @@ def generate_json(vehicles):
 
         # Creates the JSON lines from available rst files
         parameters_files = [f for f in glob.glob("parameters-" + vehicle + "*.rst")]
+        parameters_files.sort(reverse=True)
+
         json_lines = []
         json_lines.append("{")
         json_lines.append("\"Click here to change\" : \"\"")


### PR DESCRIPTION

The option of versions was presented randomly in the Listbox on parameter pages of each vehicle. This PR only sorts that.
