### PR TITLE
Common: Give details of minimal firmware for some autopilots

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -29,9 +29,11 @@ Open hardware
     mRo X2.1-777 <https://store.mrobotics.io/mRo-X2-1-777-p/mro-x2.1-777-mr.htm>
     OpenPilot Revolution <common-openpilot-revo-mini>
     PocketPilot* (Linux) <https://github.com/PocketPilot/PocketPilot>
-    TauLabs Sparky2 <common-taulabs-sparky2>
+    TauLabs Sparky2** <common-taulabs-sparky2>
 
 \* these devices are sensor add-on boards for a Beagle Bone microcomputer. See board links for details 
+
+\** due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
 
 Closed hardware
 ---------------
@@ -44,17 +46,17 @@ Closed hardware
     Furious FPV F-35 Lightning and Wing FC-10 <common-furiousfpv-f35>
     Holybro Durandal H7 <common-durandal-overview>
     Holybro Kakute F4 <common-holybro-kakutef4>
-    Holybro Kakute F7 AIO <common-holybro-kakutef7aio>
-    Holybro Kakute F7 Mini <common-holybro-kakutef7mini>
+    Holybro Kakute F7 AIO* <common-holybro-kakutef7aio>
+    Holybro Kakute F7 Mini* <common-holybro-kakutef7mini>
     Holybro Pixhawk 4 <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/Pixhawk4/README.md>
     Holybro Pixhawk 4 Mini <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/PH4-mini/README.md>
-    Mateksys F405-STD and variants <common-matekf405>
-    Mateksys F405-Wing <common-matekf405-wing>
+    Mateksys F405-STD and variants* <common-matekf405>
+    Mateksys F405-Wing* <common-matekf405-wing>
     Mateksys F765-Wing <common-matekf765-wing>
     mRo ControlZero F7 <https://store.mrobotics.io/mRo-Control-Zero-F7-p/mro-ctrl-zero-f7.htm>
-    Omnibus F4 AIO/Pro <common-omnibusf4pro>
+    Omnibus F4 AIO/Pro* <common-omnibusf4pro>
     OmnibusNanoV6 <common-omnibusnanov6>
-    Omnibus F7V2 <common-omnibusf7>
+    Omnibus F7V2* <common-omnibusf7>
 [site wiki="copter"]
     Parrot Bebop Autopilot <parrot-bebop-autopilot>
 [/site]
@@ -63,6 +65,8 @@ Closed hardware
     SpeedyBee F4 (this board currently is non-verified) <common-speedybeef4>
     VR Brain 5 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrain5-detail>
     VR uBrain 5.1 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrainmicro51-detail>
+
+\* due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
 
 .. note:: For more information on using ArduPilot on Linux based boards, see :ref:`building-the-code`
 
@@ -87,5 +91,98 @@ available if you're still working on those platforms:
    NAVIO+ 
    PX4FMU
    Qualcomm Snapdragon Flight Kit
+
+.. _common-autopilots_limited_firmware:
+
+Firmware Limitations on Selected Hardware
+-----------------------------------------
+
+The ArduPilot firmware in some configurations exceeds 1 MB in size. Some autopilots may not have enough
+flash memory to store the full firmware.
+
+For the affected autopilots, a reduced firmware is generated. This firmware omits less-commonly used features
+in order to reduce the firmware size to less than 1 MB.
+
+The missing features are listed below.
+
+
+-  **KakuteF7, KakuteF7 Mini, OmnibusF7V2, sparky2 and older versions of the Pixhawk (with the RevA, RevY and Rev1 of the STM32F427 chip)**
+
+   -  **Common to all vehicles**
+
+      -  Aux function for testing IMU failover (KILL_IMU)
+      -  LTM, Devo and Hott telemetry formats
+      -  Piccolo CAN
+      -  Oreo LED lights
+      -  NCP5623 LED lights
+      -  NMEA output format
+      -  Solo Gimbal
+      -  DSP support
+      -  MTK, SIRF GPS support
+      -  EFI engine support
+      -  AK09916 on ICM20948 compass
+      -  Runcam
+      -  External I2C barometers
+      -  DLVR Airspeed sensors
+
+
+   -  **Copter only**
+
+      -  Sprayer
+      -  Visual Odometry
+      -  Gripper
+      -  RPM
+      -  ADSB
+      -  Guided, Follow, Sport, SystemID, Zigzag and Autorotate modes
+      -  Beacon
+      -  OAPathPlanner
+      -  Optical Flow
+
+
+   -  **Plane Only**
+
+      -  HIL
+      -  Gripper
+      -  Soaring
+      -  Landing Gear
+      -  Qautotune mode
+
+
+   -  **Rover Only**
+
+      -  N/A
+
+
+   -  **Sub Only**
+
+      -  N/A
+
+
+-  **Matek F405**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+
+
+-  **Matek F405-Wing**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+   -  EKF2
+
+
+-  **OmnibusF4 & F4Pro**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+
+
+-  **SuccexF4**
+
+   -  Parachute
+   -  Sprayer
 
 

--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -33,7 +33,7 @@ Open hardware
 
 \* these devices are sensor add-on boards for a Beagle Bone microcomputer. See board links for details 
 
-\** due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+\** due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Closed hardware
 ---------------
@@ -66,7 +66,7 @@ Closed hardware
     VR Brain 5 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrain5-detail>
     VR uBrain 5.1 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrainmicro51-detail>
 
-\* due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+\* due to flash memory limitations, these boards do not include all ArduPilot features. See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 .. note:: For more information on using ArduPilot on Linux based boards, see :ref:`building-the-code`
 
@@ -91,98 +91,4 @@ available if you're still working on those platforms:
    NAVIO+ 
    PX4FMU
    Qualcomm Snapdragon Flight Kit
-
-.. _common-autopilots_limited_firmware:
-
-Firmware Limitations on Selected Hardware
------------------------------------------
-
-The ArduPilot firmware in some configurations exceeds 1 MB in size. Some autopilots may not have enough
-flash memory to store the full firmware.
-
-For the affected autopilots, a reduced firmware is generated. This firmware omits less-commonly used features
-in order to reduce the firmware size to less than 1 MB.
-
-The missing features are listed below.
-
-
--  **KakuteF7, KakuteF7 Mini, OmnibusF7V2, sparky2 and older versions of the Pixhawk (with the RevA, RevY and Rev1 of the STM32F427 chip)**
-
-   -  **Common to all vehicles**
-
-      -  Aux function for testing IMU failover (KILL_IMU)
-      -  LTM, Devo and Hott telemetry formats
-      -  Piccolo CAN
-      -  Oreo LED lights
-      -  NCP5623 LED lights
-      -  NMEA output format
-      -  Solo Gimbal
-      -  DSP support
-      -  MTK, SIRF GPS support
-      -  EFI engine support
-      -  AK09916 on ICM20948 compass
-      -  Runcam
-      -  External I2C barometers
-      -  DLVR Airspeed sensors
-
-
-   -  **Copter only**
-
-      -  Sprayer
-      -  Visual Odometry
-      -  Gripper
-      -  RPM
-      -  ADSB
-      -  Guided, Follow, Sport, SystemID, Zigzag and Autorotate modes
-      -  Beacon
-      -  OAPathPlanner
-      -  Optical Flow
-
-
-   -  **Plane Only**
-
-      -  HIL
-      -  Gripper
-      -  Soaring
-      -  Landing Gear
-      -  Qautotune mode
-
-
-   -  **Rover Only**
-
-      -  N/A
-
-
-   -  **Sub Only**
-
-      -  N/A
-
-
--  **Matek F405**
-
-   -  SMBUS battery
-   -  Parachute
-   -  Sprayer
-
-
--  **Matek F405-Wing**
-
-   -  SMBUS battery
-   -  Parachute
-   -  Sprayer
-   -  EKF2
-
-
--  **OmnibusF4 & F4Pro**
-
-   -  SMBUS battery
-   -  Parachute
-   -  Sprayer
-
-
--  **SuccexF4**
-
-   -  Parachute
-   -  Sprayer
-
 

--- a/common/source/docs/common-holybro-kakutef7aio.rst
+++ b/common/source/docs/common-holybro-kakutef7aio.rst
@@ -13,6 +13,11 @@ Holybro Kakute F7 and KAKUTE F7 AIO
 
    Support for these two boards are available with Copter-3.6.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-holybro-kakutef7aio.rst
+++ b/common/source/docs/common-holybro-kakutef7aio.rst
@@ -16,7 +16,7 @@ Holybro Kakute F7 and KAKUTE F7 AIO
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-holybro-kakutef7mini.rst
+++ b/common/source/docs/common-holybro-kakutef7mini.rst
@@ -16,7 +16,7 @@ Holybro Kakute F7 Mini
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-holybro-kakutef7mini.rst
+++ b/common/source/docs/common-holybro-kakutef7mini.rst
@@ -13,6 +13,11 @@ Holybro Kakute F7 Mini
 
    Support for this board is available with ArduPilot-4.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-limited-firmware.rst
+++ b/common/source/docs/common-limited-firmware.rst
@@ -1,0 +1,92 @@
+.. _common-limited_firmware:
+
+==========================================
+Firmware Limitations on AutoPilot Hardware
+==========================================
+
+The ArduPilot firmware in some configurations exceeds 1 MB in size. Some autopilots may not have enough
+flash memory to store the full firmware.
+
+For the affected autopilots, a reduced firmware is generated. This firmware omits less-commonly used features
+in order to reduce the firmware size to less than 1 MB.
+
+The missing features are listed below.
+
+
+-  **KakuteF7, KakuteF7 Mini, OmnibusF7V2, sparky2 and older versions of the Pixhawk (with the RevA, RevY and Rev1 of the STM32F427 chip)**
+
+   -  **Common to all vehicles**
+
+      -  Aux function for testing IMU failover (KILL_IMU)
+      -  LTM, Devo and Hott telemetry formats
+      -  Piccolo CAN
+      -  Oreo LED lights
+      -  NCP5623 LED lights
+      -  NMEA output format
+      -  Solo Gimbal
+      -  DSP support
+      -  MTK, SIRF GPS support
+      -  EFI engine support
+      -  AK09916 on ICM20948 compass
+      -  Runcam
+      -  External I2C barometers
+      -  DLVR Airspeed sensors
+
+
+   -  **Copter only**
+
+      -  Sprayer
+      -  Visual Odometry
+      -  Gripper
+      -  RPM
+      -  ADSB
+      -  Guided, Follow, Sport, SystemID, Zigzag and Autorotate modes
+      -  Beacon
+      -  OAPathPlanner
+      -  Optical Flow
+
+
+   -  **Plane Only**
+
+      -  HIL
+      -  Gripper
+      -  Soaring
+      -  Landing Gear
+      -  Qautotune mode
+
+
+   -  **Rover Only**
+
+      -  N/A
+
+
+   -  **Sub Only**
+
+      -  N/A
+
+
+-  **Matek F405**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+
+
+-  **Matek F405-Wing**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+
+
+-  **OmnibusF4 & F4Pro**
+
+   -  SMBUS battery
+   -  Parachute
+   -  Sprayer
+
+
+-  **SuccexF4**
+
+   -  Parachute
+   -  Sprayer

--- a/common/source/docs/common-matekf405-wing.rst
+++ b/common/source/docs/common-matekf405-wing.rst
@@ -14,6 +14,11 @@ the above image and some content courtesy of `mateksys.com <http://www.mateksys.
 
    Support for this board is available with Copter-3.6.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-matekf405-wing.rst
+++ b/common/source/docs/common-matekf405-wing.rst
@@ -17,7 +17,7 @@ the above image and some content courtesy of `mateksys.com <http://www.mateksys.
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-matekf405.rst
+++ b/common/source/docs/common-matekf405.rst
@@ -14,6 +14,11 @@ Mateksys F405-STD and variants
 
 the above images and some content courtesy of `mateksys.com <http://www.mateksys.com/?portfolio=f405-std>`__
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-matekf405.rst
+++ b/common/source/docs/common-matekf405.rst
@@ -17,7 +17,7 @@ the above images and some content courtesy of `mateksys.com <http://www.mateksys
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-omnibusf4pro.rst
+++ b/common/source/docs/common-omnibusf4pro.rst
@@ -17,7 +17,7 @@ Omnibus F4 Pro (on-board current sensor) and Omnibus F4 AIO (no sensor onboard)
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-omnibusf4pro.rst
+++ b/common/source/docs/common-omnibusf4pro.rst
@@ -14,6 +14,11 @@ Omnibus F4 Pro (on-board current sensor) and Omnibus F4 AIO (no sensor onboard)
 
    Support for this board is available with Copter-3.6.0 and Plane-3.9.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-omnibusf7.rst
+++ b/common/source/docs/common-omnibusf7.rst
@@ -17,7 +17,7 @@ Omnibus F7
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-omnibusf7.rst
+++ b/common/source/docs/common-omnibusf7.rst
@@ -14,6 +14,11 @@ Omnibus F7
 
    Support for this board is available with Copter-3.6.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -9,7 +9,7 @@ Pixhawk Overview
 	Older versions of Pixhawk use an early version of the STM32F427 chip (RevA, RevY and Rev1).
         A hardware bug is present in these chips that limit the flash memory to 1 MB. Any boards
         containing this chip cannot include all ArduPilot features due to this limitation. See
-        :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -4,6 +4,13 @@
 Pixhawk Overview
 ================
 
+.. note::
+
+	Older versions of Pixhawk use an early version of the STM32F427 chip (RevA, RevY and Rev1).
+        A hardware bug is present in these chips that limit the flash memory to 1 MB. Any boards
+        containing this chip cannot include all ArduPilot features due to this limitation. See
+        :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/common/source/docs/common-taulabs-sparky2.rst
+++ b/common/source/docs/common-taulabs-sparky2.rst
@@ -16,7 +16,7 @@ TauLabs Sparky2
 .. note::
 
 	Due to flash memory limitations, this board does not include all ArduPilot features.
-        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+        See :ref:`Firmware Limitations <common-limited_firmware>` for details.
 
 Specifications
 ==============

--- a/common/source/docs/common-taulabs-sparky2.rst
+++ b/common/source/docs/common-taulabs-sparky2.rst
@@ -13,6 +13,11 @@ TauLabs Sparky2
 
    Support for the TauLabs Sparky2 is available with Copter-3.6.0 (and higher)
 
+.. note::
+
+	Due to flash memory limitations, this board does not include all ArduPilot features.
+        See :ref:`Firmware Limitations <common-autopilots_limited_firmware>` for details.
+
 Specifications
 ==============
 

--- a/copter/source/index.rst
+++ b/copter/source/index.rst
@@ -174,6 +174,7 @@ Getting more info
    
    Introducing Copter <docs/introduction>
    AutoPilot Hardware Options <docs/common-autopilots>
+   Firmware Limitations on AutoPilot Hardware <docs/common-limited-firmware>
    First Time Setup <docs/initial-setup>
    First Flight <docs/flying-arducopter>
    If A Problem Arises <docs/common-when-problems-arise>

--- a/plane/source/index.rst
+++ b/plane/source/index.rst
@@ -101,6 +101,7 @@ Monitor https://discuss.ardupilot.org/c/arduplane for plane-related announcement
    
     Introduction <docs/introduction>
     AutoPilot Hardware <docs/common-autopilots>
+    Firmware Limitations on AutoPilot Hardware <docs/common-limited-firmware>
     First Time Setup <docs/arduplane-setup>
     First Flight <docs/first-flight-landing-page>
     If A Problem Arises <docs/common-when-problems-arise> 

--- a/rover/source/index.rst
+++ b/rover/source/index.rst
@@ -30,6 +30,7 @@ automation in our :ref:`Video Demos <rover-video-demonstrations>`).
    
     Introduction <docs/gettit>
     Autopilot Hardware Options <docs/common-autopilots>
+    Firmware Limitations on AutoPilot Hardware <docs/common-limited-firmware>
     First Time Setup <docs/apmrover-setup>
     First Drive <docs/rover-first-drive>
     If A Problem Arises <docs/common-when-problems-arise>


### PR DESCRIPTION
This comes from the my research into ``HAL_MINIMIZE_FEATURES`` define in ArduPilot.

This will assist users in determining if their autopilot is missing any features that they require.