### PR TITLE
Move copter tx tuning into common page and update references in copter

### DIFF
--- a/common/source/docs/common-transmitter-tuning.rst
+++ b/common/source/docs/common-transmitter-tuning.rst
@@ -1,14 +1,15 @@
 .. _common-transmitter-tuning:
 
-[copywiki destination="plane"]
+[copywiki destination="plane,copter"]
 ========================
 Transmitter Based Tuning
 ========================
 
 You can perform extensive parameter tuning in flight using your R/C
 transmitter. This is meant for advanced users who are unable to use
-the autotune features or wish to do fine tuning with full manual
+the Autotune features or wish to do fine tuning with full manual
 tuning control of each parameter
+
 
 Overview
 ========
@@ -17,6 +18,8 @@ Transmitter based tuning allows you to tune a single parameter or a
 set of parameters while flying. The basic idea is to link the tuning
 value of a parameter to a knob or slider on your transmitter then to
 adjust the parameter in flight by moving the knob.
+
+[site wiki="plane"]
 
 Key features of transmitter based tuning are:
 
@@ -271,3 +274,145 @@ At that point you can land the vehicle, or just enjoy flying it.
 The first time you do a full tune in this way it will probably take
 about five minutes of flight time to do a tune. With some practice you
 can do a full tune in a bit over a minute.
+
+[/site]
+[site wiki="copter"]
+
+With transmitter based tuning you can tune a single or multiple parameters in flight using Channel 6 of the transmitter.
+
+The :ref:`TUNE<TUNE>` parameter determines which parameter is being tuned.
+
+The :ref:`TUNE_MAX<TUNE_MAX>` parameter determines the maximum value of the parameter when the channel is at :ref:`RC6_MAX<RC6_MAX>`, while the :ref:`TUNE_MIN<TUNE_MIN>` parameter determines the value when RC channle 6 is at :ref:`RC6_MIN<RC6_MIN>`.
+
+:ref:`TUNE<TUNE>` Values
+========================
+
++--------+-------------------------+----------------------------------------------------------------------+
+|Value	 |Meaning                  | Parameter                                                            |
++========+=========================+======================================================================+
+|0       |         None            |                                                                      |
++--------+-------------------------+----------------------------------------------------------------------+
+|1       |Stab Roll/Pitch kP       |  :ref:`ATC_ANG_RLL_P<ATC_ANG_RLL_P>` ,                               |
+|        |                         |  :ref:`ATC_ANG_PIT_P<ATC_ANG_PIT_P>`                                 |
++--------+-------------------------+----------------------------------------------------------------------+
+|4       |Rate Roll/Pitch kP       |  :ref:`ATC_RAT_RLL_P<ATC_RAT_RLL_P__AC_AttitudeControl_Multi>` ,     |
+|        |                         |  :ref:`ATC_RAT_PIT_P<ATC_RAT_PIT_P__AC_AttitudeControl_Multi>`       |
++--------+-------------------------+----------------------------------------------------------------------+
+|5       |Rate Roll/Pitch kI       |  :ref:`ATC_RAT_RLL_I<ATC_RAT_RLL_I__AC_AttitudeControl_Multi>` ,     |
+|        |                         |  :ref:`ATC_RAT_PIT_I<ATC_RAT_PIT_I__AC_AttitudeControl_Multi>`       |
++--------+-------------------------+----------------------------------------------------------------------+
+|21      |Rate Roll/Pitch kD       |  :ref:`ATC_RAT_RLL_D<ATC_RAT_RLL_D__AC_AttitudeControl_Multi>` ,     |
+|        |                         |  :ref:`ATC_RAT_PIT_D<ATC_RAT_PIT_D__AC_AttitudeControl_Multi>`       |
++--------+-------------------------+----------------------------------------------------------------------+
+|3       |Stab Yaw kP              |  :ref:`ATC_ANG_YAW_P<ATC_ANG_YAW_P>`                                 |
++--------+-------------------------+----------------------------------------------------------------------+
+|6       |Rate Yaw kP              |  :ref:`ATC_RAT_YAW_P<ATC_RAT_YAW_P__AC_AttitudeControl_Multi>`       |
++--------+-------------------------+----------------------------------------------------------------------+
+|26      |Rate Yaw kD              |  :ref:`ATC_RAT_YAW_D<ATC_RAT_YAW_D__AC_AttitudeControl_Multi>`       |
++--------+-------------------------+----------------------------------------------------------------------+
+|56      |Rate Yaw Filter          |  :ref:`ATC_RAT_YAW_FLTE<ATC_RAT_YAW_FLTE__AC_AttitudeControl_Multi>` |
++--------+-------------------------+----------------------------------------------------------------------+
+|55      |Motor Yaw Headroom       |  :ref:`MOT_YAW_HEADROOM<MOT_YAW_HEADROOM>`                           |
++--------+-------------------------+----------------------------------------------------------------------+
+|14      |AltHold kP               |  :ref:`PSC_POSZ_P<PSC_POSZ_P>`                                       |
++--------+-------------------------+----------------------------------------------------------------------+
+|7       |Throttle Rate kP         |  :ref:`PSC_VELZ_P<PSC_VELZ_P>`                                       |
++--------+-------------------------+----------------------------------------------------------------------+
+|34      |Throttle Accel kP        |  :ref:`PSC_ACCZ_P<PSC_ACCZ_P>`                                       |
++--------+-------------------------+----------------------------------------------------------------------+
+|3       |Throttle Accel kI        |  :ref:`PSC_ACCZ_I<PSC_ACCZ_I>`                                       |
++--------+-------------------------+----------------------------------------------------------------------+
+|36      |Throttle Accel kD        |  :ref:`PSC_ACCZ_I<PSC_ACCZ_I>`                                       |
++--------+-------------------------+----------------------------------------------------------------------+
+|12      |Loiter Pos kP            |  :ref:`PSC_POSXY_P<PSC_POSXY_P>`                                     |
++--------+-------------------------+----------------------------------------------------------------------+
+|22      |Velocity XY kP           |  :ref:`PSC_POSXY_P<PSC_POSXY_P>`                                     |
++--------+-------------------------+----------------------------------------------------------------------+
+|28      |Velocity XY kI           |  :ref:`PSC_VELXY_I<PSC_VELXY_I>`                                     |
++--------+-------------------------+----------------------------------------------------------------------+
+|10      |WP Speed                 |  :ref:`WPNAV_SPEED<WPNAV_SPEED>`                                     |
++--------+-------------------------+----------------------------------------------------------------------+
+|25      |Acro RollPitch kP        | :ref:`ACRO_RP_P<ACRO_RP_P>`                                          |
++--------+-------------------------+----------------------------------------------------------------------+
+|40      |Acro Yaw kP              | :ref:`ACRO_YAW_P<ACRO_YAW_P>`                                        |
++--------+-------------------------+----------------------------------------------------------------------+
+|45      |RC Feel                  | :ref:`ATC_INPUT_TC<ATC_INPUT_TC>`                                    |
++--------+-------------------------+----------------------------------------------------------------------+
+|13      |Heli Ext Gyro            | :ref:`H_GYR_GAIN<H_GYR_GAIN>`                                        |
++--------+-------------------------+----------------------------------------------------------------------+
+|38      |Declination              | :ref:`COMPASS_DEC<COMPASS_DEC>`                                      |
++--------+-------------------------+----------------------------------------------------------------------+
+|39      |Circle Rate              | :ref:`CIRCLE_RATE<CIRCLE_RATE>`                                      |
++--------+-------------------------+----------------------------------------------------------------------+
+|41      |RangeFinder Gain         |  :ref:`RNGFND_GAIN<RNGFND_GAIN>`                                     |
++--------+-------------------------+----------------------------------------------------------------------+
+|46      |Rate Pitch kP            | :ref:`ATC_RAT_PIT_P<ATC_RAT_PIT_P__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|47      |Rate Pitch kI            | :ref:`ATC_RAT_PIT_I<ATC_RAT_PIT_I__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|48      |Rate Pitch kD            | :ref:`ATC_RAT_PIT_D<ATC_RAT_PIT_D__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|49      |Rate Roll kP             | :ref:`ATC_RAT_RLL_P<ATC_RAT_RLL_P__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|50      |Rate Roll kI             | :ref:`ATC_RAT_RLL_I<ATC_RAT_RLL_I__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|51      |Rate Roll kD             | :ref:`ATC_RAT_RLL_D<ATC_RAT_RLL_D__AC_AttitudeControl_Multi>`        |
++--------+-------------------------+----------------------------------------------------------------------+
+|52      |Rate Pitch FF            | :ref:`ATC_RAT_PIT_FF<ATC_RAT_PIT_FF>` (heli only)                    |
++--------+-------------------------+----------------------------------------------------------------------+
+|53      |Rate Roll FF             | :ref:`ATC_RAT_RLL_FF<ATC_RAT_RLL_FF>` (heli only)                    |
++--------+-------------------------+----------------------------------------------------------------------+
+|54      |Rate Yaw FF              | :ref:`ATC_RAT_YAW_FF<ATC_RAT_YAW_FF>` (heli only)                    |
++--------+-------------------------+----------------------------------------------------------------------+
+|57      |Winch                    | :ref:`WINCH__RATE_MAX<WINCH__RATE_MAX>`                              |
++--------+-------------------------+----------------------------------------------------------------------+
+|58      |SysID Magnitude          | :ref:`SIDS_MAGNITUDE<SID_MAGNITUDE>`                                 |
++--------+-------------------------+----------------------------------------------------------------------+
+
+
+These values can be either set manually or using Mission Planner
+
+
+Setting with Mission Planner
+============================
+
+Rate Roll P and Rate Pitch P will be used in the following example procedure
+
+.. image:: ../images/RollPitchTuning.png
+    :target: ../_images/RollPitchTuning.png
+
+#. Connect your autopilot to Mission Planner
+#. On Mission Planner, select Config/Tuning >> Copter Pids
+#. Set the CH6 Opt to "Rate Roll/Pitch kP"
+#. Set Min to 0.08, Max to 0.20 (most copters ideal gain is within this
+   range although from a small number of copter the Max can be as high
+   as 0.25)
+#. Push the "Write Params" button
+#. Turn your transmitter's CH6 tuning knob to the minimum position,
+   press the "Refresh Params" button and ensure that the Rate Roll P and
+   Rate Pitch P values become 0.08 (or something very close)
+#. Turn the CH6 knob to it's maximum position, press "Refresh Params"
+   and ensure the Rate Roll P moves to 0.20
+#. Move the CH6 knob back to the middle
+#. Arm and fly your copter in Stabilize mode adjusting the ch6 knob
+   until you get a copter that is responsive but not wobbly
+#. After the flight, disconnect your LiPo battery and reconnect the autopilot to the mission planner
+#. With the CH6 knob in the position that gave the best performance,
+   return to the Copter Pids screen and push the "Refresh Params" button
+#. In the Rate Roll P and Rate Pitch P fields re-type the value that you
+   see but just slightly modified so that the mission planner recongises
+   that it's changed and resends to the autopilot (Note: if you re-type
+   exactly the same number as what appears in Rate Roll P it won't be
+   updated).  So for example if the Rate Roll P appears as "0.1213" make
+   it "0.1200"
+#. Set Ch6 Opt back to "None" and push "Write Params"
+#. Push the Disconnect button on the top right, and the Connect
+#. Ensure that the Rate Roll P value is the value that you retyped in
+   step #12
+
+Note: while you are moving the tuning knob the values update at 3 times
+per second.  The need to press the Refresh button in the mission planner
+in steps #6 and #7 above is just because the Copter is not sending the
+updates to the mission planner in real-time.
+
+[/site]

--- a/common/source/docs/common-tuning.rst
+++ b/common/source/docs/common-tuning.rst
@@ -15,9 +15,10 @@ parameters. The following topics shown you how.
 
     Tuning Process Instructions <tuning-process-instructions>
     AutoTune <autotune>
-    Roll and Pitch Tuning <ac_rollpitchtuning>
-    Advanced Tuning <tuning>
+    Manual Roll and Pitch Tuning <ac_rollpitchtuning>
     Basic Tuning <basic-tuning>
+    Advanced Tuning <tuning>
+    Transmitter Based Tuning <common-transmitter-tuning>
     Configuring Notch Filtering <common-imu-notch-filtering>
 
 -----

--- a/copter/source/docs/ac_rollpitchtuning.rst
+++ b/copter/source/docs/ac_rollpitchtuning.rst
@@ -1,8 +1,8 @@
 .. _ac_rollpitchtuning:
 
-=================================
-InFlight tuning of Roll and Pitch
-=================================
+============================
+Manual Roll and Pitch Tuning
+============================
 
 Although there are many gains that can be tuned in Copter to get optimal
 performance, the most critical is the Rate Roll and Pitch P values which
@@ -21,48 +21,10 @@ Some general advice on how to tune this parameter:
 
 .. _ac_rollpitchtuning_in-flight_tuning:
 
-In-flight tuning
-~~~~~~~~~~~~~~~~
+Transmitter based tuning
+~~~~~~~~~~~~~~~~~~~~~~~~
 
-Rate Roll P and Rate Pitch P can be tuned in flight using your
-transmitter's channel 6 tuning knob by following these instructions:
-
-.. image:: ../images/RollPitchTuning.png
-    :target: ../_images/RollPitchTuning.png
-
-#. Connect your autopilot to Mission Planner
-#. On Mission Planner, select Config/Tuning >> Copter Pids
-#. Set the CH6 Opt to "Rate Roll/Pitch kP"
-#. Set Min to 0.08, Max to 0.20 (most copters ideal gain is within this
-   range although from a small number of copter the Max can be as high
-   as 0.25)
-#. Push the "Write Params" button
-#. Turn your transmitter's CH6 tuning knob to the minimum position,
-   press the "Refresh Params" button and ensure that the Rate Roll P and
-   Rate Pitch P values become 0.08 (or something very close)
-#. Turn the CH6 knob to it's maximum position, press "Refresh Params"
-   and ensure the Rate Roll P moves to 0.20
-#. Move the CH6 knob back to the middle
-#. Arm and fly your copter in Stabilize mode adjusting the ch6 knob
-   until you get a copter that is responsive but not wobbly
-#. After the flight, disconnect your LiPo battery and reconnect the autopilot to the mission planner
-#. With the CH6 knob in the position that gave the best performance,
-   return to the Copter Pids screen and push the "Refresh Params" button
-#. In the Rate Roll P and Rate Pitch P fields re-type the value that you
-   see but just slightly modified so that the mission planner recongises
-   that it's changed and resends to the autopilot (Note: if you re-type
-   exactly the same number as what appears in Rate Roll P it won't be
-   updated).  So for example if the Rate Roll P appears as "0.1213" make
-   it "0.1200"
-#. Set Ch6 Opt back to "None" and push "Write Params"
-#. Push the Disconnect button on the top right, and the Connect
-#. Ensure that the Rate Roll P value is the value that you retyped in
-   step #12
-
-Note: while you are moving the tuning knob the values update at 3 times
-per second.  The need to press the Refresh button in the mission planner
-in steps #6 and #7 above is just because the Copter is not sending the
-updates to the mission planner in real-time.
+See the :ref:`Transmitter based tuning <common-transmitter-tuning>` page for information on how to tune these values, as well as other parameters while in the air.
 
 Video of in-flight tuning
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/copter/source/docs/traditional-helicopter-tuning.rst
+++ b/copter/source/docs/traditional-helicopter-tuning.rst
@@ -239,8 +239,7 @@ Once you have the heli responding nicely with the rate FF gain, now tune the
 PID gains. The rate PID controller provides stability to reject disturbances and
 keep the actual aircraft following the software predicted rates.
  
-Start with the D gain.  Use the tuning feature of ArduCopter which is linked to
-channel 6 on your radio.  Make the following parameter changes:
+Start with the D gain.  Use the :ref:`Transmitter based tuning<common-transmitter-tuning>` feature of ArduCopter.  Make the following parameter changes:
 
 +--------------------------------------------+---------+
 | :ref:`TUNE<TUNE>`                          | 21      |

--- a/copter/source/docs/tuning-process-instructions.rst
+++ b/copter/source/docs/tuning-process-instructions.rst
@@ -194,16 +194,16 @@ When oscillations start do not make large or sudden stick inputs. Reduce the thr
 5. Reduce the P term in steps of 10% until the oscillation disappears
 6. Reduce the P term by a further 25%
 
-Each time the P term is changed set the I term equal to the P term. Those parameters can be changed on ground and preferably disarmed. A confident pilot could set them in flight with GCS or CH6 tuning knob.
+Each time the P term is changed set the I term equal to the P term. Those parameters can be changed on ground and preferably disarmed. A confident pilot could set them in flight with GCS or transmitter tuning knob (see :ref:`Transmitter based tuning<common-transmitter-tuning>` section).
 
-The ch6 tuning knob may be used to make these adjustments. If this is done set the minimum value of the tuning range to the current safe value and the upper range to approximately 4 times the current value. Be careful not to move the slider before the parameter list is refreshed to recover the set value. Ensure the ch6 tuning is switched off before setting the parameter value or the tuning may immediately overwrite it.
+If using :ref:`Transmitter based tuning<common-transmitter-tuning>` , set the minimum value of the tuning range to the current safe value and the upper range to approximately 4 times the current value. Be careful not to move the slider before the parameter list is refreshed to recover the set value. Ensure the transmitter tuning is switched off before setting the parameter value or the tuning may immediately overwrite it.
 
 Autotune
 --------
 
 If the aircraft appears stable enough to attempt autotune follow the instructions in the autotune page.
 
-There a number of problems that can prevent Autotune from providing a good tune. Some of the reason autotune can fail are:
+There a number of problems that can prevent Autotune from providing a good tune. Some of the reasons Autotune can fail are:
 
 - High levels of gyro noise.
 - Incorrect value of :ref:`MOT_THST_EXPO <MOT_THST_EXPO>`.

--- a/copter/source/docs/tuning.rst
+++ b/copter/source/docs/tuning.rst
@@ -124,17 +124,7 @@ parameters including the horizontal speed.
 In-flight tuning
 ================
 
-A single parameter's value can be tuned in flight using the
-transmitter's Ch6 tuning knob.  A specific example for tuning the Rate
-Roll/Pitch P values can be found on the :ref:`Rate Roll and Pitch P tuning wiki page <ac_rollpitchtuning_in-flight_tuning>`.
-Please see the Ch6 Opt drop-down on the Mission Planner's
-**Config/Tuning \| Copter Pids**'s screen for a full list of parameters
-that can be tuned.
-
-After setting the Ch6 Opt value, the Min and Max should also be set to
-reasonable values (i.e. non-zero and also not unreasonably high) and
-then the "Refresh screen" button should be pushed by tuning the Ch6 knob
-to ensure that the parameter is updating correctly.
+See the :ref:`Transmitter based tuning<common-transmitter-tuning>` page for details.
 
 Filter tuning
 =============


### PR DESCRIPTION
generalize and move copter tx tuning sections into the common tx tuning page for future proofing
add TUNE value table
use references to this page wherever CH6 tuning was mentioned