### PR TITLE
Renamed firmware loading page titles; updated refs in antennatracker

### DIFF
--- a/antennatracker/source/docs/loading-the-firmware.rst
+++ b/antennatracker/source/docs/loading-the-firmware.rst
@@ -7,10 +7,7 @@ Loading the Firmware
 Before loading Firmware, you need to choose which :ref:`autopilot hardware <common-autopilots>` to use.
 All supported autopilots are suitable for use with AntennaTracker.
 The antenna tracker firmware can be loaded from the Mission Planner's
-**Initial Setup \| Install Firmware** very :ref:`much like Copter. <planner:common-loading-firmware-onto-pixhawk>`
-
-Use Mission Planner's Install Firmware screen to load the firmware
-==================================================================
+**Setup \| Install Firmware** very :ref:`much like any other vehicle <common-loading-firmware-onto-pixhawk>` if ArduPilot firmware is already loaded.
 
 .. image:: ../images/AntennaTracker_MP_LoadFirmware.jpg
     :target: ../_images/AntennaTracker_MP_LoadFirmware.jpg
@@ -23,6 +20,8 @@ Use Mission Planner's Install Firmware screen to load the firmware
    that appear and after a minute or so the firmware should be uploaded
    and you should be able to connect with the mission planner and see
    the Flight Data screen's HUD update.
+   
+If non-ArduPilot firmware is loaded on the autopilot, see :ref:`these instructions <common-loading-firmware-onto-chibios-only-boards>` for instructions to download a version of antennatracker_with_bl.hex firmware and install.
 
 .. note::
 
@@ -31,8 +30,3 @@ Use Mission Planner's Install Firmware screen to load the firmware
    installed on the board (i.e. Copter or Plane) it is likely the EEPROM
    will have been erased by the firmware upload.
 
-.. note::
-
-   Firmware for other boards (APM1, Flymaple, etc) cannot be loaded
-   directly from the mission planner but must be compiled and loaded onto
-   the board more manually.

--- a/common/source/docs/common-bootloader-update.rst
+++ b/common/source/docs/common-bootloader-update.rst
@@ -26,7 +26,7 @@ The ArduPilot specific bootloader is included within the ArduPilot firmware but 
 Upgrading using Mission Planner
 -------------------------------
 
-- Install a recent version of ArduPilot to the autopilot (:ref:`Pixhawk family <common-loading-firmware-onto-pixhawk>`, :ref:`ChibiOS-only autopilots <common-loading-firmware-onto-chibios-only-boards>`)
+- Install a recent version of ArduPilot to the autopilot (:ref:`with existing ArduPilot firmware <common-loading-firmware-onto-pixhawk>`, :ref:`without existing ArduPilot firmware <common-loading-firmware-onto-chibios-only-boards>`)
 - Connect and check that the autopilot has at least 20k of free memory.  Open the Data screen's Quick tab, double click on any entry and the select "freemem".
 
   .. image:: ../../../images/bootloader-update-MP-memory-check.png

--- a/common/source/docs/common-connect-mission-planner-autopilot.rst
+++ b/common/source/docs/common-connect-mission-planner-autopilot.rst
@@ -9,7 +9,7 @@ in order to receive telemetry and control the vehicle.
 
 .. note::
 
-   There are separate instructions for connecting in order to :ref:`Load Firmware <common-loading-firmware-onto-pixhawk>`.
+   There are separate instructions for connecting in order to :ref:`Load Firmware <common-loading-firmware-onto-pixhawk>` for existing Ardupilot firmware installations, or for boards :ref:`without existing Ardupilot firmware <common-loading-firmware-onto-chibios-only-boards>` .
 
 
 Setting up the connection

--- a/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
+++ b/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
@@ -50,7 +50,7 @@ Download the ArduPilot firmware
   - select click on the link for your vehicle type (i.e. `Plane <https://firmware.ardupilot.org/Plane/>`__, `Copter <https://firmware.ardupilot.org/Copter/>`__, `Rover <https://firmware.ardupilot.org/Rover/>`__, `Sub <https://firmware.ardupilot.org/Sub/>`__ or `Antenna Tracker <https://firmware.ardupilot.org/AntennaTracker/>`__)
   - select "beta" or "stable"
   - look for the directory with the name that most closely matches the autopilot
-  - download the "arduXXX_with_bl.hex" file
+  - download the "arduXXX_with_bl.hex" file by right clicking and using the "save link as.." menu item. Remember where you saved it!
 
 Upload ArduPilot to the board
 -----------------------------
@@ -59,7 +59,7 @@ Upload ArduPilot to the board
 
   - Select "Firmware Flasher" on the left side of the screen
   - Select DFU from the top right
-  - Push "Load Firmware [Local]" from the bottom right and select the arduXXX_with_bl.hex file downloaded above
+  - Push "Load Firmware [Local]" from the bottom right and select the arduXXX_with_bl.hex file you downloaded above.
   - Push "Flash Firmware" and after a few minutes the firmware should be loaded
 
   .. image:: ../../../images/loading-firmware-betaflight-configurator.png

--- a/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
+++ b/common/source/docs/common-loading-firmware-onto-chibios-only-boards.rst
@@ -1,11 +1,13 @@
 .. _common-loading-firmware-onto-chibios-only-boards:
 
-=========================================
-Loading Firmware onto ChibiOS-only boards
-=========================================
+================================================================
+Loading Firmware onto boards without existing ArduPilot firmware
+================================================================
 
 Recent versions of ArduPilot (Copter-3.6, Plane-3.9, Rover-3.5) run on relatively small, non-Pixhawk, autopilots using the ChibiOS operating system.
 Examples of these boards include the :ref:`OpenPilot RevoMini <common-openpilot-revo-mini>`, :ref:`Mateksys F405-Wing <common-matekf405-wing>` and :ref:`Omnibus F4 Pro <common-omnibusf4pro>`.
+
+Most often, these boards have another flight controller software pre-installed. (If the board has ArduPilot already installed, see :ref:`common-loading-firmware-onto-pixhawk` for firmware loading instructions.
 
 Installing ArduPilot to these autopilot involves:
 

--- a/common/source/docs/common-loading-firmware-onto-pixhawk.rst
+++ b/common/source/docs/common-loading-firmware-onto-pixhawk.rst
@@ -4,7 +4,7 @@
 Loading Firmware
 ================
 
-These instructions will show you how to download the latest firmware onto the autopilot using the Mission Planner ground station.
+These instructions will show you how to download the latest firmware onto the autopilot using the Mission Planner ground station,which already has ArduPilot firmware installed . See :ref:`common-loading-firmware-onto-chibios-only-boards` .
 
 [copywiki destination="copter,plane,rover,planner"]
 

--- a/copter/source/docs/initial-setup.rst
+++ b/copter/source/docs/initial-setup.rst
@@ -25,8 +25,8 @@ within the sections) see the topics below:
 
     Install Ground Station Software <common-install-gcs>
     Autopilot System Assembly <autopilot-assembly-instructions>
-    Loading Firmware to Pixhawk boards <common-loading-firmware-onto-pixhawk>
-    Loading Firmware to ChibiOS-only boards <common-loading-firmware-onto-chibios-only-boards>
+    Loading Firmware to boards with existing ArduPilot firmware <common-loading-firmware-onto-pixhawk>
+    Loading Firmware to boards without existing ArduPilot firmware<common-loading-firmware-onto-chibios-only-boards>
     Connect Mission Planner to AutoPilot <common-connect-mission-planner-autopilot>
     Configuration <configuring-hardware>
     

--- a/plane/source/docs/arduplane-setup.rst
+++ b/plane/source/docs/arduplane-setup.rst
@@ -15,8 +15,8 @@ give you a taste:
 
     Install Ground Station Software <common-install-gcs>
     Autopilot System Assembly <autopilot-assembly-instructions>
-    Loading Firmware to Pixhawk boards <common-loading-firmware-onto-pixhawk>
-    Loading Firmware to ChibiOS-only boards <common-loading-firmware-onto-chibios-only-boards>
+    Loading Firmware to boards with existing ArduPilot firmware <common-loading-firmware-onto-pixhawk>
+    Loading Firmware to boards without existing ArduPilot firmware <common-loading-firmware-onto-chibios-only-boards>
     Connect Mission Planner to AutoPilot <common-connect-mission-planner-autopilot>
     Configuration <plane-configuration-landing-page>
     Airframe Specific Setup Guides <airframe-guides>

--- a/planner/source/docs/mission-planner-installation.rst
+++ b/planner/source/docs/mission-planner-installation.rst
@@ -36,6 +36,8 @@ Then you can either:
 - :ref:`Connect Mission Planner to AutoPilot <common-connect-mission-planner-autopilot>` in order to receive telemetry and control the vehicle OR
 - :ref:`Load Firmware <common-loading-firmware-onto-pixhawk>`
 
+.. note:: If ArduPilot firmware is not already installed on the autopilot, see :ref:`Loading Firmware to boards without existing ArduPilot firmware <common-loading-firmware-onto-chibios-only-boards>`.
+
 Updating Mission Planner
 ========================
 

--- a/planner/source/index.rst
+++ b/planner/source/index.rst
@@ -34,8 +34,8 @@ Full Table of Contents
 
    Mission Planner Overview <docs/mission-planner-overview>
    docs/mission-planner-installation
-   docs/common-loading-firmware-onto-pixhawk
-   Loading Firmware onto ChibiOS-only boards (first time only) <docs/common-loading-firmware-onto-chibios-only-boards>
+   Loading Firmware onto boards with existing ArduPilot firmware <docs/common-loading-firmware-onto-pixhawk>
+   Loading Firmware onto boards without existing ArduPilot firmware (first time only) <docs/common-loading-firmware-onto-chibios-only-boards>
    docs/common-connect-mission-planner-autopilot
    docs/common-mission-planning
    docs/mission-planner-features

--- a/rover/source/docs/apmrover-setup.rst
+++ b/rover/source/docs/apmrover-setup.rst
@@ -12,7 +12,7 @@ This section provides a step-by-step guide for assembling and configuring an Unm
 
     Install Ground Station Software <common-install-gcs>
     Autopilot System Assembly Instructions <rover-autopilot-assembly-instructions>
-    Loading Firmware to Pixhawk boards <common-loading-firmware-onto-pixhawk>
-    Loading Firmware to ChibiOS-only boards <common-loading-firmware-onto-chibios-only-boards>
+    Loading Firmware onto boards with existing ArduPilot firmware <common-loading-firmware-onto-pixhawk>
+    Loading Firmware onto boards without existing ArduPilot firmware (first time only) <common-loading-firmware-onto-chibios-only-boards>
     Connect Mission Planner to AutoPilot <common-connect-mission-planner-autopilot>
     Configuration <rover-code-configuration>

--- a/rover/source/docs/balance_bot-configure.rst
+++ b/rover/source/docs/balance_bot-configure.rst
@@ -17,7 +17,7 @@ Configuration and Setup
     - GPS(optional)
     - Telemetry(optional)
 
-#. :ref:`Install GCS<common-install-gcs>` (Mission Planner recommended) and :ref:`upload rover firmware<common-loading-firmware-onto-pixhawk>`
+#. :ref:`Install GCS<common-install-gcs>` (Mission Planner recommended) and :ref:`upload rover firmware<common-loading-firmware-onto-pixhawk>`, if ArduPilot firmware already is installed, or :ref:`Loading Firmware onto boards without existing ArduPilot firmware (first time only) <common-loading-firmware-onto-chibios-only-boards>`
 #. Perform all the :ref:`hardware calibration<rover-code-configuration>` steps for:
 
     - :ref:`Accelerometer<common-accelerometer-calibration>`


### PR DESCRIPTION
first step in clarifying the firmware load process based on comments on the forums I monitor and support (mainly RC hobbyists)...this PR removes Chibios/Pixhawk distinctions...either the board already had ArduPilot or not when determining firmware loading procedures..

no actual content change...will merge in a couple of days 

- next step is to clarify the way to actually download from firmware.ardupilot.org and add note for first time loading...there is no mention now
- then  to add to the driver install process for DFU, there are simpler methods than ZADIG... STM32CUBE loader and  ImpulseRC Driver Fixer...that should be mentioned