### PR TITLE
SRV_Channels: set_output_pwm_chan_timeout_ms()

### DIFF
--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -383,6 +383,9 @@ Servo Channels (SRV_Channels:)
 
 - :code:`get_output_pwm(output_function)` - Returns first servo output PWM value an output assigned output_function (See ``SERVOx_FUNCTION`` parameters ). False if none is assigned.
 
+- :code:`set_output_pwm_chan_timeout(channel, pwm, timeout)` - Sets servo channel to specified PWM for a time in ms. This overrides any commands from the autopilot until the timeout expires.
+
+
 Servo Output
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Adds documentation for SRV_Channels:set_output_pwm_chan_counter(). Dependent on [this PR in ardupilot](https://github.com/ArduPilot/ardupilot/pull/14366).