### PR TITLE
AP_Scripting: add binding for get_output_pwm

### DIFF
--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -381,6 +381,8 @@ Servo Channels (SRV_Channels:)
 
 - :code:`find_channel(output_function)` - Returns first servo output number -1 of an output assigned output_function (See ``SERVOx_FUNCTION`` parameters ). False if none is assigned.
 
+- :code:`get_output_pwm(output_function)` - Returns first servo output PWM value an output assigned output_function (See ``SERVOx_FUNCTION`` parameters ). False if none is assigned.
+
 Servo Output
 ~~~~~~~~~~~~
 


### PR DESCRIPTION
Dependent on [this PR](https://github.com/ArduPilot/ardupilot/pull/14386).