### PR TITLE
Input Interface of the Navio2 is PPM not PWM

### DIFF
--- a/common/source/docs/common-navio2-overview.rst
+++ b/common/source/docs/common-navio2-overview.rst
@@ -34,7 +34,7 @@ Specifications
 -  **Interfaces**
 
    -  UART, I2C, ADC for extensions
-   -  PWM/S.Bus input
+   -  PPM/S.Bus input
    -  14 PWM servo outputs
     
 -  **Dimensions**


### PR DESCRIPTION
e.g. see https://docs.emlid.com/navio2/ardupilot/hardware-setup/