### PR TITLE
Fixed Cubepilot pages issues 

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -20,9 +20,9 @@ Open hardware
     F4BY <common-f4by>
     Hex/ProfiCNC Cube Black <common-thecube-overview>
     Hex/ProfiCNC Cube Orange <common-thecubeorange-overview>
-    Hex/ProfiCNC Cube Purple <ommon-thecubepurple-overview>
+    Hex/ProfiCNC Cube Purple <common-thecubepurple-overview>
     Hex/ProfiCNC Cube Yellow <common-thecubeyellow-overview>
-    Hex/ProfiCNC Cube Green <http://www.proficnc.com/all-products/79-the-cube.html>
+    Hex/ProfiCNC Cube Green <https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview>
     mRo Pixhawk <common-pixhawk-overview>
     mRo Pixracer <common-pixracer-overview>
     mRo X2.1 <https://store.mrobotics.io/mRo-X2-1-Rev-2-p/mro-x2.1rv2-mr.htm>

--- a/common/source/docs/common-thecube-overview.rst
+++ b/common/source/docs/common-thecube-overview.rst
@@ -419,11 +419,11 @@ Cubepilot Ecosystem
 More Information
 ================
 
-For more detials and instructions on the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
+For more information and instructions on setting up and using the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
 
-For help and support see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
+For technical help and support on the cubepilot system see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
 
-More info on Cubpilot see  `www.proficnc.com  <http://www.proficnc.com>`__
+Company information on Cubpilot can be found at  `www.proficnc.com  <http://www.proficnc.com>`__
 
 
 Carrier Board Design

--- a/common/source/docs/common-thecubeorange-overview.rst
+++ b/common/source/docs/common-thecubeorange-overview.rst
@@ -1,8 +1,8 @@
 .. _common-thecubeorange-overview:
 
-=================
+=====================================
 The Cube Orange With ADSB-In Overview
-=================
+=====================================
 
 .. image:: ../../../images/Cube_orange_adsb.jpg
     :target: ../_images/Cube_orange_adsb.jpg
@@ -11,21 +11,21 @@ The Cube Orange With ADSB-In Overview
 System Features
 ===============
 
-The Cube Orange autopilot is the latest and most powerful model in the Cubepilot ecosystem. Designed for hobby users, commercial system integrators and UAS manufacturers the Cube Orange autopilot is part of a wide ecosystem of autopilot modules and carrier boards. Because all Cube models are compatible with all carriers this allows users to choose an off the shelf carrier board that best suits their needs. System designers are able to integrate the Cube directly into their designs via published carrier board specifications. 
+The Cube Orange autopilot is the latest and most powerful model in the Cubepilot ecosystem. Designed for hobby users, commercial system integrators and UAS manufacturers the Cube Orange autopilot is part of a wide ecosystem of autopilot modules and carrier boards. All Cube models are compatible with all carriers which allows users to choose an off the shelf carrier board that best suits their needs. System designers are able to integrate the Cube directly into their designs via published carrier board specifications. 
 
 
 The Cube Orange is available as a standalone module or as a package with a new updated version of the original carrier board that now includes an integrated ADS-B In module from uAvionics. 
 
 ADS-B Carrier Board
-==================
+===================
 
-The new ADS-B carrier boards overall footprint is identical to the standard versions and main changes compared to original carrier are as follows:
+The new ADS-B carrier boards overall footprint is identical to the standard versions and the main changes compared to the original carrier are as follows:
 
 -  Integration of uAvonix ADS-B IN Receiver on Serial 5
 -  Built-In ADS-B Antenna 
 -  Removal of Intel Edison Bay and Debug USB Ports
 
-All other specification and external connections remain identical to the original board s listed on the Cube Black page.
+All other specification and external connections remain identical to the original board as listed on the Cube Black page.
 
 Cube Orange Features
 ====================
@@ -35,7 +35,7 @@ Cube Orange Features
 -  2 sets of IMU are vibration-isolated mechanically, reducing the effect of frame vibration to state estimation
 -  IMUs are temperature-controlled by onboard heating resistors, allowing optimum working temperature of IMUs
 -  The entire flight management unit(FMU) and inertial management unit(IMU) are housed in a reatively small form factor (a cube). 
--  Fully Cubepilot carrierboard compatible, all inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suite their specific needs now and in the future. 
+-  Fully Cubepilot carrierboard compatible, all inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suit their specific needs now and in the future. 
 
 Specifications
 ==============
@@ -49,8 +49,8 @@ Specifications
 -  **Sensors**
 
    - Three redundant IMUs (accels, gyros and compass)
-   -  ICM 20649 integrated accelerometer / gyro, MS5611 Barometer on base board
-   -  InvenSense ICM20602 IMU,ICM20948 IMU/MAG, MS5611 Barometer on temperature controlled, vibration isolated board
+   -  ICM 20649 integrated accelerometer / gyro, MS5611 barometer on base board
+   -  InvenSense ICM20602 IMU,ICM20948 IMU/MAG, MS5611 barometer on temperature controlled, vibration isolated board
    -  All sensors connected via SPI.
 
 -  **Power**
@@ -81,7 +81,7 @@ Specifications
 The Cube connector pin assignments
 ==================================
 
-All other specification and external connections remain identical to the original board s listed on the Cube Black page.
+All other specification and external connections remain identical to the original board as listed on the Cube Black page.
 
 Cubepilot Ecosystem
 ===================
@@ -93,17 +93,17 @@ Cubepilot Ecosystem
 More Information
 ================
 
-For more detials and instructions on the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
+For more information and instructions on setting up and using the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
 
-For help and support see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
+For technical help and support on the cubepilot system see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
 
-More info on Cubpilot see  `www.proficnc.com  <http://www.proficnc.com>`__
+Company information on Cubpilot can be found at  `www.proficnc.com  <http://www.proficnc.com>`__
 
 
 Carrier Board Design
 ====================
 
-The reference design files of the standard carrier board are available in `github  <https://github.com/proficnc/The-Cube>`__, or `here <https://github.com/ArduPilot/Schematics/tree/master/ProfiCNC>`__ ,this serve as a starting point for designers to design their own system based on The Cube autopilot.
+The reference design files of the standard carrier board are available in `github  <https://github.com/proficnc/The-Cube>`__, or `here <https://github.com/ArduPilot/Schematics/tree/master/ProfiCNC>`__ ,this serves as a starting point for designers to design their own system based on The Cube autopilot.
 
 Where to Buy
 ============

--- a/common/source/docs/common-thecubepurple-overview.rst
+++ b/common/source/docs/common-thecubepurple-overview.rst
@@ -1,8 +1,8 @@
 .. _common-thecubepurple-overview:
 
-=================
+========================
 The Cube Purple Overview
-=================
+========================
 
 .. image:: ../../../images/Cube_purple.jpg
     :target: ../_images/Cube_purple.jpg
@@ -11,11 +11,11 @@ The Cube Purple Overview
 System Features
 ===============
 
-The Cube Purple autopilot is designed for ground based applications such as boat, car or rover. Based on the Cube Black main module the purple is a much smaller platform for use cases where sensor redundancy is not required.
+The Cube Purple autopilot is designed for ground based applications such as boat, car or rover. Based on the Cube Black main module the purple is a much smaller platform for applications where sensor redundancy is not required.
 
 -  Single IMU sensor
 -  Single Baro Sensor
--  The entire flight management unit(FMU) and inertial management unit(IMU) are housed in a reatively small form factor (a cube). All inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suite their specific needs.
+-  The entire flight management unit(FMU) and inertial management unit(IMU) are housed in a reatively small form factor (a cube). All inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suit their specific needs.
 
 Specifications
 ==============
@@ -39,7 +39,9 @@ Carrier Board Mini
     :target: ../_images/CCarrier_mini.jpg
     :width: 360px
 
-Mini Carrier Board has the standardized DF17 connector which allows user to connect it to every version of the Cube flight controller. With smaller size and almost the same capability with standard carrier board, it can better fit-in to those applications which have size limits. Also, it can be equipped with the Cube Purple to better fulfil the requests from customers. Functionality of Carrier Board:
+Mini Carrier Board has the standardized DF17 connector which allows the user to connect it to every version of the Cube flight controller. With smaller size and almost the same capability with the standard carrier board, it can better fit in to those applications which have size limits. Also, it can be equipped with the Cube Purple to better fulfil the requests from customers. 
+
+Functionality of Carrier Board:
 
 Dual power input (for redundant power, automatic switch to another power when one fails)
 Power distribution (limit the current at each connector, avoiding overloading when one device draws too large current)
@@ -51,7 +53,7 @@ Voltage protection (over or under voltage protection, the circuit will be shut d
 The Cube connector pin assignments
 ==================================
 
-All other specification and external connections remain identical to the original board s listed on the Cube Black page.
+All other specification and external connections remain identical to the original board as listed on the Cube Black page.
 
 Cubepilot Ecosystem
 ===================
@@ -63,17 +65,17 @@ Cubepilot Ecosystem
 More Information
 ================
 
-For more detials and instructions on the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
+For more information and instructions on setting up and using the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
 
-For help and support see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
+For technical help and support on the cubepilot system see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
 
-More info on Cubpilot see  `www.proficnc.com  <http://www.proficnc.com>`__
+Company information on Cubpilot can be found at  `www.proficnc.com  <http://www.proficnc.com>`__
 
 
 Carrier Board Design
 ====================
 
-The reference design files of the standard carrier board are available in `github  <https://github.com/proficnc/The-Cube>`__, or `here <https://github.com/ArduPilot/Schematics/tree/master/ProfiCNC>`__ ,this serve as a starting point for designers to design their own system based on The Cube autopilot.
+The reference design files of the standard carrier board are available in `github  <https://github.com/proficnc/The-Cube>`__, or `here <https://github.com/ArduPilot/Schematics/tree/master/ProfiCNC>`__ ,this serves as a starting point for designers to design their own system based on The Cube autopilot.
 
 Where to Buy
 ============

--- a/common/source/docs/common-thecubeyellow-overview.rst
+++ b/common/source/docs/common-thecubeyellow-overview.rst
@@ -1,8 +1,8 @@
 .. _common-thecubeyellow-overview:
 
-=================
+========================
 The Cube Yellow Overview
-=================
+========================
 
 .. image:: ../../../images/Cube_yellow_module.jpg
     :target: ../_images/Cube_yellow_module.jpg
@@ -11,9 +11,9 @@ The Cube Yellow Overview
 System Features
 ===============
 
-The Cube Yellow autopilot is new model in the Cubepilot ecosystem, designed for hobby users, commercial system integrators and UAS manufacturers the Cube Yellow is based on the Arm STM32F7 series SOC. Sitting directly between the Cube Black and Orange the this model offers better preference and newer sensors over the Cube Black while retaining F series SOC compatibility. 
+The Cube Yellow autopilot is a new model in the Cubepilot ecosystem, designed for hobby users, commercial system integrators and UAS manufacturers the Cube Yellow is based on the Arm STM32F7 series SOC. Sitting directly between the Cube Black and Orange this model offers better performance and newer sensors over the Cube Black while retaining F series SOC compatibility. 
 
-Just like the other models the Yellow is part of a wide ecosystem of autopilot modules and carrier boards. Because all Cube models are compatible with all carriers this allows users to choose an off the shelf carrier board that best suits their needs. System designers are able to integrate the Cube directly into their designs via published carrier board specifications. 
+Just like the other models the Yellow is part of a wide ecosystem of autopilot modules and carrier boards. All the Cube models are compatible with all of the carriers which allows users to choose an off the shelf carrier board design that best suits their needs. System designers are able to integrate the Cube directly into their designs via published carrier board specifications. 
 
 
 Cube Yellow Features
@@ -24,7 +24,7 @@ Cube Yellow Features
 -  2 sets of IMU are vibration-isolated mechanically, reducing the effect of frame vibration to state estimation
 -  IMUs are temperature-controlled by onboard heating resistors, allowing optimum working temperature of IMUs
 -  The entire flight management unit(FMU) and inertial management unit(IMU) are housed in a reatively small form factor (a cube). 
--  Fully Cubepilot carrierboard compatible, all inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suite their specific needs now and in the future. 
+-  Fully Cubepilot carrierboard compatible, all inputs and outputs go through a 80-pin DF17 connector, allowing a plug-in solution for manufacturers of commercial systems. Manufacturers can design their own carrier boards to suit their specific needs now and in the future. 
 
 Specifications
 ==============
@@ -38,8 +38,8 @@ Specifications
 -  **Sensors**
 
    -  Three redundant IMUs (accels, gyros and compass)
-   -  ICM 20649 integrated accelerometer / gyro, MS5611 Barometer on base board
-   -  InvenSense ICM20602 IMU,ICM20948 IMU/MAG, MS5611 Barometer on temperature controlled, vibration isolated board
+   -  ICM 20649 integrated accelerometer / gyro, MS5611 barometer on base board
+   -  InvenSense ICM20602 IMU,ICM20948 IMU/MAG, MS5611 barometer on temperature controlled, vibration isolated board
    -  All sensors connected via SPI.
 
 -  **Power**
@@ -83,11 +83,11 @@ Cubepilot Ecosystem
 More Information
 ================
 
-For more detials and instructions on the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
+For more information and instructions on setting up and using the Cubepilot system see  `Cubepilot Docs  <https://docs.cubepilot.org/user-guides/>`__
 
-For help and support see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
+For technical help and support on the cubepilot system see  `Cubepilot Forum  <https://discuss.cubepilot.org/>`__
 
-More info on Cubpilot see  `www.proficnc.com  <http://www.proficnc.com>`__
+Company information on Cubpilot can be found at  `www.proficnc.com  <http://www.proficnc.com>`__
 
 
 Carrier Board Design


### PR DESCRIPTION
Hi guys, I have made the changes and tested this on a local build on Plane,Copter and Rover.  

I believe I now have this correct but please give feedback as this is all new to me, on a learning curve for sure. 

I also 'think' I have quieted the commits. 

**Changes made** 

Corrected spelling errors and formatting on Cube Orange page.

Corrected formatting and spelling errors on Cube Yellow page.

Corrected  spelling and formatting errors on Cube Purple page.

Changed link to Cube Green to Cubepilot, (I will create a page for this in the future for the Solo) 

Changed links to support and docs on all pages above to be tidier and clearer.

Corrected link to Cube Purple page from common autopilot hardware as was missing first letter.