### PR TITLE
Fix: Rover parameters versioning

### DIFF
--- a/update.py
+++ b/update.py
@@ -59,7 +59,7 @@ args = parser.parse_args()
 #print(args.site)
 #print(args.clean)
 
-PARAMETER_SITE={'rover':'Rover', 'copter':'ArduCopter','plane':'ArduPlane','antennatracker':'AntennaTracker' }
+PARAMETER_SITE={'rover':'APMrover2', 'copter':'ArduCopter','plane':'ArduPlane','antennatracker':'AntennaTracker' }
 LOGMESSAGE_SITE={'rover':'Rover', 'copter':'Copter','plane':'Plane','antennatracker':'Tracker' }
 error_count = 0
 


### PR DESCRIPTION
It does some workaround to re-enable versioning for Rover parameters files. Tested locally.

It also inserts the ":orphan:" tag in the files in order to stop warnings for parameters files for old versions.