### PR TITLE
Update common-partners.rst

### DIFF
--- a/common/source/docs/common-partners.rst
+++ b/common/source/docs/common-partners.rst
@@ -154,7 +154,7 @@ Details on the Partners Program and how to join can be found on the :doc:`Partne
             :target:  http://ttrobotix.com
 
     *
-      - .. image:: ../../../images/supporters/supporters_logo_Air_Supply_Aerial.png
+      - .. image:: ../../../images/supporters/supporters_logo_Air-Supply-Aerial.png
             :width: 250px
             :align: center
             :target:  https://airsupply.com


### PR DESCRIPTION
when I updated the Air Supply logo a little while back it seems I had a typo in the image filename.  Rather than fix that, I'm just pointing to the name of the new logo