### PR TITLE
Backup engine for wiki building.

### DIFF
--- a/update.py
+++ b/update.py
@@ -38,6 +38,9 @@ import filecmp
 import time
 import sys
 import hashlib
+from datetime import datetime
+import distutils
+from distutils import dir_util
 
 DEFAULT_COPY_WIKIS =['copter', 'plane', 'rover']
 ALL_WIKIS =['copter', 'plane', 'rover','antennatracker','dev','planner','planner2','ardupilot', 'mavproxy']
@@ -53,6 +56,8 @@ parser.add_argument('--clean', action='store_true', help="Does a very clean buil
 parser.add_argument('--cached-parameter-files', action='store_true', help="Do not re-download parameter files")
 parser.add_argument('--parallel', type=int, help="limit parallel builds, -1 for unlimited", default=1)
 parser.add_argument('--destdir', default="/var/sites/wiki/web", help="Destination directory for compiled docs")
+parser.add_argument('--enablebackups', action='store_true', default=False, help="Enable several backups up to const N_BACKUPS_RETAIN in --backupdestdir folder")
+parser.add_argument('--backupdestdir', default="/var/sites/wiki-backup/web", help="Destination directory for compiled docs")
 parser.add_argument('--paramversioning', action='store_true', default=False, help="Build multiple parameters pages for each vehicle based on its firmware repo.")
 parser.add_argument('--verbose', dest='verbose', action='store_false', default=True, help="show debugging output")
 args = parser.parse_args()
@@ -62,6 +67,8 @@ args = parser.parse_args()
 PARAMETER_SITE={'rover':'APMrover2', 'copter':'ArduCopter','plane':'ArduPlane','antennatracker':'AntennaTracker' }
 LOGMESSAGE_SITE={'rover':'Rover', 'copter':'Copter','plane':'Plane','antennatracker':'Tracker' }
 error_count = 0
+N_BACKUPS_RETAIN = 10
+
 
 def debug(str_to_print):
     """Debug output if verbose is set."""
@@ -136,6 +143,7 @@ def build_one(wiki):
     subprocess.check_call(["nice", "make", "clean"], cwd=wiki)
     subprocess.check_call(["nice", "make", "html"], cwd=wiki)
 
+
 def sphinx_make(site):
     """
     Calls 'make html' to build each site
@@ -172,6 +180,7 @@ def sphinx_make(site):
                 if p.exitcode != 0:
                     error_count += 1
         time.sleep(0.1)
+
 
 def copy_build(site):
     """
@@ -217,6 +226,64 @@ def copy_build(site):
         # delete the old directory
         print('DEBUG: removing %s' % olddir )
         shutil.rmtree(olddir)
+
+
+def copy_and_keep_build(site):
+    """
+    Copies each site into the target location and keep last "n" builds as backups
+    """
+    global error_count
+    for wiki in ALL_WIKIS:
+        if site=='common':
+            continue
+        if site is not None and site != wiki:
+            continue
+        debug('coping: %s' % wiki)
+        targetdir = os.path.join(args.destdir, wiki)
+        distutils.dir_util.mkpath(targetdir)
+
+        if os.path.exists(targetdir):
+            olddir = os.path.join(args.backupdestdir, str(building_time + '-wiki-bkp'), str(wiki) )
+            debug('Checking %s' % olddir )
+            distutils.dir_util.mkpath(olddir)
+            debug('Moving %s into %s' % (targetdir,olddir))
+            shutil.move(targetdir, olddir)
+
+            sourcedir = os.path.join(os.path.abspath(os.getcwd()), str(wiki), 'build', 'html')
+            html_moved_dir = os.path.join(args.destdir, 'html')
+            try:
+                #subprocess.check_call(['mv', sourcedir, html_moved_dir])
+                shutil.move(sourcedir, html_moved_dir)
+                # Rename move! (single move to html/* failed)
+                #subprocess.check_call(['mv', html_moved_dir ,targetdir])
+                shutil.move(html_moved_dir, targetdir)
+                debug("Moved to %s" % targetdir)
+            except:
+                error("FAIL moving output to %s" % targetdir)
+            finally:
+                debug("Creating a backup in %s" % olddir)
+                # subprocess.check_call(['cp', '-r', targetdir ,olddir])
+                distutils.dir_util.copy_tree(targetdir, olddir, preserve_symlinks=0)
+        else:
+            error("FAIL when looking for folder %s" % targetdir)
+
+
+def delete_old_wiki_backups(folder, n_to_keep):
+    try:
+        debug('Checking number of number of backups in folder %s' % folder)
+        backup_folders = glob.glob(folder  + "/*-wiki-bkp/")
+        backup_folders.sort()
+        if len(backup_folders) > n_to_keep:
+            for i in range(0, len(backup_folders) - n_to_keep):
+                if '-wiki-bkp' in str(backup_folders[i]):
+                    debug('Deleting folder %s' % str(backup_folders[i]))
+                    shutil.rmtree(str(backup_folders[i]))
+                else:
+                    debug('Ignoring folder %s because it does not look like a auto generated wiki backup folder' % str(backup_folders[i]))
+        else:
+            debug('No old backups to delete in %s' % folder)
+    except Exception as e:
+        error('Error on deleting some previous wiki backup folders: %s' % e)
 
 
 def generate_copy_dict(start_dir=COMMON_DIR):
@@ -383,6 +450,7 @@ def is_the_same_file(file1, file2):
 
     return(digests[0] == digests[1])
 
+
 def fetch_versioned_parameters(site=args.site):
     """
     It relies on "build_parameters.py" be executed before the "update.py"     
@@ -546,6 +614,8 @@ def put_cached_parameters_files_in_sites(site=args.site):
 
 ###############################################################################################################
 
+now = datetime.now() 
+building_time = now.strftime("%Y-%m-%d-%H-%M-%S")
 
 if args.paramversioning:                
     fetch_versioned_parameters(args.site)   # Parameters for all versions availble on firmware.ardupilot.org    
@@ -561,7 +631,15 @@ if args.paramversioning:
     put_cached_parameters_files_in_sites(args.site)
     cache_parameters_files(args.site)
 
-copy_build(args.site)
+
+if args.enablebackups:                
+    copy_and_keep_build(args.site)
+    delete_old_wiki_backups(args.backupdestdir, N_BACKUPS_RETAIN)
+else:
+    copy_build(args.site)
+
+
+
 
 # To navigate locally and view versioning script for parameters working is necessary run Chrome as "chrome --allow-file-access-from-files". Otherwise it will appear empty locally and working once is on the server.
 


### PR DESCRIPTION
This PR enables the "--enablebackups" flag in the build script. When used, this keeps up to N_BACKUPS_RETAIM previous wiki builds as backups.

The default used folder is supposed to be another http site.  It will enable navigation between those versions to check for errors or make it easier to get a built copy online due to some issues.