### PR TITLE
copter: Change from GSC to GCS

### DIFF
--- a/copter/source/docs/ac2_followme.rst
+++ b/copter/source/docs/ac2_followme.rst
@@ -1,7 +1,7 @@
 .. _ac2_followme:
 
 ============================
-Follow Me Mode (GSC Enabled)
+Follow Me Mode (GCS Enabled)
 ============================
 
 Follow Me mode makes it possible for you to have your copter follow you

--- a/copter/source/docs/flight-modes.rst
+++ b/copter/source/docs/flight-modes.rst
@@ -152,7 +152,7 @@ Full list of flight modes
     Flip <flip-mode>
     FlowHold <flowhold-mode>
     Follow <follow-mode>
-    Follow Me (GSC Enabled) <ac2_followme>
+    Follow Me (GCS Enabled) <ac2_followme>
     Guided <ac2_guidedmode>
     Heli_Autorotate <traditional-helicopter-autorotation-mode>
     Land <land-mode>


### PR DESCRIPTION
I would change the GCS to indicate the ground control station.