### PR TITLE
ICM20689 does not have compass

### DIFF
--- a/common/source/docs/common-holybro-kakutef4.rst
+++ b/common/source/docs/common-holybro-kakutef4.rst
@@ -22,7 +22,7 @@ Specifications
 
 -  **Sensors**
 
-   -  InvenSense ICM20689 IMU (accel, gyro, compass) on vibration isolating foam
+   -  InvenSense ICM20689 IMU (accel, gyro) on vibration isolating foam
    -  BMP280 barometers
 
 -  **Power**


### PR DESCRIPTION
Updated line 25, as line 123 already stated correctly, ICM20689 does not include any compass.