### PR TITLE
Fix pix32v5 file charset

### DIFF
--- a/common/source/docs/common-holybro-pix32v5.rst
+++ b/common/source/docs/common-holybro-pix32v5.rst
@@ -24,8 +24,8 @@ Specifications
 ==============
 
 -  **Processors**
-     - 32 Bit Arm è¢Ó Cortexè¢Ó -M7, 216MHz, 2MB memory, 512KB RAM
-     - 32 Bit Arm è¢Ó Cortexè¢Ó -M3 IO co-processor, 24MHz, 8KB SRAM
+     - 32 Bit Arm Cortex -M7, 216MHz, 2MB memory, 512KB RAM
+     - 32 Bit Arm Cortex -M3 IO co-processor, 24MHz, 8KB SRAM
 
 -  **Sensors**
      - Accel/Gyro: ICM-20689


### PR DESCRIPTION
The wiki building did break due to file common-holybro-pix32v5.rst charset was not set to utf8.

This PR converts the file to ut8 and remove bad characters.