### PR TITLE
Insert Trademark symbol for ARM Cortex in pix32v5

### DIFF
--- a/common/source/docs/common-holybro-pix32v5.rst
+++ b/common/source/docs/common-holybro-pix32v5.rst
@@ -1,5 +1,8 @@
 .. _common-holybro-pix32v5:
 
+.. role:: raw-html(raw)
+   :format: html
+
 =================
 Pix32 v5
 =================
@@ -24,8 +27,8 @@ Specifications
 ==============
 
 -  **Processors**
-     - 32 Bit Arm Cortex -M7, 216MHz, 2MB memory, 512KB RAM
-     - 32 Bit Arm Cortex -M3 IO co-processor, 24MHz, 8KB SRAM
+     - 32 Bit Arm Cortex-M7 :raw-html:`&reg;` , 216MHz, 2MB memory, 512KB RAM
+     - 32 Bit Arm Cortex-M3 :raw-html:`&reg;` IO co-processor, 24MHz, 8KB SRAM
 
 -  **Sensors**
      - Accel/Gyro: ICM-20689


### PR DESCRIPTION
This (re)insert the copyright symbol from PR #2915

