### PR TITLE
Add User Alert Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@
 /plane/source/docs/logmessages.rst
 /rover/source/docs/logmessages.rst
 /antennatracker/source/docs/logmessages.rst
+
+# Javascript files
+antennatracker/source/_static/useralerts.js
+copter/source/_static/useralerts.js
+dev/source/_static/useralerts.js
+plane/source/_static/useralerts.js
+rover/source/_static/useralerts.js

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ clean: $(ALL_CLEAN)
 
 %_common: %
 	echo "Copying common files to $</source/docs"
-	rsync -av common/source/docs/common-*rst $</source/docs/
+	rsync -av common/source/docs/common-*rst $</source/docs/ && rsync -av common/source/_static/*.js $</source/_static/
 
 %_clean: %
 	$(MAKE) -C $< clean

--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -167,6 +167,8 @@ html_favicon = '../../images/favicon_default.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = ['./useralerts.js']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/antennatracker/source/index.rst
+++ b/antennatracker/source/index.rst
@@ -52,3 +52,4 @@ This manual will guide you through setup and configuration process.
     How to Operate <docs/how-to-operate>
     docs/common-appendix
     docs/common-table-of-contents
+    User Alerts <docs/common-user-alerts>

--- a/common/source/_static/useralerts.js
+++ b/common/source/_static/useralerts.js
@@ -1,0 +1,86 @@
+/*
+Script for downloading and displaying User Alerts in the common-user-alerts.rst page
+Requires a table with the css class "useralerts-list"
+Written by Stephen Dade (stephen_dade@hotmail.com)
+*/
+$(document).ready(function() {
+    $.getScript("https://firmware.ardupilot.org/userAlerts/manifest.js", function() {
+    // figure out which vehicle's wiki we are in
+    var url = window.location.href;
+    if (url.search("copter") !== -1) {
+        var vehicle = 'copter';
+    }
+    if (url.search("plane") !== -1) {
+        var vehicle = 'plane';
+    }
+    if (url.search("rover") !== -1) {
+        var vehicle = 'rover';
+    }
+    if (url.search("antennatracker") !== -1) {
+        var vehicle = 'tracker';
+    }
+    var content = '';
+    //go through all the user alerts and generate table rows
+    for (var key in userAlerts) {
+            for (var i = 0, len = userAlerts[key].affectedFirmware.length; i < len; i++) {
+                //console.log(userAlerts[key].affectedFirmware[i]);
+              if (userAlerts[key].affectedFirmware[i] === "all" || userAlerts[key].affectedFirmware[i] === vehicle) {
+                    content += '<tr id="' + key + '">';
+                    content += '<td>' + key.slice(0, -5) + '</td>';
+                    content += '<td>' + ((userAlerts[key].hardwareLimited.length === 0 ) ? 'all' : userAlerts[key].hardwareLimited) + '</td>';
+
+                    //figure out versions affected. 4 combinations
+                    var versionAffected = ''
+                    // all versions, no fix
+                    if (userAlerts[key].versionFrom[vehicle] === undefined &&
+                    userAlerts[key].versionFixed[vehicle] === undefined) {
+                        versionAffected = 'All';
+                    }
+                    // some versions, no fix
+                    else if (userAlerts[key].versionFrom[vehicle] !== undefined &&
+                    userAlerts[key].versionFixed[vehicle] === undefined) {
+                        versionAffected = userAlerts[key].versionFrom[vehicle] + ' and above';
+                    }
+                    // all versions, there is a fix
+                    else if (userAlerts[key].versionFrom[vehicle] === undefined &&
+                    userAlerts[key].versionFixed[vehicle] !== undefined) {
+                        versionAffected = 'All versions < ' + userAlerts[key].versionFixed[vehicle];
+                    }
+                    // some versions, there is a fix
+                    else if (userAlerts[key].versionFrom[vehicle] !== undefined &&
+                    userAlerts[key].versionFixed[vehicle] !== undefined) {
+                        versionAffected = userAlerts[key].versionFrom[vehicle] + ' to < ' + userAlerts[key].versionFixed[vehicle];
+                    }
+                    content += '<td>' + versionAffected + '</td>';
+
+                    content += '<td>' + userAlerts[key].description + '</td>';
+                    // if User Alert is resolved - suggest upgrade instead
+                    if (userAlerts[key].versionFixed[vehicle] === undefined) {
+                        content += '<td>' + userAlerts[key].mitigation + '</td>';
+                    }
+                    else {
+                        content += '<td>' + 'Upgrade to version ' + userAlerts[key].versionFixed[vehicle] +'</td>';
+                    }
+                    //figure out status - Open, patched in master, released in stable
+                    if (userAlerts[key].versionFixed[vehicle] === undefined) {
+                        if (userAlerts[key].fixCommit.length === 0) {
+                            content += '<td>Not fixed</td>';
+                        }
+                        else {
+                            content += '<td>Fixed in master, not released</td>';
+                        }
+                    }
+                    else {
+                        content += '<td>' + 'Fixed in version ' + userAlerts[key].versionFixed[vehicle] + '</td>';
+                    }
+                    content += '</tr>';
+                }
+            }
+        }
+        // dump the generated table into the tbody
+        $('.useralerts-list tbody').html(content);
+        // set styling
+        $('.useralerts-list tbody td').css('white-space', 'normal');
+        $('.useralerts-list thead th').css('white-space', 'normal');
+    });
+});

--- a/common/source/docs/common-user-alerts.rst
+++ b/common/source/docs/common-user-alerts.rst
@@ -1,5 +1,7 @@
 .. _common-user-alerts:
 
+[copywiki destination="copter,plane,rover,antennatracker"]
+
 ===========
 User Alerts
 ===========

--- a/common/source/docs/common-user-alerts.rst
+++ b/common/source/docs/common-user-alerts.rst
@@ -1,0 +1,35 @@
+.. _common-user-alerts:
+
+===========
+User Alerts
+===========
+
+A User Alert is a formal report of an ArduPilot issue that may affect the safe operation of a vehicle.
+
+All ArduPilot users are strongly encouraged to regularly check this page for any User Alerts that may affect their vehicles.
+
+User Alerts will only be for ArduPilot software issues. Manufacturer hardware will not be included at this stage, although this may be reviewed at a later date.
+
+The User Alert documentation is available on the :ref:`developer wiki <dev:user-alerts-developer>`.
+
+The following alerts are applicable:
+
+.. list-table::
+   :widths: 30 40 20 30 20 20
+   :header-rows: 1
+   :class: useralerts-list
+
+   * - Alert ID
+     - Boards Affected
+     - Versions Affected
+     - Description
+     - Mitigation
+     - Status
+
+   * - loading...
+     - loading...
+     - loading...
+     - loading...
+     - loading...
+     - loading...
+

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -166,6 +166,8 @@ html_favicon = '../../images/favicon_copter.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = ['./useralerts.js']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/copter/source/index.rst
+++ b/copter/source/index.rst
@@ -193,6 +193,7 @@ Getting more info
    Antenna Tracking <docs/common-antenna-tracking>
    Simulation <docs/common-simulation>
    Upcoming Features <docs/common-master-features>
+   User Alerts <docs/common-user-alerts>
    Appendix <docs/common-appendix>
    Full Table of Contents <docs/common-table-of-contents>
 

--- a/dev/source/_static/common_theme_override.css
+++ b/dev/source/_static/common_theme_override.css
@@ -1,0 +1,6 @@
+/* custom CSS for ArduPilot wiki */
+
+/* Table in user alerts page */
+table.useralerts-table td {
+    white-space: normal;
+}

--- a/dev/source/docs/user-alerts-developer.rst
+++ b/dev/source/docs/user-alerts-developer.rst
@@ -1,0 +1,149 @@
+.. _user-alerts-developer:
+
+==========================
+User Alerts for Developers
+==========================
+
+A User Alert is a formal report of an ArduPilot issue that may affect the safe operation of a vehicle. An "issue" is typically a bug report or GitHub Issue. "Safe Operation" is the ability of a vehicle to reliably respond to user commands in a timely manner AND the ability of the vehicle to reliably follow commanded actions in automated flight modes.
+
+Examples of Safe Operation issues include:
+
+- Corrupted packets in I2C bus locking up the flight controller
+- Non-commanded disarming whilst in-flight
+- Malformed stored waypoint causes vehicle to fly away whilst in AUTO mode
+- Triggering of the watchdog reset whilst in-flight
+
+Examples of issues which are NOT Safe Operation issues include:
+
+- Sub-optimal parameter values that lead to poor navigation performance
+- User error or misunderstanding of parameter configuration
+- Issues that, if experienced, an average user would be likely to safely recover from
+
+User Alerts will only be for ArduPilot software issues. Manufacturer hardware will not be included at this stage, although this may be reviewed at a later date.
+
+As per the open nature of ArduPilot, all User Alerts will be published publicly on `Github <https://github.com/ardupilot/useralerts>`__.
+
+The User Alerts system consists of 3 parts:
+
+- A process to raise, authorise and manage User Alerts
+- A method of storing and handling the User Alert data
+- The ability of applications (GCS software, websites) to ingest and use the User Alert data.
+
+
+Processes
+=========
+
+The process for entering a new User Alert is:
+
+1. Bug reported or suspected
+2. Issue raised on ArduPilot GitHub
+3. Developer decides if safety issue
+4. Developer raises PR on User Alert GitHub repo
+5. 2nd Developer reviews and confirms that it's a real ArduPilot software bug
+6. 3rd person confirms PR is filled out correctly and process has been followed
+7. PR in User Alert repo merged by authorised team member
+
+The process for resolving an active User Alert is:
+
+1. Patch created for ArduPilot
+2. Patch tested
+3. Patch merged into ArduPilot master
+4. Patch in stable ArduPilot release X.Y.Z
+5. Developer Raises PR on User Alert Github repo to update User Alert fields
+6. 2nd Developer reviews and confirms
+7. 3rd person confirms PR is filled out correctly and process has been followed
+8. PR in User Alert repo merged by authorised team member
+
+Data Structure
+==============
+
+
+The User Alert data will be hosted on a `Github repository <https://github.com/ardupilot/useralerts>`__ under the ArduPilot organisation.
+
+The repository will contain the following file/folder structure:
+
+- README.md
+- examples
+
+  - EX00001.json
+  - ...
+
+- alerts
+
+  - UA00001.json
+  - ...
+
+Each User Alert will be a json file. There will be 1 User Alert per json file. An applicable User Alert will be stored in the ``alerts`` folder.
+
+The repository will have a small CI routine to confirm the validity of the json files with each PR.
+
+The json files themselves will each have the below fields. There are examples in the `Github repository <https://github.com/ArduPilot/useralerts/tree/master/examples>`__ (the ``EX0000x.json`` files).
+
+.. list-table::
+   :widths: 20 40 40
+   :header-rows: 1
+   :class: useralerts-table
+
+   * - Field Name
+     - Type
+     - Description
+
+   * - dateRaised
+     - ``YYYYMMDD``
+     - Date that this User Alert was raised.
+
+   * - affectedFirmware
+     - String array containing ``["all"]`` OR individual firmwares. For example: ``["copter", "sub", "tracker", "AP_Periph"]``
+     - Which ArduPilot firmware is affected. Use comma separated value to specify multiple vehicles if "all" does not work.
+
+   * - hardwareLimited
+     - String array of board names, using the names as per the build system. For example: ``["CubeBlack", "Pixhawk1-1M", "KakuteF4"]``
+     - If the User Alert is only applicable to certain boards, list the board names. An empty array indicates that all boards are affected.
+
+   * - description
+     - ``string``
+     - Textual description of the User Alert. Should be understandable by an average user.
+
+   * - mitigation
+     - ``string``
+     - Textual description of any mitigations that a user can take to prevent the issue from occurring BEFORE a patched ArduPilot is released. Should be understandable by an average user.
+
+   * - fixCommit
+     - String array of commit ID’s. For example: ``["23874b32c9281dja", "w9085bqwfskjdtnu243"]``
+     - Commit ID of the fix (on master branch) for this Issue. Can be multiple commits if the fix commits are spread among different libraries. Empty array if no fix yet. If this field is not ``[]``, it is considered that the issue has been fixed in master.
+
+   * - dateResolved
+     - ``YYYYMMDD``
+     - Date that this User Alert was resolved. "Resolved" in this case means a patched ArduPilot version has been released for ALL affected vehicle and board types, and no further edits to this User Alert are expected.
+
+   * - linkedIssue
+     - ``string``
+     - URL to Issue in ArduPilot GitHub repo. Optional
+
+   * - linkedInfo
+     - String array of URLs
+     - URLs to any supporting information about the issue, such as forum posts. Optional
+
+   * - linkedPR
+     - ``string``
+     - URL to the fix PR in ArduPilot GitHub repo. Blank if there is not PR yet.
+
+   * - versionFrom
+     - Dict of firmware=version. For example: ``{"copter": "4.0.1", "plane": "4.0.5"}``
+     - ArduPilot release which introduced the issue, if known.  Empty assumes all previous versions. The dict must cover all firmwares listed in "Affected firmware".
+
+   * - versionFixed
+     - Dict of firmware=version. FOr example: ``{"copter": "4.0.1", "plane": "4.0.5"}``
+     - ArduPilot release which contains fix. List must cover all firmwares listed in "Affected firmware". It is assumed that all versions between VersionFrom and this are affected by the User Alert. This field is an empty dict if there is no fixed version yet
+
+
+Application Ingestion
+=====================
+
+To make application ingestion easier, there will be a generated manifest file listing all user alerts. These can then be filtered by the ``versionFrom``, ``versionFixed``, ``affectedFirmware`` and ``hardwareLimited`` fields to match with the user's autopilot and display any relevant user alerts.
+
+There are URL's for both an example manifest (for testing purposes) and the actual user alerts manifest:
+
+- URL for example User Alerts: https://firmware.ardupilot.org/userAlerts/exampleManifest.json
+- URL for User Alerts: https://firmware.ardupilot.org/userAlerts/manifest.json
+

--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -158,6 +158,7 @@ Full Table of Contents
     GSoC 2020 project ideas <docs/gsoc-ideas-list>
     Wiki Editing Guide <docs/common-wiki_editing_guide>
     USB IDs <docs/USB-IDs>
+    User Alerts <docs/user-alerts-developer>
     Upcoming Features <docs/common-master-features>
     Appendix <docs/common-appendix>
     Full Table of Contents <docs/common-table-of-contents>

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -165,6 +165,8 @@ html_favicon = '../../images/favicon_plane.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = ['./useralerts.js']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/plane/source/index.rst
+++ b/plane/source/index.rst
@@ -113,6 +113,7 @@ Monitor https://discuss.ardupilot.org/c/arduplane for plane-related announcement
     Use-Cases and Applications <docs/common-use-cases-and-applications>
     Antenna Tracking <docs/common-antenna-tracking>
     Simulation <docs/common-simulation>
+    User Alerts <docs/common-user-alerts>
     Upcoming Features <docs/common-master-features>
     Appendix <docs/common-appendix>
     Fixed Wing FAQ <docs/fixed-wing-faq>

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -164,6 +164,8 @@ html_favicon = '../../images/favicon_rover.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_js_files = ['./useralerts.js']
+
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
 # directly to the root of the documentation.

--- a/rover/source/index.rst
+++ b/rover/source/index.rst
@@ -44,6 +44,7 @@ automation in our :ref:`Video Demos <rover-video-demonstrations>`).
     Use-Cases and Applications <docs/common-use-cases-and-applications>
     Antenna Tracking <docs/common-antenna-tracking>
     Simulation <docs/common-simulation>
+    User Alerts <docs/common-user-alerts>
     Upcoming Features <docs/common-master-features>
     Appendix <docs/common-appendix>
     Full Table of Contents <docs/common-table-of-contents>


### PR DESCRIPTION
This PR adds:
-Developer documentation for handling and processing user alerts, based on document at https://docs.google.com/document/d/1vLX0uRuPjPImEvvol0YnI2afBFTTNbcackr2JBIw_yc/edit#
-User page for each firmware listing current user alerts. Note these are pulled directly by the client from https://firmware.ardupilot.org/userAlerts, so there is no need to process updates server-side. This did require a bunch of custom JS to perform the processing.

Note for reviewers:
To use the example user alert data, change the URL in ``useralerts.js`` to "https://firmware.ardupilot.org/userAlerts/exampleManifest.js". This will provide more useful data to test with.