### PR TITLE
removing apparently superfluous <th>value</th>

### DIFF
--- a/plane/source/docs/guide-tilt-rotor.rst
+++ b/plane/source/docs/guide-tilt-rotor.rst
@@ -133,7 +133,7 @@ You control that with 3 possible servo function values.
 .. raw:: html
 
    <table border="1" class="docutils">
-   <tr><th>SERVOn_FUNCTION</th><th>Value</th><th>Value</th></tr>
+   <tr><th>SERVOn_FUNCTION</th><th>Value</th></tr>
    <tr><td>41</td><td>Motor tilt</td></tr>
    <tr><td>75</td><td>Left Motor tilt</td></tr>
    <tr><td>76</td><td>Right Motor tilt</td></tr>


### PR DESCRIPTION
It appears that `<th>value</th>` appears twice in the table of Tilt Servo functions & values (https://ardupilot.org/plane/docs/guide-tilt-rotor.html#tilt-servos)