### PR TITLE
Sphinx: remove mercurial and change vimeo plugin location

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -12,7 +12,7 @@ if [ ${DISTRIBUTION_CODENAME} == 'Ubuntu' ]; then
   add-apt-repository universe
 fi
 apt-get -y update
-apt-get install -y unzip git imagemagick mercurial curl wget make
+apt-get install -y unzip git imagemagick curl wget make
 
 # Get pip through the official website to get the lastest release
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm -f get-pip.py
@@ -27,13 +27,7 @@ pip install git+https://github.com/ArduPilot/sphinx_rtd_theme.git -UI
 pip install git+https://github.com/sphinx-contrib/youtube.git -UI
 
 # and a vimeo plugin:
-hg clone https://bitbucket.org/jdouglass/sphinxcontrib.vimeo
-pushd sphinxcontrib.vimeo
-python setup.py build
-python setup.py install
-popd
-# remove vimeo plugin source as they belong to root
-rm -rf sphinxcontrib.vimeo
+pip install git+https://github.com/ArduPilot/sphinxcontrib.vimeo.git -UI
 
 # Say that we finish
 echo "Setup completed successfully !"


### PR DESCRIPTION
This is RFC.
It removed mercurial dependency to save some space and bandwidth on setup. It change the target to a clone of the original vimeo plugin on github. The plugin hasn't been updated from long time. Ideally we should put the plugin on ArduPilot github

It works as previously no issue spotted. We gain 40Mo of space and some second on environment setting. We also remove dependency to mercurial and bitbucket to have only git and github.