### PR TITLE
Scripts: Ensure js files are picked up

### DIFF
--- a/update.py
+++ b/update.py
@@ -341,7 +341,7 @@ def generate_copy_dict(start_dir=COMMON_DIR):
                     destination_file = open(targetfile, 'w', 'utf-8')
                     destination_file.write(content)
                     destination_file.close()
-            elif file.endswith(".css"):
+            elif file.endswith(".css") or file.endswith(".js"):
                 for wiki in ALL_WIKIS:
                     shutil.copy2(os.path.join(root, file), '%s/source/_static/' % wiki)
 


### PR DESCRIPTION
This is a follow-on to https://github.com/ArduPilot/ardupilot_wiki/pull/2926. A required js file wasn't picked up by the build system. This patch fixes this.

Tested locally and works fine.