### PR TITLE
dev: STIL: add MATLAB, Simulink and JSON pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 # Vagrant
 /.vagrant
 
+# VSCode
+/.vscode
+
 # Parameters multiversioning
 /copter/source/docs/parameters-Copter-*.rst
 /plane/source/docs/parameters-Plane-*.rst
@@ -66,3 +69,8 @@ copter/source/_static/useralerts.js
 dev/source/_static/useralerts.js
 plane/source/_static/useralerts.js
 rover/source/_static/useralerts.js
+ardupilot/source/_static/useralerts.js
+mavproxy/source/_static/useralerts.js
+planner/source/_static/useralerts.js
+planner2/source/_static/useralerts.js
+

--- a/dev/source/_static/common_theme_override.css
+++ b/dev/source/_static/common_theme_override.css
@@ -1,6 +1,42 @@
 /* custom CSS for ArduPilot wiki */
 
-/* Table in user alerts page */
-table.useralerts-table td {
-    white-space: normal;
+/* CSS for Partners logo list */
+table.partners-table {
+    width: 100%;
+}
+
+table.partners-table img {
+    width: 100% !important;
+    height: 100% !important;
+    object-fit: contain;
+}
+
+table.partners-table td {
+    background-color: #fff !important;
+    height: 15vw;
+}
+
+@media screen and (min-width: 1660px) {
+    table.partners-table td {
+        height: 250px;
+    }
+}
+
+@media screen and (max-width: 600px) {
+    table.partners-table td {
+        width: 100%;
+        display: block;
+        height: 20vw;
+        border: 1px solid #e1e4e5 !important;
+    }
+
+    table.partners-table, table.partners-table tbody {
+        display: block;
+    }
+}
+
+/* wiki top menu makes anchor links disappear under it, this hack fixes it */
+.section {
+    padding-top: 40px;
+    margin-top: -40px;
 }

--- a/dev/source/docs/MATLAB-Plotting.rst
+++ b/dev/source/docs/MATLAB-Plotting.rst
@@ -1,0 +1,90 @@
+.. _MATLAB-Plotting:
+
+==========================
+MATLAB Real Time Plotting
+==========================
+
+.. youtube:: m_cmR_wLe5c
+    :width: 100%
+
+The same high speed MATLAB UDP connection implemented for SITL can also be used to stream data from ArduPilot to MATLAB. 
+This allows real-time plotting and calculations to be done in MATLAB. This is only a one-way link, data cannot be passed 
+back to ArduPilot. ArduPilot can be using any of its `Simulation backends <https://youtu.be/YbOZWb8pddk>`__, including 
+MATLAB or Simulink provided they are running in a second MATLAB instance. This method can be used to short-cut any analysis 
+that would previously require a SITL test flight and log analysis.
+
+To avoid lag the data must be processed by MATLAB fast enough that the input buffer remains empty. A common use case for 
+such a tool is to prototype a function. Once the function is working as expected in MATLAB it can be manually translated 
+in to C++ and run natively within ArduPilot. The c++ result can then be included in the data streamed to MATLAB to be 
+compared with the prototype implementation. 
+
+Minimal changes are required to ArduPilot. Firstly the socket library must be included in the header file associated with 
+the cpp of interest. A socket private variable is then defined. For example:
+
+::
+
+  #include <AP_HAL/utility/Socket.h>
+  class streaming_example
+  {
+    private:
+    SocketAPM   sock{true};
+  };
+
+
+In the function of interest the data of is then assembled into a structure and sent out over UDP. Note that the structure 
+must be aligned, the simplest way to achieve this is to used the same variable types. The IP and port number should be set 
+to match those used in MATLAB.
+
+::
+
+  struct interesting_data {
+    float data1 = interesting_number1;
+    float data2 = interesting_number2;
+    float data3 = interesting_number2;
+  } data_to_send;
+
+  sock.sendto(&data_to_send, sideof(data_to_send), 127.0.0.1, 9002)
+
+The MATLAB code to receive the data would be as follows, the TCP/UDP/IP Toolbox should be added to the MATLAB path.
+
+::
+
+  % Init the UDP port
+  pnet('closeall')
+  u = pnet('udpsocket',9002); % port should match that used in AP
+  pnet(u,'setreadtimeout',0);
+
+  bytes_read =  3*4; % expecting 3 floats of 4 bytes each
+
+  while true
+
+    % see if there is anything waiting
+    in_bytes = pnet(u,'readpacket',bytes_read);
+
+    if in_bytes == 0
+        % wait for data
+        % you could use this wait to update your plots
+        while true
+            in_bytes = pnet(u,'readpacket',bytes_read);
+            if in_bytes > 0
+                break;
+            end
+        end
+    end
+
+    % read in data from AP
+    % C++ floats are a MATLAB SINGLE type, were expecting 3, cast to doubles as used by MATLAB natively
+    data_received = double(pnet(u,'read',3,'SINGLE','intel'));
+
+    % convert back to AP variables names for consistency
+    interesting_number1 = data_received(1);
+    interesting_number2 = data_received(2);
+    interesting_number3 = data_received(3);
+
+    % do something interesting here
+
+  end
+
+
+
+

--- a/dev/source/docs/MATLAB-Serial-driver.rst
+++ b/dev/source/docs/MATLAB-Serial-driver.rst
@@ -1,0 +1,72 @@
+.. _MATLAB-Serial-driver:
+
+==============================
+MATLAB Serial driver testing
+==============================
+
+The TCP/UDP/IP Toolbox can also be used to interact directly with SITL serial ports. This allows MATLAB to be used to replicate 
+a sensor protocol fore testing and debugging ArduPilot drivers. Unlike previous examples TCP is used and two way communication is 
+possible. By default SITL uses ports 5760 to 5763 for serial ports 0 to 3. The appropriate SERIALx_PROTOCOL parameter should 
+be set to the driver being tested, baud rate is not used. Such a MATLAB tool greatly speeds up development of drivers 
+removing the need to flash and test on real hardware.
+
+This is a example used to send a NMEA string from simulated water speed sensor:
+
+::
+
+  clc
+  clear
+
+  % This is a example of using MATLAB to test a sensor drive using TCP
+  % we send a NMEA messages at 1hz, note that this assumes that SITL is
+  % running at real time.
+
+  % NMEA is a basic one way protocol but more complex protocols can be
+  % implemented in the same way
+
+  % Use the same TCP/UDP libbary that is used for MALTAB SITL
+  addpath(genpath('../../SITL/examples/JSON/MATLAB/tcp_udp_ip_2.0.6'))
+
+  % if this dosn't work try the MALTAB SITL example first
+  pnet('closeall')
+
+  % Init the TCP port, 5763 is serial 2
+  u = pnet('tcpconnect','127.0.0.1',5763);
+
+  flipflop = true;
+  while(true)
+
+      if flipflop
+          % send MTW temp message
+          water_temp = 10 + randn();
+          NMEA_string = sprintf('$YXMTW,%0.1f,C',water_temp);
+      else 
+          % send VHW speed message
+          water_speed_knots = 5 + randn()*2;
+          water_speed_kph = water_speed_knots * 1.852;
+          NMEA_string = sprintf('$VWVHW,,T,,M,%0.1f,N,%0.1f,F',water_speed_knots,water_speed_kph);
+      end
+      flipflop = ~flipflop;
+
+      % Calculate the correct checksum
+      NMEA_string = add_checksum(NMEA_string);
+
+      % send to ap
+      pnet(u,'printf',sprintf('%s\r\n',NMEA_string));
+      pnet(u,'writepacket');
+
+      % also print to MATLAB console
+      fprintf("%s\n",NMEA_string);
+
+      % 1hz (ish)
+      pause(1);
+  end
+
+  function NMEA_string_out = add_checksum(NMEA_string_in)  
+      checksum = uint8(0);
+      for i = 2:numel(NMEA_string_in)
+          checksum = bitxor(checksum,uint8(NMEA_string_in(i)),'uint8');
+      end
+      NMEA_string_out = sprintf('%s*%s',NMEA_string_in,dec2hex(checksum));
+  end
+

--- a/dev/source/docs/MATLAB-Simulation.rst
+++ b/dev/source/docs/MATLAB-Simulation.rst
@@ -1,0 +1,19 @@
+.. _MATLAB-Simulation:
+
+==========================
+MATLAB Simulation
+==========================
+
+.. youtube:: sYCU2ch7oFE
+    :width: 100%
+
+MATLAB can be connected directly to ArduPilot using the JSON SITL interface. A connection function is provided along with a copter example. 
+The connection function deals with the UDP communications with ArduPilot. The copter example also contains a `function <https://github.com/ArduPilot/ardupilot/blob/afa153fb6fb569419455eb37384a1889971bd5bf/libraries/SITL/examples/JSON/MATLAB/Copter/SIM_multicopter.m#L127>`__
+to deal with the 6 dof dynamics of the system using the ArduPilot reference frames and conventions. This allows new vehicle types to only 
+output a calculated force and moment given the vehicles state and PWM inputs. The example code is thoroughly commented and can be found in 
+the `main repository <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON/MATLAB/Copter>`__.
+
+In order to connect MATLAB run the standard SITL command followed with ``-f JSON:127.0.0.1`` where, if necessary, ``127.0.0.1`` is replaced 
+by the IP of the machine where MATLAB is running. There is no requirement for MATLAB and SITL to be on the same system, however firewall 
+exceptions may need to be added for both. Both MATLAB and SITL can be stopped and restarted and the other should re-connect. Break-points 
+will work as normal.

--- a/dev/source/docs/MATLAB-Simulink-Simulation.rst
+++ b/dev/source/docs/MATLAB-Simulink-Simulation.rst
@@ -1,0 +1,17 @@
+.. _MATLAB-Simulink-Simulation:
+
+==========================
+Simulink Simulation
+==========================
+
+.. youtube:: hTFyMrjwQlI
+    :width: 100%
+
+`Connection blocks <https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/examples/JSON/MATLAB/AP_Conector.slx>`__ 
+are provided to read and write to ArduPilot SITL, along with examples for a `basic rover <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON/MATLAB/Rover>`__ and a `complex helicopter <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON/MATLAB/Heli>`__ 
+model. Both examples require additional MATLAB toolboxes. It is recommended to run the :ref:`MATLAB example <MATLAB-Simulation>` 
+to test the connection before proceeding to the Simulink examples, the Simulink connection is made using the same ``-f JSON:127.0.0.1`` command.
+
+.. note::
+  The Simulink connection library and examples were made using 2020a, older versions of the software can't use these files. Someone 
+  with access to 2020a can export for use with a older version, however it may not run as expected. Join the Discord simulation chanel for help.

--- a/dev/source/docs/simulation-2.rst
+++ b/dev/source/docs/simulation-2.rst
@@ -24,6 +24,10 @@ The most commonly used simulators are:
 -  :ref:`JSBSim <sitl-with-jsbsim>` is a sophisticated open-source plane and multicopter simulator with no graphical interface. It can be used with a wide variety of airframes.
 -  :ref:`AirSim <sitl-with-airsim>` is an open-source, cross-platform simulator for drones & cars, built on Unreal Engine for physically and visually realistic simulations
 -  :ref:`Silent Wings Soaring<soaring-sitl-with-silentwings>` 
+-  :ref:`MATLAB and Simulink<sitl-with-MATLAB>` are numerical computing environments used for developing algorithms and plotting data developed by `MathWorks <https://www.mathworks.com/>`__.
+-  :ref:`JSON interface<sitl-with-JSON>` The JSON interface is a generic interface protocol designed to be easy to implement for those developing physics backend. There are Python and MATLAB examples.
+-  :ref:`Webots <sitl-with-webots>` is a simulator mainly used for robotics. It is easy to build many vehicles using it. ArduPilot has Rover, Quadcopter, and Tricopters examples that have been built especially for this simulator.
+
 
 Less often used simulators include:
 
@@ -52,3 +56,5 @@ List of simulators (so they can appear in the menu):
     Autotest Framework <the-ardupilot-autotest-framework>
     SCRIMMAGE <sitl-with-scrimmage>
     Webots <sitl-with-webots>
+    MATLAB and Simulink <sitl-with-MATLAB>
+    JSON interface <sitl-with-JSON>

--- a/dev/source/docs/sitl-with-JSON.rst
+++ b/dev/source/docs/sitl-with-JSON.rst
@@ -1,0 +1,12 @@
+.. _sitl-with-JSON:
+
+==========================
+JSON interface
+==========================
+
+The JSON interface is designed to be easy to implement for those developing new physics backend. It provides a plain text return to ArduPilot 
+with easily configurable fields. The interface uses UDP communication and is launched using ``-f JSON:127.0.0.1`` where, if necessary, ``127.0.0.1`` is replaced 
+by the IP of the machine where the physics backend is running.
+
+The JSON interface has examples in Python, :ref:`MATLAB and Simulink <sitl-with-MATLAB>`. These along with a detailed description of the protocol can be found in the 
+`ArduPilot repository <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON>`__.

--- a/dev/source/docs/sitl-with-MATLAB.rst
+++ b/dev/source/docs/sitl-with-MATLAB.rst
@@ -1,0 +1,23 @@
+.. _sitl-with-MATLAB:
+
+==========================
+MATLAB and Simulink
+==========================
+
+All Matlab and Simulink functions rely on the `TCP/UDP/IP Toolbox 2.0.6 <https://www.mathworks.com/matlabcentral/fileexchange/345-tcp-udp-ip-toolbox-2-0-6>`__. 
+A modified version of the toolbox is provided in the ArduPilot `repository <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/JSON/MATLAB/tcp_udp_ip_2.0.6>`__.
+The toolbox is compiled into a `MEX file <https://www.mathworks.com/help/matlab/call-mex-file-functions.html>`__ allowing for fast connection speeds,
+also removing the need for a licence for the official TCP/UDP tools. Pre-built MEX files are provided for Windows and Linux however it may be necessary
+to compile locally. The `basic MATLAB Simulation copter <https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/examples/JSON/MATLAB/Copter/SIM_multicopter.m>`__
+example will try to do this if no MEX file is found. This should be run before trying the other examples.
+
+.. toctree::
+    :maxdepth: 1
+
+    MATLAB Simulation <MATLAB-Simulation>
+    Simulink Simulation <MATLAB-Simulink-Simulation>
+    Plotting in real time <MATLAB-Plotting>
+    MATLAB serial driver testing<MATLAB-Serial-driver>
+
+.. tip::
+  For advice using MATLAB and Simulink with ArduPilot please join the simulation channel on :ref:`Discord<ardupilot-discord-server>`.


### PR DESCRIPTION
This adds documentation for the MATLAB, Simulink and JSON SITL backends I have been working on for GSoC @tridge @bnsgeyer 