### PR TITLE
Add start date for User Alerts

### DIFF
--- a/common/source/docs/common-user-alerts.rst
+++ b/common/source/docs/common-user-alerts.rst
@@ -14,6 +14,12 @@ User Alerts will only be for ArduPilot software issues. Manufacturer hardware wi
 
 The User Alert documentation is available on the :ref:`developer wiki <dev:user-alerts-developer>`.
 
+
+.. note::
+
+   All User Alerts reported from 16/09/2020 (or later) are in the User Alert database. There is no guarantee
+   that the database holds all User Alerts reported before this date.
+   
 The following alerts are applicable:
 
 .. list-table::

--- a/dev/source/docs/user-alerts-developer.rst
+++ b/dev/source/docs/user-alerts-developer.rst
@@ -30,6 +30,11 @@ The User Alerts system consists of 3 parts:
 - The ability of applications (GCS software, websites) to ingest and use the User Alert data.
 
 
+.. note::
+
+   All User Alerts reported from 16/09/2020 (or later) are in the User Alert database. There is no guarantee
+   that the database holds all User Alerts reported before this date.
+   
 Processes
 =========
 


### PR DESCRIPTION
This PR adds a small note to the User Alert pages explaining that the User Alerts don't 100% cover the time period before 16/09/2020.