### PR TITLE
common: remove duplicate link

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -51,7 +51,9 @@ tuning options for the vehicle.
     Fly-By-Wire Low Altitude Limit <fly-by-wire-low-altitude-limit>
 [/site]
     FPort Setup <common-FPort-receivers>
+[site wiki="plane"]
     GeoFencing Failsafe  <common-geofencing-landing-page>
+[/site]
     GPIOs <common-gpios>
     GPS for Yaw (aka Moving Baseline) <common-gps-for-yaw>
     Ground Control Station Only Operation <common-gcs-only-operation>


### PR DESCRIPTION
unify to "GeoFencing Failsafe"
![image](https://user-images.githubusercontent.com/16643069/93545225-df9b5400-f99a-11ea-90b2-16ec7b250166.png)