### PR TITLE
Rover: Updated Ext Fuse Settings for common-ppm-encoder

### DIFF
--- a/common/source/docs/common-ppm-encoder.rst
+++ b/common/source/docs/common-ppm-encoder.rst
@@ -117,7 +117,7 @@ Following fuse settings should be used when programming with AVR Studio:
 
 - LOW: 0xFF
 - High: 0xDA
-- Ext: 0xFD
+- Ext: 0x07
 
 
 Re-Programming instructions for Windows


### PR DESCRIPTION
Changed Ext Fuse Settings from 0xFD to 0x07 

Resolves : #3038