### PR TITLE
User Alerts - more documentation

### DIFF
--- a/common/source/docs/common-user-alerts.rst
+++ b/common/source/docs/common-user-alerts.rst
@@ -14,6 +14,9 @@ User Alerts will only be for ArduPilot software issues. Manufacturer hardware wi
 
 The User Alert documentation is available on the :ref:`developer wiki <dev:user-alerts-developer>`.
 
+For more information about a specific User Alert, see the `User Alert
+Database <https://firmware.ardupilot.org/userAlerts/alerts.html>`_.
+
 
 .. note::
 

--- a/mavproxy/source/docs/modules/index.rst
+++ b/mavproxy/source/docs/modules/index.rst
@@ -96,3 +96,5 @@ List of Modules
     tracker
     tuneopt
     ublox
+    useralerts
+

--- a/mavproxy/source/docs/modules/useralerts.rst
+++ b/mavproxy/source/docs/modules/useralerts.rst
@@ -1,0 +1,38 @@
+===========
+User Alerts
+===========
+
+.. code:: bash
+
+    module load useralerts
+
+This module checks the currently connected firmware (ArduPilot) against the
+:ref:`User Alerts <dev:user-alerts-developer>` database and will notify if any User Alerts are applicable.
+
+An Internet connection is required to run the module.
+
+After loading, it can be run via:
+
+.. code:: bash
+
+    useralerts check
+
+
+Settings
+========
+
+The configurable settings for this module can be controlled by:
+
+.. code:: bash
+
+    useralerts set <setting> <value>
+    
+The settings are:
+
+===============================   ========================================   ===============================
+Setting                           Description                                Default
+===============================   ========================================   ===============================
+useTest                           Use the example User Alerts database       False
+filterBoard                       Filter the User Alerts by board hardware   True
+===============================   ========================================   ===============================
+


### PR DESCRIPTION
A few more User Alerts changes:

- Documentation for running the MAVProxy User Alerts module
- Link to the User Alerts Database