### PR TITLE
Lua scripts: Update how to add bindings

### DIFF
--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -401,13 +401,11 @@ See the `code examples folder  <https://github.com/ArduPilot/ardupilot/tree/mast
 How to Add New Bindings
 =======================
 
-To give Lua scripts access to more features of ArduPilot the API can be extended by creating new bindings.  If the object is already available to Lua (i.e. AHRS, Location, etc) the process is as follows:
+To give Lua scripts access to more features of ArduPilot the API can be extended by creating new bindings. The process is as follows:
 
-- Find the method or function you would like to expose to Lua.  For example if you wanted to expose an additional feature of AHRS you would first find the method within `libraries/AP_AHRS/AP_AHRS.h <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_AHRS/AP_AHRS.h>`__
-- Edit the `libraries/AP_Scripting/generator/description/bindings.desc <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/generator/description/bindings.desc>`__ and add a new line in the appropriate section for the method.
-- Open a command line prompt and cd to the `/libraries/AP_Scripting/generator <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/generator>`__ directory and type "make run"
-
-`Here is an example PR <https://github.com/ArduPilot/ardupilot/pull/11787>`__ which adds a binding for AHRS's get_roll, get_pitch and get_yaw methods.
+- Find the method or function you would like to expose to Lua. For example if you wanted to expose an additional feature of AHRS you would first find the method within `libraries/AP_AHRS/AP_AHRS.h <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_AHRS/AP_AHRS.h>`__. This can be an already existing method (function) or a method (function) newly added to the code.
+- Edit the `libraries/AP_Scripting/generator/description/bindings.desc <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/generator/description/bindings.desc>`__ and add a new line in the appropriate section for the method, or add a new section if a new class shall be added by following the examples of the other sections.
+- Open a command line prompt and cd to the `/libraries/AP_Scripting/generator <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/generator>`__ directory and type "make run". Alternatively, and probably easier, clean the distribution (./waf distclean) and restart compilation from there as usual.
 
 Further Information
 ===================


### PR DESCRIPTION
I believe the description for adding Lua bindings is quite outdated. Especially, there isn't no need anymore for doing the make thing. Cleaning the distro does do it now, which is IMHO a much simpler approach. I wonder if the first sentence in the 3rd bullet should be removed altogether.

By virtue of that I also believe that the reference to the PR is inapproriate since all one has to do now is to PR the additions to the bindings.desc. I thus removed it.