### PR TITLE
Add prompt-toolkit to windows dev install commands

### DIFF
--- a/mavproxy/source/docs/development/mavdevenvwindows.rst
+++ b/mavproxy/source/docs/development/mavdevenvwindows.rst
@@ -10,7 +10,7 @@ To install the required libraries:
 
 .. code:: bash
 
-    pip install pywin32 lxml pymavlink numpy matplotlib==3.2.2 pyserial opencv-python PyYAML Pygame Pillow wxpython
+    pip install pywin32 lxml pymavlink numpy matplotlib==3.2.2 pyserial opencv-python PyYAML Pygame Pillow wxpython prompt-toolkit
     pip install pyinstaller setuptools packaging --no-use-pep517
     
 Download the MAVProxy `source <https://github.com/ArduPilot/MAVProxy>`_.


### PR DESCRIPTION
Fixes error `ModuleNotFoundError: No module named 'prompt_toolkit'` when launching mavproxy.py

I guess it is already [fixed in setup.py](https://github.com/ArduPilot/MAVProxy/blob/b1da24d62a25e075dd6202b15ea03698e304338c/setup.py#L45), but installation with setup.py script fails for me on Windows, so this documentation is relevant.

Tested on Windows 10, Python 3.8.5, pip 20.1.1