### PR TITLE
MAV_CMD_CONDITION_YAW: Enable rotation speed

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -2377,8 +2377,6 @@ subtracted from the current heading (note that the vehicle will always
 turn in direction that most quickly gets it to the new target heading
 regardless of the ``param3`` value).
 
-We don't support controlling the yaw rate, so the ``param2`` value (Sec)
-is ignored.
 
 **Command parameters**
 
@@ -2400,7 +2398,6 @@ is ignored.
    If <code>param4=1</code> (relative): The change in heading (in degrees).
    </td>
    </tr>
-   <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
    <td>Sec</td>
    <td>Speed during yaw change:[deg per second].</td>


### PR DESCRIPTION
Copters support rotational speed.
I would remove the description of PARAM2.

![Screenshot from 2020-11-03 11-17-46](https://user-images.githubusercontent.com/646194/97939695-ce7d9980-1dc6-11eb-9a09-7ec79c8c8483.png)

