### PR TITLE
Changed to a better tutorial link for Jetson users

### DIFF
--- a/common/source/docs/common-vio-tracking-camera.rst
+++ b/common/source/docs/common-vio-tracking-camera.rst
@@ -108,7 +108,7 @@ Install ``librealsense`` and ``pyrealsense2``
 The Realsense T265 is supported via `librealsense <https://github.com/IntelRealSense/librealsense>`__ on Windows and Linux. Installation process varies widely for different systems, hence refer to `the official github page <https://github.com/IntelRealSense/librealsense>`__ for instructions for your specific system:
 
 - `Ubuntu <https://github.com/IntelRealSense/librealsense/blob/master/doc/installation.md>`__
-- `Jetson <https://github.com/IntelRealSense/librealsense/blob/master/doc/installation_jetson.md>`__
+- `Jetson <https://github.com/IntelRealSense/librealsense/blob/master/wrappers/python/readme.md>`__ (Compiling from source is needed to get the Python wrapper ``pyrealsense2``)
 - `Odroid <https://github.com/IntelRealSense/librealsense/blob/master/doc/installation_odroid.md>`__
 - `Windows <https://github.com/IntelRealSense/librealsense/blob/master/doc/installation_windows.md>`__
 - `Raspbian <https://github.com/IntelRealSense/librealsense/blob/master/doc/installation_raspbian.md>`__


### PR DESCRIPTION
I updated the Jetson tutorial link, because the old link can only get the librealsense.so. Jetson can not install pyrealsense2 with pip. In order to get the Python wrapper, compiling from source is a must. The updated link contains the compiling tutorials that leads to both ``librealsense`` and ``pyrealsense2``.