### PR TITLE
 Update SERIAL2_PROTOCOL value for APSync/APWeb

### DIFF
--- a/dev/source/docs/apsync-intro.rst
+++ b/dev/source/docs/apsync-intro.rst
@@ -74,7 +74,7 @@ Please follow the instructions for installing these images on the wiki page for 
 The flight controller (i.e. Pixhawk or similar) should be configured to communicate with the companion computer by setting the following parameters and then reboot the board:
 
 - :ref:`SERIAL2_BAUD <copter:SERIAL2_BAUD>` 921 (for RPi3, TX1 and Edison) or 1500 (for TX2)
-- :ref:`SERIAL2_PROTOCOL <copter:SERIAL2_PROTOCOL>` 1
+- :ref:`SERIAL2_PROTOCOL <copter:SERIAL2_PROTOCOL>` 2
 - :ref:`LOG_BACKEND_TYPE <copter:LOG_BACKEND_TYPE>` 3
 
 Connecting with SSH


### PR DESCRIPTION
I'm using the latest APSync for Raspberry Pi. 
If SEREAL2_PROTOCOL = 1, below error occurs in APWeb and nothing is displayed.
If SEREAL2_PROTOCOL = 2, the error does not occur, and APWeb is displayed normally.

Shouldn't this parameter value be changed?

![image](https://user-images.githubusercontent.com/15110000/100492090-7e4aea80-316c-11eb-8666-963d76731995.png)
