### PR TITLE
Changing the URI of dronekit-python

### DIFF
--- a/dev/source/docs/droneapi-tutorial.rst
+++ b/dev/source/docs/droneapi-tutorial.rst
@@ -4,7 +4,7 @@
 DroneKit Tutorial
 =================
 
-`DroneKit-Python <https://github.com/dronekit/dronekit-android/>`__ allows you to control ArduPilot using the Python programming language.
+`DroneKit-Python <https://github.com/dronekit/dronekit-python/>`__ allows you to control ArduPilot using the Python programming language.
 
 The `official DroneKit Python documentation <https://dronekit-python.readthedocs.io/en/latest/>`__ contains a `quick start guide <https://dronekit-python.readthedocs.io/en/latest/guide/quick_start.html>`__.
 
@@ -13,4 +13,3 @@ SITL/MAVProxy on Linux.
 
 .. youtube:: wSEc7Sm2O0E
     :width: 100%
-


### PR DESCRIPTION
When I click on the title of dronekit-python, it will take me to dronekit-android.
I change the URI.