### PR TITLE
Update common-durandal-overview.rst

### DIFF
--- a/common/source/docs/common-durandal-overview.rst
+++ b/common/source/docs/common-durandal-overview.rst
@@ -63,8 +63,7 @@ Specifications
 Where to Buy
 ============
 
- - Order from `Holybro <https://shop.holybro.com/>`__.
- - Direct link for `beta hardware release <https://shop.holybro.com/durandalbeta_p1189.html>`__.
+ - Order from `Holybro <https://shop.holybro.com/durandalbeta_p1189.html>`__.
  - Holybro distributors are listed `here <https://shop.holybro.com/art/distributors_a0050.html>`__.
 
 


### PR DESCRIPTION
- Removing "Beta Hardware", there is no beta hardware, only beta Ardupilot firmware. Since Durandal is running Stable firmware now,  removing this will clear some confusion. 
- Updating the "Order from" link to the direct product purchase link.