### PR TITLE
Clarify F.Port setup steps required on OpenTX side

### DIFF
--- a/common/source/docs/common-FPort-receivers.rst
+++ b/common/source/docs/common-FPort-receivers.rst
@@ -18,7 +18,7 @@ Most F7 and H7 autopilots, on the other hand, have internal inverters, and can b
 Telemetry protocol
 ==================
 
-Only the :ref:`Passthrough telemetry <common-frsky-passthrough>` protocol is supported. To get sensors to show up in OpenTX you have to install and enable :ref:`Yaapu FrSky Telemetry Script for OpenTX<common-frsky-yaapu>`. Otherwise the only sensor discovered would be GPS.
+ArduPilot will send telemetry data to the receiver over Fport using the :ref:`Passthrough telemetry <common-frsky-passthrough>` protocol. To get sensors to show up in OpenTX you have to install and enable a script which can display Passthrough telemetry, such as  :ref:`Yaapu FrSky Telemetry Script for OpenTX<common-frsky-yaapu>`. Otherwise the only sensor that will be discovered would be GPS.
 
 Connection Diagrams
 ===================
@@ -106,4 +106,3 @@ The normal RC input, UART6 RX, can now be used for FPort with the following conf
 - :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` =23
 - :ref:`SERIAL6_OPTIONS<SERIAL6_OPTIONS>` =15
 - :ref:`RSSI_TYPE<RSSI_TYPE>` =3
-

--- a/common/source/docs/common-FPort-receivers.rst
+++ b/common/source/docs/common-FPort-receivers.rst
@@ -15,6 +15,11 @@ Most F7 and H7 autopilots, on the other hand, have internal inverters, and can b
 
 .. note:: ArduPilot supports both 16 and 24 channels FPort2 but telemetry is enabled only for 16 channels mode.
 
+Telemetry protocol
+==================
+
+Only the :ref:`Passthrough telemetry <common-frsky-passthrough>` protocol is supported. To get sensors to show up in OpenTX you have to install and enable :ref:`Yaapu FrSky Telemetry Script for OpenTX<common-frsky-yaapu>`. Otherwise the only sensor discovered would be GPS.
+
 Connection Diagrams
 ===================
 


### PR DESCRIPTION
I spent a lot of time confused why the sensors don't show up in OpenTX even though they worked in s.port mode.. Added a blurb to hopefully clarify the point that Yaapu script has to be enabled for the sensors to appear.