### PR TITLE
Update building-for-bebop-on-linux.rst

### DIFF
--- a/dev/source/docs/building-for-bebop-on-linux.rst
+++ b/dev/source/docs/building-for-bebop-on-linux.rst
@@ -68,6 +68,10 @@ In order to upgrade to this version:
 
        telnet 192.168.42.1
 
+   .. note::
+
+      A telnet error here indicates the Bebop's current firmware does not have the correct port open. Manually reboot the Bebop to complete the update.
+
 #. Sync and reboot
 
    ::


### PR DESCRIPTION
Purchased a remanufactured Bebop and the current firmware did not have port 23 open. Had to do the firmware upgrade to get telnet to work.