### PR TITLE
Add a link to the LightWare SF45

### DIFF
--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -68,6 +68,7 @@ based upon your set-up.
     LightWare SF20 / LW20 Lidar <common-lightware-lw20-lidar>
     Lightware SF02 Lidar <common-rangefinder-sf02>
     Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
+    LightWare SF45/B 350 Lidar <common-lightware-sf45b>
     Maxbotix I2C Sonar <common-rangefinder-maxbotixi2c>
     Maxbotix Analog Sonar <common-rangefinder-maxbotix-analog>
     RPLidar A2 360 degree laser scanner <common-rplidar-a2>


### PR DESCRIPTION
I was interested in SF45.
I didn't see a link to it on the rangefinder list.
I will add the SF45 to the list.