### PR TITLE
Add a submarine link

### DIFF
--- a/common/source/docs/common-downloads_firmware.rst
+++ b/common/source/docs/common-downloads_firmware.rst
@@ -11,6 +11,7 @@ This includes:
 * `Plane <https://firmware.ardupilot.org/Plane>`__ 
 * `Rover <https://firmware.ardupilot.org/Rover>`__ 
 * `AntennaTracker <https://firmware.ardupilot.org/AntennaTracker>`__ 
+* `Sub <https://firmware.ardupilot.org/Sub>`__ 
 
 This page provides additional links to a number of specific builds that are considered "significant" - for example, the last builds of 
 Copter to fit on the APM2.x board.


### PR DESCRIPTION
There was no link to the submarine.
I will add the submarine firmware link.