### PR TITLE
Cleanup of out of date firmware references

### DIFF
--- a/common/source/docs/common-3d-mapping.rst
+++ b/common/source/docs/common-3d-mapping.rst
@@ -89,11 +89,7 @@ triggered continuously until the vehicle is switched out of AUTO mode.
 vehicles returns home.
 
 **DO_SET_ROI** can be used to point the nose of the vehicle and gimbal
-at a specific point on the map.  Note: in AC3.1.2, as the vehicle passes
-a waypoint it will point to the next waypoint, this means that in order
-to point at a single point throughout the mission, the do-set-roi
-command must appear over and over again after each waypoint.  In AC3.2
-this behaviour has been modified so that this is not necessary.
+at a specific point on the map.
 
 .. image:: ../../../images/3dMapping_MPFlightPlanExample.jpg
     :target: ../_images/3dMapping_MPFlightPlanExample.jpg

--- a/common/source/docs/common-lightware-sf10-lidar.rst
+++ b/common/source/docs/common-lightware-sf10-lidar.rst
@@ -14,8 +14,8 @@ SF10/C (100m) and
 
 \ |SF10-B|
 
-Connecting to the Pixhawk
-=========================
+Connecting to the AutoPilot
+===========================
 
 The diagram below shows the sensor output pins and a conveniently colour-coded cable (normally included or `see spec here <http://documents.lightware.co.za/LW%20000_135%20-%20Main%20cable%20type%201%20assembly%20-%20Rev%200.pdf>`__) which is used to connect to the autopilot. :ref:`Serial <sf10-serial-connection>`, :ref:`I2C <sf10-i2c-connection>` and :ref:`Analog <sf10-analog-connection>` connections are possible but we recommended using :ref:`Serial <sf10-serial-connection>` if possible especially if using cables that are 30cm or longer.
 
@@ -70,10 +70,6 @@ Lightware lidars manufactured before May 2018 shipped with a default baud rate o
 
 I2C connection
 --------------
-
-.. warning::
-
-   I2C support is present in Plane 3.4 (and higher) and Rover 2.50 (and higher) and Copter 3.4 (and higher).
 
 Connect the SDA line of the Lidar to the SDA line of the I2C port on the Pixhawk, and the SCL line of the Lidar to the SCL line of the I2C port. Also connect the GND and 5V lines.
 

--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -1612,7 +1612,7 @@ control the landing are provided in :ref:`LAND flight mode <plane:land-mode>`.
    <tr>
    <td><strong>param1</strong></td>
    <td>Abort Alt</td>
-   <td>Altitude to climb to if landing is aborted (From Plane 3.4)</td>
+   </td>
    </tr>
    <tr style="color: #c0c0c0">
    <td>param2</td>
@@ -1740,7 +1740,7 @@ Move to the next command when the desired altitude is reached.
 
 .. note::
 
-   In Plane 3.4 (and later) the ``param1`` value sets how close the
+   The ``param1`` value sets how close the
    vehicle altitude must be to target altitude for command
    completion.
 
@@ -1761,7 +1761,7 @@ Move to the next command when the desired altitude is reached.
    <td>Climb or Descend (0 = Neutral, command completes when within 5m of this
    command's altitude, 1 = Climbing, command completes when at or above
    this command's altitude, 2 = Descending, command completes when at or
-   below this command's altitude. Introduced in Plane 3.4.
+   below this command's altitude.
    </td>
    </tr>
    <tr style="color: #c0c0c0">
@@ -3786,10 +3786,6 @@ This command allows you to specify a roll, pitch and yaw angle which
 will be sent to the :ref:`camera gimbal <common-cameras-and-gimbals>`. This
 can be used to point the camera in specific directions at various times
 in the mission.
-
-.. note::
-
-   Supported from AC3.3, Plane 3.4
 
 **Command parameters**
 

--- a/common/source/docs/common-px4flow-overview.rst
+++ b/common/source/docs/common-px4flow-overview.rst
@@ -13,7 +13,7 @@ This article describes how to setup the `PX4FLOW (Optical Flow) Sensor <https://
 
 .. warning::
 
-   The PX4FLOW is supported from Copter 3.3 and higher. It is not yet supported in Plane or Rover.
+   The PX4FLOW is not yet supported in Plane or Rover.
 
 Overview
 ========

--- a/common/source/docs/common-rangefinder-lidarlite.rst
+++ b/common/source/docs/common-rangefinder-lidarlite.rst
@@ -6,11 +6,6 @@ LIDAR-Lite Rangefinder
 
 The `Garmin / PulsedLight LIDAR-Lite <https://support.garmin.com/support/manuals/manuals.htm?partNo=010-01722-00>`__ rangefinder is a low-cost optical distance measurement solution with a 40m range under most operating conditions, low power consumption, and small form factor.  This sensor can be purchased from many online retailers including `Sparkfun <https://www.sparkfun.com/products/14032>`__.  Technical info can be found `here <https://support.garmin.com/support/manuals/manuals.htm?partNo=010-01722-00>`__.
 
-.. note::
-
-   Support was added in Copter 3.3, Plane 3.3, and Rover 2.49.
-   ArduPilot supports LIDAR-Lite v1 (aka "Black Label"), v2 (aka "Blue Label") and v3.
-
 ..  youtube:: 3I06AOwIQVY
     :width: 100%
 

--- a/common/source/docs/common-rangefinder-maxbotixi2c.rst
+++ b/common/source/docs/common-rangefinder-maxbotixi2c.rst
@@ -14,13 +14,9 @@ resistance while the EZ0 has the widest beam and highest sensitivity.
 `The datasheet can be found here <https://www.maxbotix.com/documents/I2CXL-MaxSonar-EZ_Datasheet.pdf>`__. 
 Additional information on the similar :ref:`analog version of this sonar can be found here <copter:sonar>`.
 
-.. note::
 
-   This rangefinder is only supported on the Pixhawk running AC3.2 or
-   higher or recent versions of Plane and Rover.
-   
 .. warning::
-   
+
    ``RNGFNDx_MAX_CM`` must be set to a tested, appropriate value.  If ``RNGFNDx_MAX_CM`` is set to a value
    greater than the range of the sensor, the autopilot will not respond correctly to the 
    data provided.

--- a/common/source/docs/common-rangefinder-sf02.rst
+++ b/common/source/docs/common-rangefinder-sf02.rst
@@ -10,11 +10,6 @@ In `tests by the development team <https://diydrones.com/profiles/blogs/testing-
 the sensor has produced very reliable distance measurements for long and
 short ranges even on fast moving vehicles.
 
-.. warning::
-
-   This rangefinder is only supported on the Pixhawk running AC3.2
-   or higher or recent versions of Plane and Rover using the sensor's
-   analog output much like an analog sonar.
 
 Connecting to the Pixhawk
 =========================

--- a/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
+++ b/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
@@ -59,7 +59,7 @@ the following:
 
 [site wiki="copter"]
 -  (Copter) Optionally check the :ref:`Simple Mode <copter:simpleandsuper-simple-modes_simple_mode>`
-   check-box for that switch position. If using AC3.1 or higher you can
+   check-box for that switch position. You can
    optionally set :ref:`Super Simple mode <copter:simpleandsuper-simple-modes_super_simple_mode>`.
    If both Simple mode and Super Simple mode checkboxes are checked
    Super Simple will be used.

--- a/common/source/docs/common-rcmap.rst
+++ b/common/source/docs/common-rcmap.rst
@@ -7,11 +7,6 @@ RC Input Channel Mapping (RCMAP)
 This article shows how to set up a non-standard RC input channel mapping
 using the RCMAP feature.
 
-.. note::
-
-   This feature is available in AC3.2.1 and higher (and equivalent
-   Plane and Rover versions).
-
 Configuration
 =============
 

--- a/common/source/docs/common-simplebgc-gimbal.rst
+++ b/common/source/docs/common-simplebgc-gimbal.rst
@@ -7,10 +7,6 @@ SimpleBGC Gimbal (aka AlexMos gimbal)
 The SimpleBGC is a popular brushless gimbal controller that can communicate with ArduPilot (Copter, Plane, and Rover) using a custom serial protocol.
 More details on the capabilities of this gimbal can be found at `basecamelectronics.com <https://www.basecamelectronics.com/>`__
 
-.. note::
-
-   Support for this gimbal is included in Copter 3.4 (and higher). 
-
 Where to Buy
 ============
 

--- a/common/source/docs/common-storm32-gimbal.rst
+++ b/common/source/docs/common-storm32-gimbal.rst
@@ -20,7 +20,7 @@ gimbal has been tested with a `DYS 3-axis brushless gimbal <https://hobbyking.co
 
 .. note::
 
-   Support for this gimbal is included in Copter 3.3 (and higher) for
+   Support for this gimbal is included for
    gimbals running
    `v067e <http://www.olliw.eu/storm32bgc-wiki/Downloads>`__ (or higher). 
 

--- a/copter/source/docs/ac2_positionmode.rst
+++ b/copter/source/docs/ac2_positionmode.rst
@@ -9,10 +9,6 @@ control. This means that, in position mode, the copter maintains a
 consistent location and heading, while allowing the operator to control
 the throttle manually.
 
-.. warning::
-
-   This mode is not available in AC3.2 and higher.
-
 .. image:: ../images/position.jpg
     :target: ../_images/position.jpg
 

--- a/copter/source/docs/acro-mode.rst
+++ b/copter/source/docs/acro-mode.rst
@@ -39,7 +39,7 @@ Overview
 .. youtube:: tC0mF-N5z0Q
     :width: 100%
 
-The above video was filmed with a Pixhawk running AC3.2 in ACRO mode
+The above video was filmed in ACRO mode
 using :ref:`FPV goggles <common-fpv-first-person-view>`.
 
 

--- a/copter/source/docs/altholdmode.rst
+++ b/copter/source/docs/altholdmode.rst
@@ -47,8 +47,7 @@ throttle stick.
    the stick.  When the stick is completely down the copter will descend
    at 2.5m/s and if at the very top it will climb by 2.5m/s.  These
    speeds can be adjusted with the :ref:`PILOT_SPEED_UP<PILOT_SPEED_UP>` and :ref:`PILOT_SPEED_DN<PILOT_SPEED_DN>` parameters.
--  The size of the deadband can be adjusted with the :ref:`THR_DZ<THR_DZ>` parameter
-   (AC3.2 and higher only).  This params value should be between "0" and
+-  The size of the deadband can be adjusted with the :ref:`THR_DZ<THR_DZ>` parameter.  This param's value should be between "0" and
    "400" with "0" meaning no deadband.  "100" would produce a deadband
    10% above and below mid throttle (i.e. deadband extends from 40% to
    60% throttle stick position).
@@ -147,8 +146,7 @@ Common Problems
    to move the autopilot out of the prop wash effect or shield
    it within an appropriately ventilated enclosure.
 #. Sudden altitude changes caused by light striking the barometer. 
-   APM2.x sold after mid 2013 come with black tape on the inside of the
-   case to protect against this.
+
 
 Adequate Power
 ==============

--- a/copter/source/docs/boat-mode.rst
+++ b/copter/source/docs/boat-mode.rst
@@ -4,11 +4,7 @@
 Boat Mode
 =========
 
-Copter 3.4 (and higher) includes "boat mode" which allows taking off from a moving platform including boats.  It is not really a "mode" but rather a change to how the gyros are calibrated.
-
-.. note::
-
-    "Boat mode" was introduced in Copter 3.4.
+Copter includes "boat mode" which allows taking off from a moving platform including boats.  It is not really a "mode" but rather a change to how the gyros are calibrated.
 
 ..  youtube:: wNlnwqC-bx4
     :width: 100%
@@ -16,7 +12,7 @@ Copter 3.4 (and higher) includes "boat mode" which allows taking off from a movi
 Settings
 ========
 
-In many cases Copter-3.4 will be able to take off from a moving platform without any special parameter changes as long as the platform is not moving too rapidly during the gyro calibration which occurs a few seconds after startup (look for the LEDs flashing red and blue).
+In many cases Copter will be able to take off from a moving platform without any special parameter changes as long as the platform is not moving too rapidly during the gyro calibration which occurs a few seconds after startup (look for the LEDs flashing red and blue).
 
 If the platform is moving too much however, the gyro calibration will fail after 30 seconds and gyro related warnings like "Bad Gyro Health" will appear on the HUD.  Despite this warning the vehicle may fly normally but having the warning is unnerving and may hide other errors.  In this case, it is best to disable the automatic gyro calibration by setting the :ref:`INS_GYR_CAL <INS_GYR_CAL>` parameter to "0".
 

--- a/copter/source/docs/brake-mode.rst
+++ b/copter/source/docs/brake-mode.rst
@@ -8,10 +8,6 @@ This very simple flight mode simply stops the vehicle as soon as
 possible using the Loiter controller.  Once invoked, this mode does not
 accept any input from the pilot. This mode requires GPS.
 
-.. note::
-
-   The Brake flight mode was introduced in AC3.3.
-
 Overview
 ========
 

--- a/copter/source/docs/channel-7-and-8-options.rst
+++ b/copter/source/docs/channel-7-and-8-options.rst
@@ -5,7 +5,6 @@ Auxiliary Function Switches (3.6 and earlier)
 =============================================
 
 This article shows how to set up which features are invoked from the transmitter's auxiliary function switches prior to Copter-4.0.
-AC3.2.1 and earlier allowed channels 7 and 8 to be used as auxiliary switches.  AC3.3 and higher supports channels 7 to 12.
 
 Configuration
 =============
@@ -75,23 +74,6 @@ inputs. See details `here <autotrim>`__.
    mission. If in AUTO mode no waypoint will be saved, instead the vehicle will RTL</td>
    </tr>
    <tr>
-   <td><strong>Multi Mode</strong></td>
-   <td>
-   
-This option has been removed from AC3.3 (and higher).
-
-Ch6 tuning knob position controls which of the following 3 functions is
-invoked when ch7 or ch8 switch put in the on position.
-
--  Ch6 <1200 : Flip
--  Ch6 1201 ~ 1799 : RTL
--  Ch6 > 1800 : Save Waypoint
-
-.. raw:: html
-
-   </td>
-   </tr>
-   <tr>
    <td><strong>Camera Trigger</strong></td>
    <td>
 
@@ -115,15 +97,6 @@ Camera shutter will be activated. See more details
    <tr>
    <td><strong>Fence</strong></td>
    <td>Fence is disabled when switch is in low position, enabled when it high position.</td>
-   </tr>
-   <tr>
-   <td><strong>ResetToArmedYaw</strong></td>
-   <td>
-   This option has been removed from AC3.3 (and higher).
-
-   Vehicle will turn to face the same direction that it was facing when it
-   was first armed (e.g. at take-off). An alternative to simple mode when
-   you've lost orientation and need to bring the craft home.</td>
    </tr>
    <tr>
    <td><strong>Super Simple Mode</strong></td>
@@ -315,14 +288,15 @@ Switch pulled low turns off the fourth :ref:`relay <common-relay>`, pulled high 
 .. raw:: html
 
    </td>
-   <td>Retracts/Deploys landing gear. (AC3.3 and higher)</td>
+   <td>Retracts/Deploys landing gear. 
+   </td>
    </tr>
    <tr>
    <td><strong>Lost Copter Alarm</strong></td>
    <td>
 
 Plays the `lost copter alarm <https://download.ardupilot.org/downloads/wiki/pixhawk_sound_files/LostCopter.wav>`__
-though the buzzer (AC3.3 and higher)
+though the buzzer
 
 .. raw:: html
 
@@ -333,7 +307,7 @@ though the buzzer (AC3.3 and higher)
    <td>
 
 Stops motors immediately
-(`video <https://www.youtube.com/watch?v=-Db4u8LJE5w>`__). (AC3.3 and higher)
+(`video <https://www.youtube.com/watch?v=-Db4u8LJE5w>`__).
 
 .. raw:: html
 
@@ -344,7 +318,7 @@ Stops motors immediately
    <td>
 
 Opposite of Emergency stop (above) in that switch must be ON for motors
-to spin (`video <https://youtu.be/-Db4u8LJE5w?t=51>`__). (AC3.3 and higher)
+to spin (`video <https://youtu.be/-Db4u8LJE5w?t=51>`__).
 
 .. raw:: html
 
@@ -356,7 +330,7 @@ to spin (`video <https://youtu.be/-Db4u8LJE5w?t=51>`__). (AC3.3 and higher)
 
 Invokes the :ref:`Brake flight mode <brake-mode>` when switch goes high.
 Bringing switch back to low will return the vehicle to the mode
-indicated by the ch5 flight mode switch. (AC3.3 and higher)
+indicated by the ch5 flight mode switch.
 
 .. raw:: html
 
@@ -368,7 +342,7 @@ indicated by the ch5 flight mode switch. (AC3.3 and higher)
 
 Invokes the :ref:`Throw flight mode <throw-mode>` when switch goes high.
 Bringing switch back to low will return the vehicle to the mode
-indicated by the ch5 flight mode switch. (AC3.4 and higher)
+indicated by the ch5 flight mode switch.
 
 .. raw:: html
 
@@ -378,7 +352,7 @@ indicated by the ch5 flight mode switch. (AC3.4 and higher)
    <td><strong>ADSB-Avoidance</strong></td>
    <td>
 
-When switch is high, :ref:`ADSB avoidance <common-ads-b-receiver>` (avoidance of manned aircraft) is enabled, when switch is low, disabled. (AC3.4 and higher)
+When switch is high, :ref:`ADSB avoidance <common-ads-b-receiver>` (avoidance of manned aircraft) is enabled, when switch is low, disabled.
 
 .. raw:: html
 
@@ -388,7 +362,7 @@ When switch is high, :ref:`ADSB avoidance <common-ads-b-receiver>` (avoidance of
    <td><strong>Precision Loiter</strong></td>
    <td>
 
-Turns on/off :ref:`Precision Loiter <precision-landing-with-irlock>`.  I.e. holding position above a target in Loiter mode using IR-Lock sensor. (AC3.5 and higher)
+Turns on/off :ref:`Precision Loiter <precision-landing-with-irlock>`.  I.e. holding position above a target in Loiter mode using IR-Lock sensor. 
 
 .. raw:: html
 
@@ -398,7 +372,7 @@ Turns on/off :ref:`Precision Loiter <precision-landing-with-irlock>`.  I.e. hold
    <td><strong>Object Avoidance</strong></td>
    <td>
 
-When switch is high, avoid objects using :ref:`Lightware SF40c <common-lightware-sf40c-objectavoidance>` or :ref:`TeraRanger Tower<common-teraranger-tower-objectavoidance>`. (AC3.4 and higher)
+When switch is high, avoid objects using :ref:`Lightware SF40c <common-lightware-sf40c-objectavoidance>` or :ref:`TeraRanger Tower<common-teraranger-tower-objectavoidance>`.
 
 .. raw:: html
 
@@ -409,7 +383,7 @@ When switch is high, avoid objects using :ref:`Lightware SF40c <common-lightware
    <td>
 
 Arms the vehicle if the switch goes high (subject to arming checks).
-Disarms the vehicle if brought low. (AC3.5 and higher)
+Disarms the vehicle if brought low.
 
 .. raw:: html
 

--- a/copter/source/docs/ekf-inav-failsafe.rst
+++ b/copter/source/docs/ekf-inav-failsafe.rst
@@ -6,10 +6,6 @@ EKF Failsafe
 
 The EKF failsafe monitors the health of EKF (the position and attitude estimation system) to catch problems with the vehicle's position estimate (often caused by GPS glitches or compass errors) and prevent "flyaways".
 
-.. note::
-
-   Starting in Copter 3.3 the EKF failsafe replaces the :ref:`GPS Failsafe <archived-gps-failsafe>`. 
-
 When will it trigger?
 =====================
 

--- a/copter/source/docs/gps-failsafe-glitch-protection.rst
+++ b/copter/source/docs/gps-failsafe-glitch-protection.rst
@@ -20,7 +20,7 @@ A *GPS failsafe* event will occur if GPS 3D
 lock or the position "Glitches" for at least 5 seconds while Copter is
 in a mode that requires the GPS (RTL, Auto, Loiter, Circle, Position,
 Guided or Drift).  The GPS failsafe response can be set to Land or
-switch to AltHold mode (in AC3.1 and higher) so that you can retake
+switch to AltHold mode so that you can retake
 manual control.
 
 Without GPS updates, the inertial sensors allow approximately 10 seconds
@@ -30,14 +30,10 @@ at all.  At this point if you still have RC radio control it is
 recommended to take back control using Stabilize, Acro or AltHold as
 soon as possible.
 
-This article describes two forms of GPS glitch logic. The first is used
-by the default navigation algorithm for AC3.1 and 3.2. The second (EKF)
-can be used in AC3.2, and is mandatory in AC3.3 and later.
-
 Glitch Protection - Default
 ===========================
 
-AC3.1 and AC3.2 include GPS glitch protection which can help alert the
+GPS glitch protection is provided which can help alert the
 pilot to a bad GPS position, trigger a failsafe and reduce the incidents
 of fly-aways.  Glitches are detected by comparing the each new position
 update received from the GPS with a position projected out from the
@@ -60,13 +56,8 @@ HUD
 Glitch Protection - EKF
 =======================
 
-AC3.2 introduced a new form of glitch protection, the :ref:`ArduPilot Extended Kalman Filter (EKF) <common-apm-navigation-extended-kalman-filter-overview>`.
+:ref:`ArduPilot Extended Kalman Filter (EKF) <common-apm-navigation-extended-kalman-filter-overview>`)provided glitch protection.
 
-.. note::
-
-   AC3.3 Enables EKF by default, and it cannot be turned off. On
-   AC3.2 EKF is turned off by default - but you can enable it to run on the
-   faster boards (using 32 bit micros) by setting ``AHRS_EKF_USE = 1``.
 
 Glitch protection using the EKF works as follows:
 

--- a/copter/source/docs/ground-effect-compensation.rst
+++ b/copter/source/docs/ground-effect-compensation.rst
@@ -4,13 +4,9 @@
 Ground Effect Compensation
 ==========================
 
-Copter 3.4 (and higher) includes ground effect compensation which reduces the weighting of the barometer (in favour of the accelerometers) when the vehicle is likely taking off or landing.  This reduces the bounce sometimes seen when landing vehicles with short legs compared to the length of their propellers.
+Copter includes ground effect compensation which reduces the weighting of the barometer (in favour of the accelerometers) when the vehicle is likely taking off or landing.  This reduces the bounce sometimes seen when landing vehicles with short legs compared to the length of their propellers.
 
 If your vehicle is not suffering from the bounce on landing it's best to leave this feature disabled because it slightly increases the risk of high vibration levels upsetting the altitude estimate.
-
-.. note::
-
-    Ground Effect compensation was introduced in Copter 3.4.
 
 Setup
 =====

--- a/copter/source/docs/poshold-mode.rst
+++ b/copter/source/docs/poshold-mode.rst
@@ -4,8 +4,7 @@
 PosHold Mode
 ============
 
-The PosHold flight mode (previously known as "Hybrid") is a new mode for
-AC3.2.  It is similar to Loiter in that the vehicle maintains a constant
+The PosHold flight mode is similar to Loiter in that the vehicle maintains a constant
 location, heading, and altitude but is generally more popular because
 the pilot stick inputs directly control the vehicle's lean angle
 providing a more "natural" feel.
@@ -38,8 +37,7 @@ with the control sticks.
 -  You may arm in PosHold mode but only once the GPS has 3D lock and the
    HDOP has dropped to 2.0 or lower.
 
-On an APM2 the board's blue light will become solid when 3D lock is
-attained. On a Pixhawk the LED will become green (:ref:`more details on LED patterns here <common-apm-board-leds>`).
+On a Pixhawk the LED will become green (:ref:`more details on LED patterns here <common-apm-board-leds>`).
 
 The HDOP value can be made clearly visible through the mission planner's
 Quick screen by double clicking and then selecting "gpshdop" from the

--- a/copter/source/docs/precision-landing-with-irlock.rst
+++ b/copter/source/docs/precision-landing-with-irlock.rst
@@ -7,7 +7,7 @@ Precision Landing and Loiter with IR-LOCK
 Overview
 ========
 
-Copter 3.4 (and higher) supports Precision Landing using the `IR-LOCK sensor <https://irlock.com/collections/frontpage/products/ir-lock-sensor-precision-landing-kit>`__ and a :ref:`sonar or lidar <common-rangefinder-landingpage>`.
+Copter supports Precision Landing using the `IR-LOCK sensor <https://irlock.com/collections/frontpage/products/ir-lock-sensor-precision-landing-kit>`__ and a :ref:`sonar or lidar <common-rangefinder-landingpage>`.
 Using this system, when the vehicle enters LAND mode (and has GPS lock) it is possible to reliably land within 30cm of an IR beacon that is moving at less than 1m/s.
 
 Copter 3.5 (and higher) additionally supports Precision Loiter which allows a vehicle to maintain its position above a target while in Loiter mode.  The Pilot can enable this using one of the transmitter's :ref:`auxiliary function switches <common-auxiliary-functions>` (in versions prior to Copter-4.0, CH7_OPT or CH_8_OPT would be used).

--- a/copter/source/docs/throw-mode.rst
+++ b/copter/source/docs/throw-mode.rst
@@ -11,10 +11,6 @@ Once in the air, this mode does not accept any input from the pilot.  This mode 
 
    Use with caution!  It is dangerous to get close to an armed multicopter as is required to throw the vehicle.  It is recommended to takeoff normally instead of using throw mode whenever possible.
 
-.. note::
-
-   The Throw flight mode was introduced in AC3.4.
-
 ..  youtube:: JIPMpDJqdJ8
     :width: 100%
 

--- a/copter/source/docs/traditional-helicopter-tuning.rst
+++ b/copter/source/docs/traditional-helicopter-tuning.rst
@@ -4,10 +4,8 @@
 Traditional Helicopter – Tuning
 ===============================
 
-This tuning guide is applicable to all versions of ArduCopter for traditional
-helicopters. However, it is written for Copter 3.4 and newer. Since the names of
-parameters, and scaling, were changed from Copter 3.3 to 3.4 the
-:ref:`old tuning guide is archived here <traditional-helicopter-archived-tuning>`
+This tuning guide is applicable to current versions of ArduCopter for traditional
+helicopters. See the :ref:`old tuning guide which is archived here <traditional-helicopter-archived-tuning>` for old versions.
 
 For making setting changes to traditional helicopters, users are reminded to 
 use only the Full or Complete Parameter List in your ground station software. 

--- a/dev/source/docs/ros-distance-sensors.rst
+++ b/dev/source/docs/ros-distance-sensors.rst
@@ -45,14 +45,6 @@ Launch MAVROS with default config. You should have rangefinder data in /mavros/d
 
 Send to FCU
 -----------
-.. warning::
-
-    Distance sensor message is currently support on :
-
-    - ArduPilot Master
-    - Copter >= 3.4
-    - Rover >= 3.1.0
-    - Plane >= 3.7.1
 
 ArduPilot support receiving rangefinder data coming from Companion Computer for example.
 To do that, setup a MAVLink rangefinder on ArduPilot side and simply set a subscriber in MAVROS plugin :


### PR DESCRIPTION
Start of wiki cleanup of outdated firmware reference. Per previous agreements only references to last two releases in a vehicle will be retained. Archived topics are exempt. And where large pieces of information would be removed, they will be archived in some manner instead of deleted.