### PR TITLE
starting.rst: Fix alignment issue

### DIFF
--- a/mavproxy/source/docs/getting_started/starting.rst
+++ b/mavproxy/source/docs/getting_started/starting.rst
@@ -247,7 +247,7 @@ MAVProxy and its modules.
 ===================
 
 A comma separated list of the modules to load on startup by default. The default 
-value of this parameter is ``log,signing,wp,rally,fence,param,relay,tuneopt,arm,mode,calibration,rc,auxopt,misc,cmdlong,battery,terrain,output,adsb``
+value of this parameter is ``log,signing,wp,rally,fence,param,relay,tuneopt,arm,mode,calibration,rc,auxopt,misc,cmdlong,`` ``battery,terrain,output,adsb``
 
 -\\-non-interactive
 ===================


### PR DESCRIPTION
Made some changes in the alignment of MavProxy wiki about [Startup Options ](https://ardupilot.org/mavproxy/docs/getting_started/starting.html#default-modules)
The comma-separated list of values defined in the default-module section seems to have an alignment issue :-
![Alignment](https://user-images.githubusercontent.com/62841337/105637957-2abbfb00-5e96-11eb-9cd4-499d5526244a.png)
After the fix :-
![alignmentfix](https://user-images.githubusercontent.com/62841337/105638026-8a1a0b00-5e96-11eb-8375-60525ecc8b85.png)
Note- the above fix was tested on [rst online editor](http://rst.ninjs.org/)
THANKS !!!
