### PR TITLE
Expand info on determined GPIO pin number

### DIFF
--- a/common/source/docs/common-gpios.rst
+++ b/common/source/docs/common-gpios.rst
@@ -14,6 +14,8 @@ For example, the Pixhawk has 8 MAIN outputs for motors/servos, and 6 AUX outputs
 
 .. image:: ../../../images/Relay_Pixhawk.jpg
 
+.. note:: Changing :ref:`BRD_PWM_COUNT<BRD_PWM_COUNT>` requires a reboot of the autopilot for it to take effect.
+
 Everytime the autopilot initializes, it sends a log message to the ground control station, showing which outputs are PWM/Oneshot/or DShot. The remaining higher numbered outputs are assigned as GPIOs.
 
 .. image:: ../../../images/RCOutbanner.jpg
@@ -23,3 +25,11 @@ GPIO "PIN" NUMBER
 =================
 
 Some GPIO-based functions require that the GPIO "pin number" to be entered into an associated parameter.This pin number is assigned in the autopilot's hardware definition file. Usually, the first GPIO capable output is assigned pin 50, the second 51, etc. So in the above case of the Pixhawk, AUX OUT 6 is pin 55.
+
+You can verify an output's GPIO pin number assignment easily. First, find its hwdef.dat file `here <ttps://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_ChibiOS/hwdef>`__ and determine the GPIO pin number listed beside its output number, as shown below:
+
+.. image:: ../../../images/GPIO_numbers.png
+
+In the above case, you could set the :ref:`BRD_PWM_COUNT<BRD_PWM_COUNT>` down to 8, freeing PWM9 and PWM10 and use their GPIO numbers for GPIO functions.
+
+.. note:: Usually, changing any feature or function's GPIO pin assignment will require a reboot for it to take effect.


### PR DESCRIPTION
Requires #3305 to be merged first since it uses one of its images.