### PR TITLE
Update common-rc-options.rst

### DIFF
--- a/common/source/docs/common-rc-options.rst
+++ b/common/source/docs/common-rc-options.rst
@@ -16,4 +16,4 @@ RC Options
 3                                       Add delay bytes in FPort protocol, needed by some systems, see :ref:`FPort Setup<common-FPort-receivers>`
 =================================       =========
 
-for example, to set this option to ignore receiver failsafe bits, you would set bit 2, or a value of "8". This may be usefull when using ground station control beyond the range of the RC system which can set its receiver's outputs to trim values upon RC signal loss, but still has a failsafe bit in the protocol which would otherwise force an RC failsafe to occur.
+for example, to set this option to ignore receiver failsafe bits, you would set bit 2, or a value of "4" (2^2=4). This may be usefull when using ground station control beyond the range of the RC system which can set its receiver's outputs to trim values upon RC signal loss, but still has a failsafe bit in the protocol which would otherwise force an RC failsafe to occur.


### PR DESCRIPTION
I believe there was a simple numerical error.  "setting bit 2" is a value of 4, not 8.  It might be even better to make the example with bit 3, then 2^3=8 has three un-repeated numbers that makes it utterly clear.