### PR TITLE
Eclipse build under Windows lists python2.7 that is although not installed by prerequisites

### DIFF
--- a/dev/source/docs/building-setup-windows-eclipse.rst
+++ b/dev/source/docs/building-setup-windows-eclipse.rst
@@ -41,7 +41,7 @@ Once Eclipse has been started import ArduPilot by doing the following:
     :width: 450px
 
 - In the Project Explorer tab on the top right, right-mouse-button-click on the "ardupilot" folder and select "Properties"
-- When the "Properties for ardupilot" window appears, under "C/C++ Build", uncheck "Use default build command" and enter ``c:\cygwin64\bin\python3.6 waf`` into the "Build command" field as shown below
+- When the "Properties for ardupilot" window appears, under "C/C++ Build", uncheck "Use default build command" and enter ``c:\cygwin64\bin\python3.6m waf`` into the "Build command" field as shown below
 
 .. image:: ../images/eclipse-install3.png
     :target: ../_images/eclipse-install3.png

--- a/dev/source/docs/building-setup-windows-eclipse.rst
+++ b/dev/source/docs/building-setup-windows-eclipse.rst
@@ -41,7 +41,7 @@ Once Eclipse has been started import ArduPilot by doing the following:
     :width: 450px
 
 - In the Project Explorer tab on the top right, right-mouse-button-click on the "ardupilot" folder and select "Properties"
-- When the "Properties for ardupilot" window appears, under "C/C++ Build", uncheck "Use default build command" and enter ``c:\cygwin64\bin\python2.7 waf`` into the "Build command" field as shown below
+- When the "Properties for ardupilot" window appears, under "C/C++ Build", uncheck "Use default build command" and enter ``c:\cygwin64\bin\python3.6 waf`` into the "Build command" field as shown below
 
 .. image:: ../images/eclipse-install3.png
     :target: ../_images/eclipse-install3.png


### PR DESCRIPTION
Python 2.7 does not get installed by following https://ardupilot.org/dev/docs/building-setup-windows-cygwin.html or running the https://github.com/ArduPilot/ardupilot/blob/master/Tools/environment_install/install-prereqs-windows.ps1 script, but Python 3.6 does.