### PR TITLE
Corrects signs on the mixing equation

### DIFF
--- a/plane/source/docs/guide-vtail-plane.rst
+++ b/plane/source/docs/guide-vtail-plane.rst
@@ -159,7 +159,7 @@ movement. For example, if :ref:`MIXING_GAIN<MIXING_GAIN>` is 0.5, then the follo
 are used:
 
 - LEFT_VTAIL = (yaw+pitch)*0.5
-- RIGHT_VTAIL = (yaw-pitch)*0.5
+- RIGHT_VTAIL = (-yaw+pitch)*0.5
 
 Adjusting the :ref:`MIXING_GAIN<MIXING_GAIN>` controls the percentabe of throws from pitch vs yaw.
 


### PR DESCRIPTION
The RIGHT_VTAIL mixing equation in the documenation does not match the ArduPlane code. The [relevant code](https://github.com/ArduPilot/ardupilot/blob/29775f310e62f5a22d0af23a2d6541ad0b899c38/libraries/AP_IOMCU/iofirmware/mixer.cpp#L110-L116) is:

```cpp
int16_t AP_IOMCU_FW::mix_elevon_vtail(int16_t angle1, int16_t angle2, bool first_output) const
{
    if (first_output) {
        return (angle2 - angle1) * mixing.mixing_gain / 1000;
    }
    return (angle1 + angle2) * mixing.mixing_gain / 1000;
}
```

This function is called by the [following code](https://github.com/ArduPilot/ardupilot/blob/29775f310e62f5a22d0af23a2d6541ad0b899c38/libraries/AP_IOMCU/iofirmware/mixer.cpp#L209-L215):

```cpp
case SRV_Channel::k_vtail_left:
    pwm = mix_output_angle(i, mix_elevon_vtail(rudder, pitch, false));
    break;

case SRV_Channel::k_vtail_right:
    pwm = mix_output_angle(i, mix_elevon_vtail(rudder, pitch, true));
    break;
```

Swapping `angle1` and `angle2` in the first snippet of code likely led to the confusion.