### PR TITLE
Fixes for Vagrant VM

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -12,10 +12,10 @@ if [ ${DISTRIBUTION_CODENAME} == 'Ubuntu' ]; then
   add-apt-repository universe
 fi
 apt-get -y update
-apt-get install -y unzip git imagemagick curl wget make python
+apt-get install -y unzip git imagemagick curl wget make python3 python-is-python3
 
 # Get pip through the official website to get the lastest release
-curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py && rm -f get-pip.py
+curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python3 get-pip.py && rm -f get-pip.py
 
 # Install sphinx
 pip install -U sphinx==1.8.3 || pip3 install -U sphinx==1.8.3

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,11 +6,11 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "ubuntu/focal64"
   config.vm.provider "virtualbox" do |vb|
       vb.name = "ArduPilot_wiki"
   end
-  config.vm.provision "shell", path: "./Sphinxsetup.sh"
+  config.vm.provision "shell", path: "./scripts/initvagrant.sh"
   config.vm.provider "virtualbox" do |vb|
       vb.customize ["modifyvm", :id, "--memory", "2048"]
   end

--- a/scripts/initvagrant.sh
+++ b/scripts/initvagrant.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+set -x
+
+echo "---------- $0 start ----------"
+
+/vagrant/Sphinxsetup.sh
+OUTDIR=/var/sites/wiki/web
+OUTDIR_OLD=/var/sites/wiki/web/old
+mkdir -p "$OUTDIR_OLD"
+chown -R vagrant.vagrant "$OUTDIR"
+
+echo "---------- $0 end ----------"


### PR DESCRIPTION
This now makes a focal64 VM rather than a bionic VM.

The actual server is xenial64 and it runs Python2.  The  setup stuff here is all based around get-pip.py which is now Python3-only.

So we may as well move it forward to the current Ubuntu LTS.
