### PR TITLE
Add AP_Periph updates in checks to update it on the Wiki

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -26,7 +26,7 @@ test -n "$FORCEBUILD" || {
         changed=1
     }
 
-    PARAMSITES="ArduPlane ArduCopter AntennaTracker Rover"
+    PARAMSITES="ArduPlane ArduCopter AntennaTracker Rover AP_Periph"
     mkdir -p old_params new_params
     for site in $PARAMSITES; do
         wget "https://autotest.ardupilot.org/Parameters/$site/Parameters.rst" -O new_params/$site.rst 2> /dev/null


### PR DESCRIPTION
Wiki is build when something is updated.

Inserting AP_Periph check as in the others vehicles.