### PR TITLE
Update Obstacle Avoidance docs for Copter/Rover 4.1

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -1,9 +1,9 @@
 .. _common-ads-b-receiver:
+[copywiki destination="plane,copter"]
 
-
-==============
+=====
 ADS-B
-==============
+=====
 
 This article describes how to attach and configure an ADS-B module so that your aircraft can be aware of, and/or transmit to, other aircraft and air-traffic control nearby. This also allows the pilot on the ground to be aware of nearby manned aircraft and optionally to allow the vehicle to automatically avoid them.
 

--- a/common/source/docs/common-oa-bendyruler.rst
+++ b/common/source/docs/common-oa-bendyruler.rst
@@ -9,19 +9,44 @@ Object Avoidance with Bendy Ruler
 
 Copter and Rover 4.0 (and higher) support "BendyRuler" for path planning around obstacles and fences.  The BendyRuler algorithm probes around the vehicle in many directions looking for open spaces and then tries to pick the direction that is sufficiently open while also moving the vehicle towards the final destination.
 
-.. note:: 
+.. note::
 
     This is only applicable in AUTO, GUIDED, and RTL flight modes.
 
 .. image:: ../../../images/oa-bendy-ruler.png
     :width: 450px
 
-Configuration
--------------
+Basic Configuration
+-------------------
 
 -  :ref:`OA_TYPE <OA_TYPE>` = 1 (BendyRuler).  You may need to refresh parameters after changing this to see the parameters below.
--  ``OA_LOOKAHEAD`` : the distance (in meters) ahead of the vehicle that should be probed.  Obstacles further than this far away will be ignored.  This should be long enough that the path around obstacles can be "seen" but not too long or the vehicle will be overly cautious and not enter areas with a lot of obstacles. 5m is typical.
+-  :ref:`OA_BR_LOOKAHEAD <OA_BR_LOOKAHEAD>` : This parameter is called "OA_LOOKAHEAD" before Copter and Rover 4.1. It is the distance (in meters) ahead of the vehicle that should be probed.  Obstacles further than this far away will be ignored.  This should be long enough that the path around obstacles can be "seen" but not too long or the vehicle will be overly cautious and not enter areas with a lot of obstacles. 5m is typical.
 -  :ref:`OA_MARGIN_MAX <OA_MARGIN_MAX>` : the distance (in meters) that the vehicle should stay away from obstacles. 2m is a typical value.
+
+.. note::
+
+    Users often get confused between OA_BR_LOOKAHEAD and OA_MARGIN_MAX parameters. A smaller OA_BR_LOOKAHEAD will make BendyRuler look for obstacles in a shorter path towards the destination, and thus any object further than this many meters will not be used in the path planning process. A shorter OA_MARGIN_MAX parameter will let the vehicle come closer to an approaching obstacle.
+
+BendyRuler Types
+-----------------
+
+Copter 4.1 onwards has support for two different types of BendyRuler Path Planning.
+
+- 1. :ref:`OA_BR_TYPE <OA_BR_TYPE>` = 1: Horizontal BendyRuler: This is the only option available on Rover and older Copter versions. This searches for obstacle-free paths only in horizontal directions and therefore when it detects an obstacle in its path, it will only move in those directions.
+
+..  youtube:: GRqjMf7kQxU
+    :width: 100%
+
+
+
+- 2. :ref:`OA_BR_TYPE <OA_BR_TYPE>` = 2: Vertical BendyRuler: This feature searches for path only in four directions: Straight towards the destination, vertically up, vertically down and backwards. This feature is typically helpful while avoiding short obstacles in a crowded space. Don't forget to setup an altitude fence if you do not want the Copter to climb above a certain height.
+
+..  youtube:: cjv0ArVOCy0
+    :width: 100%
+
+
+Advanced Configuration
+----------------------
 
 If using a lidar or proximity sensor the following "obstacle database" parameters are available:
 
@@ -29,6 +54,8 @@ If using a lidar or proximity sensor the following "obstacle database" parameter
 - :ref:`OA_DB_EXPIRE <OA_DB_EXPIRE>` : the number of seconds after an obstacle disappears from view that it is removed from the database
 - :ref:`OA_DB_QUEUE_SIZE <OA_DB_QUEUE_SIZE>` : the buffer size between the lidar and obstacle database.  Normally this can be left at the default value
 - :ref:`OA_DB_OUTPUT <OA_DB_OUTPUT>` : controls whether tracked objects are visible on the GCS as small airplanes
+- :ref:`OA_DB_ALT_MIN <OA_DB_ALT_MIN>` : OADatabase will reject obstacle's if vehicle's altitude above home is below this parameter, in a 3 meter radius around home. This can be useful if your sensor is picking up the ground as obstacles while taking off.
+
 
 Videos
 ------

--- a/common/source/docs/common-oa-dijkstrabendyruler.rst
+++ b/common/source/docs/common-oa-dijkstrabendyruler.rst
@@ -1,0 +1,31 @@
+.. _common-oa-dijkstrabendyruler:
+
+=================================================
+Object Avoidance using Dijkstra's with BendyRuler
+=================================================
+
+Copter and Rover 4.1 (and higher) support path planning with a fusion of Dijkstras and BendyRuler.
+BendyRuler does not guarantee a shortest path, and can be called a local planner. Although Dijkstra's gives us the ability to navigate around complex fences with the shortest path, yet due to the computational complexity it cannot be used for to avoid Proximity based obstacles. Therefore, the advantages of both of these algorithms are used together.
+
+.. note::
+
+    This is only applicable in AUTO, GUIDED, and RTL flight modes.
+
+This method starts with traditional Dijkstra's planning the shortest path around all the fences that are present between the flight path. In between this path, if any proximity based obstacle is detected, the navigation is switched to BendyRuler. If there are no obstacles in the nearby view of the sensor, the vehicle resumes normal Dijkstra's based navigation.
+
+Basic Configuration
+-------------------
+
+:ref:`OA_TYPE <OA_TYPE>` = 3
+
+Rest of the parameters can be set by looking at the respective documentation of :ref:`BendyRuler<common-oa-bendyruler>` and :ref:`Dijsktra's<common-oa-dijkstras>`
+
+
+Videos
+------
+
+..  youtube:: s0z0b2U2fAk
+    :width: 100%
+
+
+[copywiki destination="copter,rover"]

--- a/common/source/docs/common-object-avoidance-landing-page.rst
+++ b/common/source/docs/common-object-avoidance-landing-page.rst
@@ -13,30 +13,38 @@ Avoidance Strategies
 
 Various strategies are employed and vary depending on vehicle, mode, and/or object to be avoided. Re-routing, slide, stop, or failsafe style actions are the most common ones. See the particular Avoidance Feature below for details.
 
+[site wiki="copter,plane"]
 
-Avoidance Features
-==================
+ADSB Avoidance
+===============
 
-.. toctree::
-    :maxdepth: 1
+- :ref:`Airborne Vehicles (ADSB)<common-ads-b-receiver>`
 
-    Airborne Vehicles (ADSB) <common-ads-b-receiver>
-[site wiki="copter,rover"]
-    Simple Object Avoidance <common-simple-object-avoidance>
-    Bendy Path Planning Around Obstacles <common-oa-bendyruler>
-    Dijkstras Path Planning Around Obstacles<common-oa-dijkstras>
 [/site]
 
+[site wiki="copter,rover"]
+Path Planning and Obstacle Avoidance Features
+=============================================
 
+These methods are used for avoiding proximity sensor detected obstacles as well as GCS set fences.
 
+Hardware Setup
+--------------
 
-Hardware
-========
-
--  :ref:`ADS-B Receiver <common-ads-b-receiver>`
+-  :ref:`Proximity Sensors<common-proximity-landingpage>`
 -  :ref:`Rangefinders <common-rangefinder-landingpage>`
 -  :ref:`Realsense Depth Camera <common-realsense-depth-camera>`
 
 
+Avoidance Types
+---------------
 
+.. toctree::
+    :maxdepth: 1
+
+    Simple Object Avoidance <common-simple-object-avoidance>
+    BendyRuler Path Planning Around Obstacles and Fences <common-oa-bendyruler>
+    Dijkstra's Path Planning Around Fences<common-oa-dijkstras>
+    Dijkstra's with BendyRuler Path Planning Around Obstacles and Fences<common-oa-dijkstrabendyruler>
+[/site]
 

--- a/common/source/docs/common-proximity-landingpage.rst
+++ b/common/source/docs/common-proximity-landingpage.rst
@@ -1,0 +1,84 @@
+.. _common-proximity-landingpage:
+
+================================
+Proximity Sensors (landing page)
+================================
+
+Copter/Rover have support for avoidance obstacles that may appear in front of the vehicle. The first step to enable these features is to have a working Proximity Sensor.
+
+360 degree Lidars are typically used in object avoidance as proximity sensors, but multiple rangefinders sensors or stereo depth cameras can also be used for proximity detection.
+
+.. note::
+
+    Users often confuse RangeFinders with proximity sensors. Rangefinders are typically single dimensional sensors, that provide distances from a very narrow ray. Proximity Sensors is generally a name used for 360 Lidar and other sensors with a wider FOV. The settings and parameters used for both classes of sensors are different.
+
+Configuration
+=============
+
+You will need to set up the parameter :ref:`PRX_TYPE <PRX_TYPE>` correctly as per the sensor you are using.
+Exclusion zones are provided for 360 degree Lidars, since these may have obstructions in their field of view. Exclusion zones are set via the PRX_IGN_ANGx and PRX_IGN_WIDx parameters, specifying a direction and width the frame obstruction presents and will be ignored. Up to 6 exclusion sectors can be specified.
+
+Follow the links below for configuration information based upon your set-up:
+
+
+-    :ref:`RangeFinders <common-rangefinder-setup>`
+-    :ref:`Intel RealSense Depth Camera <common-realsense-depth-camera>`
+-    :ref:`Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>`
+-    :ref:`Lightware SF45/B (350 degree) <common-lightware-sf45b>`
+-    :ref:`RPLidar A2 360 degree laser scanner <common-rplidar-a2>`
+-    :ref:`TerraRanger Tower (360 degree) <common-teraranger-tower-objectavoidance>`
+
+Testing
+=======
+
+Real-time view
+--------------
+
+Real-time distances can be seen in the Mission Planner's proximity viewer
+
+.. image:: ../../../images/copter-object-avoidance-radar-view.png
+
+This window can be opened by moving to the MP's Flight Data screen, press Ctrl-F and push the Proximity button.
+
+.. image:: ../../../images/copter-object-avoidance-show-radar-view.png
+   :target: ../_images/copter-object-avoidance-show-radar-view.png
+   :width: 300px
+
+DataFlash logging
+-----------------
+
+Upward and downward facing range finder distances can be seen in the DataFlash Log's RFND message.
+
+The distance to the nearest object in 8 quadrants around the vehicle is recorded in the DataFlash log's PRX messages.
+Since Copter and Rover 4.1 have the ability to store 3D obstacles, various instances of PRX message log is used. 0th instance stands for obstacles detected between -75 to -45 degrees pitch. Similarly, PRX[1] stores from -45 to -15 degrees, and PRX[2] stores from -15 to + 15 degrees and so on.
+
+Additional Features
+===================
+
+Filter
+------
+
+Various sensors can be attached to the flight controller. However, depending on the quality and use case of the sensor, it might give noisy data.
+This noise will be stored onboard the flight controller as "obstacles" and the vehicle might suddenly start avoiding false objects. To counter this problem, Copter and Rover 4.1 have an inbuilt low pass filter on the raw sensor data.
+The filter can be adjusted by :ref:`PRX_FILT <PRX_FILT>` (setting it to 0 will disable the feature).
+By default, only the filtered values get logged. However, by setting :ref:`PRX_LOG_RAW <PRX_LOG_RAW>` = 1, raw values from the sensors will also be logged. This can be used for debugging purposes.
+
+Ground detection
+----------------
+
+.. note::
+
+    This feature requires a valid downward facing rangefinder configured first and only works with Copter.
+
+For low altitude obstacle avoidance, and while just taking off and landing, sometimes the sensor will pick up the ground below as obstacle. This can be dangerous because the vehicle will try and "avoid" these obstacles (if avoidance features are turned on).
+By setting :ref:`PRX_IGN_GND <PRX_IGN_GND>` = 1, we attempt to detect and ignore any obstacles that are near the ground.
+
+.. warning::
+
+    This feature only works when the vehicle is armed
+    It might also ignore valid obstacles when the vehicle is flying very close to the ground.
+    Detected obstacles will not be visible on the Mission Planner Proximity Viewer, or data flash logs.
+
+
+
+[copywiki destination="copter,rover"]

--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -4,9 +4,9 @@
 Rangefinders (landing page)
 ===========================
 
-Copter/Plane/Rover support a number of different rangefinders including Lidars (which use lasers or infra-red beams for distance measurements) and Sonars (which use ultrasonic sound), and also includes Maxbotix Sonar and Pulsed Light LED range finders. These devices can be used for measuring distance near to  the ground for precision landings and altitude control, water depth, or object distance as proximity sensors for avoiding objects.
+Copter/Plane/Rover support a number of different rangefinders including Lidars (which use lasers or infra-red beams for distance measurements), 360 degree Lidars (which can detect obstacles in multiple directions) and Sonars (which use ultrasonic sound). This category also includes Maxbotix Sonar and Pulsed Light LED range finders. These devices can be used for measuring distance near to  the ground for precision landings and altitude control, water depth, or object distance as proximity sensors for :ref:`Object Avoidance<common-object-avoidance-landing-page>`. Vision systems (see :ref:`common-realsense-depth-camera`) can also be used for Object Avoidance.
 
-360 degree Lidars are typically used in object avoidance as proximity sensors. While multiple 1D (single dimensional) sensors can be used for proximity detection.
+A forward facing rangefinders can also be used for Obstacle Avoidance. See Rangefinder :ref:`Setup Overview <common-rangefinder-setup>` to know more.
 
 [site wiki="plane"]
 .. tip::
@@ -48,8 +48,17 @@ based upon your set-up.
     :maxdepth: 1
 
     Rangefinder Setup Overview <common-rangefinder-setup>
+[site wiki="copter,rover"]
 
+    Proximity Sensors <common-proximity-landingpage>
+    
+[/site]
 
+Unidirectional Rangefinders
+===========================
+
+.. toctree::
+    :maxdepth: 1
 
     Aerotenna US-D1 Radar Altimeter <common-aerotenna-usd1>
     Attollo Engineering Wasp200 <common-wasp200-lidar>
@@ -59,23 +68,37 @@ based upon your set-up.
     Garman Lidar-Lite <common-rangefinder-lidarlite>
     GY-US42 Sonar <common-rangefinder-gy-us42>
     HC-SR04 Sonar <common-rangefinder-hcsr04>
-[site wiki="copter,rover"]
-    Intel Realsense Depth Camera <common-realsense-depth-camera>
-[/site]
     LeddarTech Leddar One <common-leddar-one-lidar>
     LeddarTech LeddarVu8 <common-leddartech-leddarvu8-lidar>
     LightWare SF10 / SF11 Lidar <common-lightware-sf10-lidar>
     LightWare SF20 / LW20 Lidar <common-lightware-lw20-lidar>
     Lightware SF02 Lidar <common-rangefinder-sf02>
-    Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
-    Lightware SF45/B (350 degree) <common-lightware-sf45b>
     Maxbotix I2C Sonar <common-rangefinder-maxbotixi2c>
     Maxbotix Analog Sonar <common-rangefinder-maxbotix-analog>
-    RPLidar A2 360 degree laser scanner <common-rplidar-a2>
     ST VL53L0X / VL53L1X Lidar <common-vl53l0x-lidar>
     TeraRanger One/EVO Rangefinders <common-teraranger-one-rangefinder>
-    TerraRanger Tower (360 degree) <common-teraranger-tower-objectavoidance>
     Underwater Sonar <common-underwater-sonars-landingpage>
+
+Omnidirectional Proximity Rangefinders
+======================================
+
+.. toctree::
+    :maxdepth: 1
+
+    Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
+    Lightware SF45/B (350 degree) <common-lightware-sf45b>
+    RPLidar A2 360 degree laser scanner <common-rplidar-a2>
+    TerraRanger Tower (360 degree) <common-teraranger-tower-objectavoidance>
+
+[site wiki="copter,rover"]
+Vision Based Sensors
+====================
+
+.. toctree::
+    :maxdepth: 1
+    
+    Intel Realsense Depth Camera <common-realsense-depth-camera>
+[/site]
 
 
 

--- a/common/source/docs/common-rangefinder-setup.rst
+++ b/common/source/docs/common-rangefinder-setup.rst
@@ -6,7 +6,7 @@ RangeFinders Setup Overview
 
 There are many different kinds of rangefinders: Lidar (using laser or infra-red light to measure distance), Sonar (using ultrasonic sound), and Radar (using microwave RF). Some are analog, producing  pulses whose timing represent the distance to an object, others are digital sending data streams over serial to UARTs, or I2C, or even via UAVCAN.
 
-:ref:`RangeFinders (Sonar or Lidar) <common-rangefinder-landingpage>` can be used for :ref:`Object Avoidance <common-object-avoidance-landing-page>` in Copter-3.5 (and higher) in Loiter and AltHold modes and in Rover-3.5 (and higher). As well as altitude sensors for precision landing in Plane and Copter
+:ref:`RangeFinders (Sonar or Lidar) <common-rangefinder-landingpage>` can be used for :ref:`Object Avoidance <common-object-avoidance-landing-page>` as well as altitude sensors for precision landing in Plane and Copter.
 
 ..  youtube:: y2Kk6nIily0
     :width: 100%
@@ -23,11 +23,12 @@ Connecting and Configuring the Rangefinder
 - Follow the instructions for each type of rangefinder described in its linked page on :ref:`common-rangefinder-landingpage`.
 - Set the RNGFNDx_ORIENT parameters (i.e. :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>`, :ref:`RNGFND2_ORIENT <RNGFND2_ORIENT>`, etc.) to specify the direction each range finder is pointing in. 
 
-..note:: Note that if the type of rangefinder is set or changed, a reboot will be required.
+.. note:: Note that if the type of rangefinder is set or changed, a reboot will be required.
+
 
 [site wiki="copter,rover"]
+  - Set the parameter :ref:`PRX_TYPE<PRX_TYPE>` = 4 to use horizontal rangefinders as Proximity Sensors (For obstacle avoidance).
   - For Copter and Rover, up to 8 rangefinders may placed around the vehicle to provide 360 degree coverage, or a single 360 degree Lidar. But only one forward facing rangefinder is required for :ref:`Object Avoidance <common-object-avoidance-landing-page>` .
-  - Exclusion zones are provided for 360 degree Lidars, since these may have obstructions in their field of view. Exclusion zones are set via the PRX_IGN_ANGx and PRX_IGN_WIDx parameters, specifying a direction and width the frame obstruction presents and will be ignored. Up to 6 exclusion sectors can be specified.
   - If a rangefinder is oriented facing up, then it will be used in the :ref:`common-simple-object-avoidance` operation as an upwards sensing proximity sensor in Copter LOITER, ALTHOLD, and POSHOLD modes.
 [/site]
 [site wiki="plane,copter"]

--- a/common/source/docs/common-simple-object-avoidance.rst
+++ b/common/source/docs/common-simple-object-avoidance.rst
@@ -5,26 +5,27 @@
 Simple Object Avoidance
 =======================
 
-Copter supports simple object avoidance horizontally and upward, while Rover avoids simple objects by only stopping. Both use rangefinders such as:
+Copter supports simple object avoidance horizontally and upward, while Rover avoids simple objects by only stopping. Both use proximity sensors such as:
 
-- 360 degree lidar including the :ref:`Lightware SF40C <copter:common-lightware-sf40c-objectavoidance>`, :ref:`TeraRanger Tower <copter:common-teraranger-tower-objectavoidance>` or :ref:`RPLidarA2/A3 <copter:common-rplidar-a2>`
-- Any of the other supported :ref:`lidars <common-rangefinder-landingpage>` .As of ArduPilot firmware versions 4.0 and higher, up to 9 rangefinders can be used for object avoidance. See :ref:`common-rangefinder-setup` for more information.
+- 360 degree lidar including the :ref:`Lightware SF40C <copter:common-lightware-sf40c-objectavoidance>`, :ref:`TeraRanger Tower <copter:common-teraranger-tower-objectavoidance>` or :ref:`RPLidarA2/A3 <copter:common-rplidar-a2>`. See the :ref:`Proximity Sensor page<common-proximity-landingpage>` for more details.
+- Any of the supported :ref:`Rangefinders <common-rangefinder-landingpage>` .As of ArduPilot firmware versions 4.0 and higher, up to 9 rangefinders can be used for object avoidance. See :ref:`common-rangefinder-setup` for more information.
 - Sensors capable of providing `MAVLink Distance Sensor <https://mavlink.io/en/messages/common.html#DISTANCE_SENSOR>`__ messages (like `OpenKai with a 3D camera <https://www.youtube.com/watch?v=qk_hEtRASqg>`__)
+- 3D Obstacle Avoidance via the new Mavlink message `OBSTACLE_DISTANCE_3D <https://mavlink.io/en/messages/ardupilotmega.html#OBSTACLE_DISTANCE_3D>`__ . Depth cameras can use this message.
+
 
 ..  youtube:: BDBSpR1Dw_8
     :width: 100%
 
 
-In addition, Simple Object Avoidance can use Geo-Fences and Fence Beacons as proximity sensors as detemined by the setting of the :ref:`AVOID_ENABLE<AVOID_ENABLE>` parameter.
- 
-See :ref:`common-rangefinder-setup` for general rangefinder setup information.
+In addition, Simple Object Avoidance can use Geo-Fences and Fence Beacons as proximity sensors as determined by the setting of the :ref:`AVOID_ENABLE<AVOID_ENABLE>` parameter.
+
 
 Simple Object Avoidance Algorithms
 ==================================
 
-Horizontal object avoidance works in :ref:`AltHold <altholdmode>` and :ref:`Loiter <loiter-mode>` modes.  Upward object avoidance works in LOITER, ALTHOLD, and POSHOLD modes only.
+Horizontal object avoidance works in :ref:`AltHold <altholdmode>` and :ref:`Loiter <loiter-mode>` modes.  Upward object avoidance works in LOITER, ALTHOLD modes only.
 
-.. warning:: Only one proximity sensor source can be enabled, using either a 360 degree lidar or up to 9 rangefinders. While a second proximity sensor appears in the parameters list, it is not currently functional
+.. warning:: Only one proximity sensor source can be enabled, using either a 360 degree lidar or up to 9 rangefinders.
 
 .. note:: For Object Avoidance in AUTO and GUIDED modes in Copter and Rover, see :ref:`common-oa-bendyruler` or :ref:`common-oa-dijkstras`
 
@@ -37,7 +38,7 @@ In LOITER, either stopping in front of the object or a "sliding" algorithm is us
 Setup the Proximity Sensor
 ==========================
 
-For 360 lidar follow the instructions corresponding to the lidar on the vehicle
+For lidars follow the instructions corresponding to the lidar on the vehicle on the :ref:`Proximity Sensor documentation<common-proximity-landingpage>`.
 
   - :ref:`Lightware SF40C <common-lightware-sf40c-objectavoidance>`
   - :ref:`TeraRanger Tower/ Tower EVO <common-teraranger-tower-objectavoidance>`
@@ -47,20 +48,25 @@ For other rangefinders follow the instructions found in there individual setup p
 
 Be sure to read the :ref:`common-rangefinder-setup` page
 
-Configuring Simple Avoidance for Copter
-=======================================
+
+SAFETY FIRST!
+=============
+
+- The avoidance algorithms have been constantly changing. While in most scenarios it will help the user keep the vehicle safe from any obstacles, or fence breaches; due to unknown sensor glitch, or other such problems, avoidance should be swiftly turned off mid-flight (especially while trying for the first time).
+- Set any vacant channel of your Transmitter to use RCx_OPTIONS parameter and set it to 40. For example, if channel 8 switch of your transmitter is vacant, set :ref:`RC8_OPTION<RC8_OPTION>` = 40.
+- Toggling this switch to HIGH would switch on Proximity based avoidance and vice versa.
+
+
+Configuring Simple Avoidance for Copter in Loiter Mode
+======================================================
+
 
 - set :ref:`AVOID_ENABLE <AVOID_ENABLE>` = 7 ("All") to use all sources of barrier information including "Proximity" sensors
 - set :ref:`PRX_TYPE <PRX_TYPE>` to a 360 deg Lidar type being used or = 4, to enable using range finders as "proximity sensors"
-- in :ref:`Loiter <loiter-mode>`  
+- in :ref:`Loiter <loiter-mode>`
 
   - :ref:`AVOID_MARGIN <AVOID_MARGIN>` controls how many meters from the barrier the vehicle will attempt to stop or try to slide along it
   - :ref:`AVOID_BEHAVE <AVOID_BEHAVE>` allows setting whether the vehicle should simply Stop in front of the barrier or Slide around it. This parameter only affects Copter, since Rover always stops.
-
-- in :ref:`AltHold <altholdmode>`
-
-  - :ref:`AVOID_DIST_MAX <AVOID_DIST_MAX>` controls how far from a barrier the vehicle starts leaning away from the barrier
-  - :ref:`AVOID_ANGLE_MAX <AVOID_ANGLE_MAX>` controls how far the vehicle will try to lean away from the barrier
 
 Configuring Simple Avoidance for Rover
 ======================================
@@ -77,31 +83,57 @@ Configuring Simple Avoidance for Rover
     :width: 100%
 
 
-Real-time view
-==============
 
-Real-time distances can be seen in the Mission Planner's proximity viewer
 
-.. image:: ../../../images/copter-object-avoidance-radar-view.png
+Advanced Configuration for Simple Avoidance (Copter/Rover 4.1 and above)
+========================================================================
 
-This window can be opened by moving to the MP's Flight Data screen, press Ctrl-F and push the Proximity button.
+Backing away from obstacles
+---------------------------
 
-.. image:: ../../../images/copter-object-avoidance-show-radar-view.png
-   :target: ../_images/copter-object-avoidance-show-radar-view.png
-   :width: 300px
+The vehicle will actively attempt to maintain distance (margin) from obstacles. This means that if an obstacle approaches the vehicle from any direction, and the sensor detects it, the vehicle will back away from the obstacle.
 
-DataFlash logging
-=================
 
-Upward and downward facing range finder distances can be seen in the DataFlash Log's RFND message.
+..  youtube:: -6PWB52J3ho
+    :width: 100%
 
-The distance to the nearest object in 8 quadrants around the vehicle is recorded in the DataFlash log's PRX messages.
 
-Limitations
-===========
 
-Simple Object Avoidance feature has the following limitations.  Future versions will likely resolve these.
+..  youtube:: /oPI0SUQVDRQ
+    :width: 100%
 
-- The vehicle should stop before hitting objects but will never back away from objects that approach the vehicle (a slow backing away will be added in future firmware versions)
-- Avoidance is "sensor based" meaning it is **not** building up a 3D map and thus has no "memory" of where barriers were once they are out of view of the lidar.
 
+
+- The speed of this backing away can be controlled via the parameter: :ref:`AVOID_BACKUP_SPD <AVOID_BACKUP_SPD>`
+- Setting this parameter to zero would disable backing up. Therefore, the vehicle will attempt to stop or slide in front of the obstacle, but never try and maintain a margin from the obstacle if it was to come closer due to any reason.
+
+
+
+Getting smoother avoidance experience
+-------------------------------------
+
+- Depending on the tuning of the vehicle, current velocity, distance to the obstacle; the user might feel that while avoidance is active, the vehicle response is very "jerky" and not smooth.
+- In this case, user should reduce the maximum acceleration with which the vehicle would avoid obstacles. See the parameter :ref:`AVOID_ACCEL_MAX <AVOID_ACCEL_MAX>`.
+
+.. warning:: Setting :ref:`AVOID_ACCEL_MAX <AVOID_ACCEL_MAX>` too low would mean that the response to the obstacle will be very sluggish and the vehicle may not be able to stop in time. Therefore, be careful while pushing this parameter to extremes.
+
+
+Minimum altitude (Copter only)
+------------------------------
+
+- If the sensor has a wide field of view, on takeoff and landings it might see the ground below as obstacle and the vehicle might react to it. 
+- Set the parameter :ref:`AVOID_ALT_MIN <AVOID_ALT_MIN>` to have a minimum altitude before avoidance is switched on.
+
+.. note:: This feature requires a valid Downward Facing Rangefinder reading to works
+
+
+
+Configuring Simple Avoidance for Copter in Altitude Hold Mode
+=============================================================
+
+.. warning:: While this mode does have the option of avoidance, avoidance in Loiter mode is much more advanced and has more features.
+
+- in :ref:`AltHold <altholdmode>`
+
+  - :ref:`AVOID_DIST_MAX <AVOID_DIST_MAX>` controls how far from a barrier the vehicle starts leaning away from the barrier
+  - :ref:`AVOID_ANGLE_MAX <AVOID_ANGLE_MAX>` controls how far the vehicle will try to lean away from the barrier


### PR DESCRIPTION
This updates Path Planning libraries documentation to Copter/Rover 4.1. This also sets up a new "proximity" hardware page, so that it can be removed from the rangefinder setup and have its own identity. I have also done some rearrangement to the main OA landing page.. hope it is fine. 

The only thing remaining from OA point of view is simple avoidance which is next on my list..  
I am really sorry @Hwurzburg for the huge delay despite the constant reminders from you. I had a branch ready, but needed videos or something else to complete it and hence did not push..

