### PR TITLE
Wiki:Dev: fixed typo

### DIFF
--- a/dev/source/docs/using-gazebo-simulator-with-sitl.rst
+++ b/dev/source/docs/using-gazebo-simulator-with-sitl.rst
@@ -63,7 +63,7 @@ The one from `khancyr <https://github.com/khancyr/ardupilot_gazebo>`__ is the or
 The one from `SwiftGust <https://github.com/SwiftGust/ardupilot_gazebo>`__  has more examples and a little bit more documentation.
 Both use the same plugin, they only differ in the documentation and examples they provide. 
 
-We will be using khancyr plugin for the following exaplation. First clone it somewhere in your home directory. (If you need help with git, please see :ref:`installed git <git-install>`, :ref:`forked <git-fork>` and :ref:`cloned <git-clone>`.)
+We will be using khancyr plugin for the following explanation. First clone it somewhere in your home directory. (If you need help with git, please see :ref:`installed git <git-install>`, :ref:`forked <git-fork>` and :ref:`cloned <git-clone>`.)
 
 ::
 


### PR DESCRIPTION
fix typo "exaplation" to explanation