### PR TITLE
Sphinxsetup.sh: install specific version of docutils to avoid __name_…

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -37,6 +37,9 @@ rm -f get-pip.py
 # Install sphinx
 python3 -m pip install --upgrade sphinx==1.8.3
 
+# install a specific version of docutils to avoid __name__ attribute error
+python3 -m pip install --upgrade docutils==0.16
+
 # Install sphinx theme from ArduPilot repository
 python3 -m pip install git+https://github.com/ArduPilot/sphinx_rtd_theme.git --upgrade
 


### PR DESCRIPTION
```
…_ problem

/usr/local/lib/python3.8/dist-packages/sphinx/util/nodes.py:94: FutureWarning:
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  for classifier in reversed(node.parent.traverse(nodes.classifier)):
/usr/local/lib/python3.8/dist-packages/sphinx/writers/html.py:462: FutureWarning:
   The iterable returned by Node.traverse()
   will become an iterator instead of a list in Docutils > 0.16.
  target_node = image_nodes and image_nodes[0] or node.parent

Exception occurred:
  File "/usr/local/lib/python3.8/dist-packages/docutils/nodes.py", line 2020, in dispatch_visit
    % (method.__name__, node_name))
AttributeError: 'functools.partial' object has no attribute '__name__'
The full traceback has been saved in /tmp/sphinx-err-wll2qejs.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```
