### PR TITLE
Plane: Change verbage for FBWA attitude holding

### DIFF
--- a/plane/source/docs/starting-up-and-calibrating-arduplane.rst
+++ b/plane/source/docs/starting-up-and-calibrating-arduplane.rst
@@ -149,7 +149,7 @@ List** and adjusting the parameters as shown in the screenshot below.
 
    These parameters are in radians (every 0.01 is about 0.6 of a
    degree) so adjust in increments of 0.01 initially. If the plane turns to
-   the left, :ref:`AHRS_TRIM_X<AHRS_TRIM_X>` should be increased. If the nose of the plane
+   the left, :ref:`AHRS_TRIM_X<AHRS_TRIM_X>` should be increased. If the nose of the plane is too low for a given throttle setting (ie flying too fast while holding altitude)
    dips down, :ref:`AHRS_TRIM_Y<AHRS_TRIM_Y>` should be increased.
 
 .. note:: this can only change the difference between the autopilot's plane and "level" by 10 degrees maximum. If more up pitch is needed (in the case that the autopilot is mounted slightly downward, for example), then you can use :ref:`TRIM_PITCH_CD<TRIM_PITCH_CD>` to further increase the "level" pitch value of the plane.

--- a/plane/source/docs/starting-up-and-calibrating-arduplane.rst
+++ b/plane/source/docs/starting-up-and-calibrating-arduplane.rst
@@ -124,10 +124,7 @@ test them in Auto mode.
 Level Adjustment
 ================
 
-You may find after flying your plane in FBWA that it has a tendency to
-turn in one direction and/or gains or loses height on a mid throttle
-setting with the transmitter sticks centered. If this happens, perform
-the following:
+You may find after flying your plane in FBWA that it does not hold level attitude with the transmitter sticks centered. If this happens, perform the following:
 
 1) With your autopilot powered on the ground and connected to your
 mission planner, select FBWA on your transmitter, select the FLIGHT DATA
@@ -152,7 +149,7 @@ List** and adjusting the parameters as shown in the screenshot below.
 
    These parameters are in radians (every 0.01 is about 0.6 of a
    degree) so adjust in increments of 0.01 initially. If the plane turns to
-   the left, :ref:`AHRS_TRIM_X<AHRS_TRIM_X>` should be increased. If the plane loses height
-   with mid throttle, :ref:`AHRS_TRIM_Y<AHRS_TRIM_Y>` should be increased.
+   the left, :ref:`AHRS_TRIM_X<AHRS_TRIM_X>` should be increased. If the nose of the plane
+   dips down, :ref:`AHRS_TRIM_Y<AHRS_TRIM_Y>` should be increased.
 
 .. note:: this can only change the difference between the autopilot's plane and "level" by 10 degrees maximum. If more up pitch is needed (in the case that the autopilot is mounted slightly downward, for example), then you can use :ref:`TRIM_PITCH_CD<TRIM_PITCH_CD>` to further increase the "level" pitch value of the plane.

--- a/plane/source/docs/starting-up-and-calibrating-arduplane.rst
+++ b/plane/source/docs/starting-up-and-calibrating-arduplane.rst
@@ -150,6 +150,6 @@ List** and adjusting the parameters as shown in the screenshot below.
    These parameters are in radians (every 0.01 is about 0.6 of a
    degree) so adjust in increments of 0.01 initially. If the plane turns to
    the left, :ref:`AHRS_TRIM_X<AHRS_TRIM_X>` should be increased. If the nose of the plane is too low for a given throttle setting (ie flying too fast while holding altitude)
-   dips down, :ref:`AHRS_TRIM_Y<AHRS_TRIM_Y>` should be increased.
+  , :ref:`AHRS_TRIM_Y<AHRS_TRIM_Y>` should be increased.
 
 .. note:: this can only change the difference between the autopilot's plane and "level" by 10 degrees maximum. If more up pitch is needed (in the case that the autopilot is mounted slightly downward, for example), then you can use :ref:`TRIM_PITCH_CD<TRIM_PITCH_CD>` to further increase the "level" pitch value of the plane.


### PR DESCRIPTION
I'm not sure how much this section of the docs is actually useful. FBWA should be for maintaining attitude and FBWB should for be height. This change at least makes it clearer that FBWA is for attitude.