### PR TITLE
Add support for Sphinx latexpdf output

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -44,6 +44,6 @@ python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinx_
 python3 -m pip install --user --upgrade git+https://github.com/sphinx-contrib/youtube.git
 
 # and a vimeo plugin:
-python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxcontrib.vimeo.git
+# python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxcontrib.vimeo.git
 
 echo "Setup completed successfully!"

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -41,7 +41,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
+    # 'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -243,7 +243,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-#'preamble': '',
+'preamble': r'\usepackage{CJK}',
 
 # Latex figure (float) alignment
 #'figure_align': 'htbp',

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -43,7 +43,7 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
+    # 'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -246,7 +246,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-#'preamble': '',
+'preamble': r'\usepackage{CJK}',
 
 # Latex figure (float) alignment
 #'figure_align': 'htbp',

--- a/update.py
+++ b/update.py
@@ -120,6 +120,20 @@ parser.add_argument(
     default=True,
     help="show debugging output",
 )
+parser.add_argument(
+    '--latexpdf',
+    dest='latexpdf',
+    action='store_true',
+    default=False,
+    help="output pdf using pdflatex"
+)
+parser.add_argument(
+    '--no-html',
+    dest='no_html',
+    action='store_true',
+    default=False,
+    help="disable html output"
+)
 
 args = parser.parse_args()
 # print(args.site)
@@ -214,7 +228,10 @@ def build_one(wiki):
     '''build one wiki'''
     print('make and clean: %s' % wiki)
     subprocess.check_call(["nice", "make", "clean"], cwd=wiki)
-    subprocess.check_call(["nice", "make", "html"], cwd=wiki)
+    if not args.no_html:
+        subprocess.check_call(["nice", "make", "html"], cwd=wiki)
+    if args.latexpdf:
+        subprocess.check_call(["nice", "make", "latexpdf"], cwd=wiki)
 
 
 def sphinx_make(site):


### PR DESCRIPTION
Currently I am a little stuck on the pdflatex portion of this. I hit a fatal error when getting to the jpeg for the Matek F405. Maybe someone with a more knowledge of pdflatex can help with that. I also get a slew of warnings from the inputenc package about Unicode characters.

To get to this point, I had to remove the sphinxcontrib.vimeo module since the sphinxcontrib.youtube module supports Vimeo in latex output. I have not checked what that looks like for the html. I also added a few options to the update.py file.

```
!pdfTeX error: pdflatex (file ./mamba_f405mk2_board.jpg): reading JPEG image fa
iled (no JPEG header found)
 ==> Fatal error occurred, no output PDF file produced!
Latexmk: Index file 'ArduPilot.idx' was written
Latexmk: Errors, so I did not complete making targets
Collected error summary (may duplicate other messages):
  pdflatex: Command for 'pdflatex' gave return code 256
Latexmk: Use the -f option to force complete processing,
 unless error was exceeding maximum runs of latex/pdflatex.
Makefile:29: recipe for target 'ArduPilot.pdf' failed
make[1]: *** [ArduPilot.pdf] Error 12
```