### PR TITLE
Dev: Static Analysis: add clang tools to Ubuntu install instructions

### DIFF
--- a/dev/source/docs/static-analysis.rst
+++ b/dev/source/docs/static-analysis.rst
@@ -20,7 +20,7 @@ You can do your own static analysis using autotest:
 
    You may need to install clang for this to work.
 
-   On Ubuntu, "sudo apt-get install clang"
+   On Ubuntu, `sudo apt-get install clang clang-tools`
 
    On Windows see https://clang.llvm.org/get_started.html
 


### PR DESCRIPTION
I also had to install clang tools, set both to version 7 to match CI