### PR TITLE
SiTL: Fix SIM_WIND_DIR explanation error

### DIFF
--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -291,7 +291,7 @@ Testing the effects of wind
 
 The wind direction, speed and turbulence can be changed to test their
 effect on flight behaviour. The following settings changes the wind so
-that it blows towards the South at a speed of 10 m/s.
+that it blows from the South at a speed of 10 m/s.
 
 ::
 


### PR DESCRIPTION
Parameter wind direction sets **from where** the wind is blowing

Tested by doing ALT_HOLD on 3m altitude, the copter is drifting north for these params:

- SIM_WIND_DIR 180
- SIM_WIND_SPD 3
- SIM_WIND_T_ALT 2

Just in case: drifts west for SIM_WIND_DIR 90