### PR TITLE
Remove sphinxcontrib.vimeo plugin

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -47,6 +47,11 @@ python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinx_
 python3 -m pip install --user --upgrade git+https://github.com/sphinx-contrib/youtube.git
 
 # and a vimeo plugin:
-python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxcontrib.vimeo.git
+# python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxcontrib.vimeo.git
+# we previously used this plugin, but the features are now included in the youtube plugin
+# remove if installed (will warn if not installed)
+if python3 -m pip show sphinxcontrib.vimeo > /dev/null 2>&1; then
+  python3 -m pip uninstall -y sphinxcontrib.vimeo
+fi
 
 echo "Setup completed successfully!"

--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -41,7 +41,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -43,7 +43,6 @@ extensions = [
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube', #For youtube embedding
-    'sphinxcontrib.vimeo', #For vimeo embedding
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
The sphinxcontrib.youtube plugin supports embedding Vimeo videos now. I did some spot checking to make sure that the video still worked as expected. The issue with using the current Vimeo plugin from our forked repo is that it does not support the latexpdf builder. The upstream repo is gone now.

One other option would be to add an `.. only:: html` block around each Vimeo video, but that creates an issue for when new Vimeo videos are added to the wiki.