### PR TITLE
Update download_and_installation.rst to install pathlib before MAVProxy to MacOS

### DIFF
--- a/mavproxy/source/docs/getting_started/download_and_installation.rst
+++ b/mavproxy/source/docs/getting_started/download_and_installation.rst
@@ -122,6 +122,7 @@ Install MAVProxy and its remaining dependencies from the public PyPi repository:
     sudo pip install gnureadline
     sudo pip install billiard
     sudo pip install numpy pyparsing
+    sudp pip install pathlib
     sudo pip install MAVProxy
 
 


### PR DESCRIPTION
I got following error when install MAVProxy to Mac OS (Big Sur 11.5.2):

--
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
conda-repo-cli 1.0.4 requires pathlib, which is not installed.
--

This error is cleared with installing pathlib.