### PR TITLE
corrected FS "reason" 5 to GCS Failsafe

### DIFF
--- a/plane/source/docs/apms-failsafe-function.rst
+++ b/plane/source/docs/apms-failsafe-function.rst
@@ -360,22 +360,26 @@ GCSs will often display text indicating the type of failsafe encountered, such a
    </tr>
    <tr>
    <td>4</td>
-   <td>GCS Failsafe</td>
+   <td>Battery Failsafe</td>
    </tr>
    <tr>
    <td>5</td>
-   <td>EKF Failsafe</td>
+   <td>GCS Failsafe</td>
    </tr>
    <tr>
    <td>6</td>
+   <td>EKF Failsafe</td>
+   </tr>
+   <tr>
+   <td>7</td>
    <td>GPS Glitch</td>
    </tr>
    <tr>
-   <td>9</td>
+   <td>8</td>
    <td>Fence Breached</td>
    </tr>
    <tr>
-   <td>10</td>
+   <td>9</td>
    <td>Terrain</td>
    </tr>
    <tr>

--- a/plane/source/docs/apms-failsafe-function.rst
+++ b/plane/source/docs/apms-failsafe-function.rst
@@ -375,23 +375,23 @@ GCSs will often display text indicating the type of failsafe encountered, such a
    <td>GPS Glitch</td>
    </tr>
    <tr>
-   <td>8</td>
+   <td>10</td>
    <td>Fence Breached</td>
    </tr>
    <tr>
-   <td>9</td>
+   <td>11</td>
    <td>Terrain</td>
    </tr>
    <tr>
-   <td>18</td>
+   <td>19</td>
    <td>Crash</td>
    </tr>
-   </tbody>
-   </table>
    <tr>
    <td>25+</td>
    <td>General unspecific</td>
    </tr>
+   </tbody>
+   </table>
 
 
 Independent Watchdog


### PR DESCRIPTION
Bat FS reason was missing from the list and made the numbering incorrect from 3 up.