### PR TITLE
Wrong information about Loiter_turns radius setting

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -1012,7 +1012,7 @@ for the parameter will be used.
 
 The radius of the circle is controlled by the
 :ref:`CIRCLE_RADIUS <copter:CIRCLE_RADIUS>`
-parameter (i.e. cannot be set as part of the command).
+parameter and can also be set by the command.
 
 This is the command equivalent of the :ref:`Circle flight mode <copter:circle-mode>`.
 
@@ -1037,7 +1037,7 @@ This is the command equivalent of the :ref:`Circle flight mode <copter:circle-mo
    <td></td>
    <td>Empty</td>
    </tr>
-   <tr style="color: #c0c0c0">
+   <tr>
    <td><strong>param3</strong></td>
    <td>Radius</td>
    <td>Empty</td>


### PR DESCRIPTION
With regards to COPTER, there was a false statement that the circle radius cannot be set as part of a NAV command. It is possible to set number of turn with param3. I don't know if this was different before, but in current firmware this is possible and tested. 
PS: Mission planner may not display the name of the param3 correctly (i did not check), but in QGC it is correct and works too.

![image](https://user-images.githubusercontent.com/31744367/133905783-77659a3e-dcb7-4497-8d09-2c08d814ea38.png)
