### PR TITLE
Added hyperlink to the commit being referred

### DIFF
--- a/dev/source/docs/the-ardupilot-autotest-framework.rst
+++ b/dev/source/docs/the-ardupilot-autotest-framework.rst
@@ -268,7 +268,7 @@ Adding a Test
 
    The autotest script is in flux.  This documentation may be out of date.
 
-The git commit e045f61473afa800afc241819cf890591fbecd5a in ArduPilot master's history is a reasonable example of adding an entirely new test to the ArduPilot suite.
+`This <https://github.com/ArduPilot/ardupilot/commit/e045f61473afa800afc241819cf890591fbecd5a>`__ git commit is a reasonable example of adding an entirely new test to the ArduPilot suite.
 
 
 Conducting an automated git bisect with an autotest


### PR DESCRIPTION
This helps the reader to directly jump to the commit being referred instead of putting efforts to search for the same first.