### PR TITLE
Re-org GSOC and add base page

### DIFF
--- a/dev/source/docs/gsoc.rst
+++ b/dev/source/docs/gsoc.rst
@@ -1,0 +1,28 @@
+.. _gsoc:
+    
+============================
+GSoC - Google Summer of Code
+============================
+ArduPilot participates in the `Google Summer of Code program <https://summerofcode.withgoogle.com/>`__  each year. Encouraging students and others to contribute to the ArduPilot code base.
+
+The development team includes experienced mentors who will help students make great contributions to ArduPilot. 
+
+To help you get started:
+
+- The :ref:`suggested projects list <gsoc-ideas-list>` is updated before GSoC begins each year. This a list of our ideas of what would be good to work on but we are open to other suggestions you make in your application.
+- The #GSOC channel in the `ArduPilot Discord server <https://ardupilot.org/discord>`__ is a place to ask questions about our GSOC program, submit ideas for projects, etc. Mentors will respond to your posts in this GSoC channel.
+- The :ref:`ArduPilot WIKI <ardupilot:home>` and, specifically, the :ref:`ArduPilot Developers WIKI <dev:home>` are good sources of information on ArduPilot and how to contribute to its code.
+
+Please note that there are likely to be more students applying than we will have places allocated by Google, so make sure you make your application is a good one. We are looking for:
+
+- Enthusiasm for your chosen project
+- Experience with the tools you will need to complete the project (eg. demonstrated ability in the relevant programming language or environment)
+- Details of past open source projects you have contributed to
+- Information on how you would approach the project, what time you can put into it and what you think you can achieve over the GSoC period
+
+Please feel free to post your ideas, or if you have more general questions, contact the mentors on our GSoC Discord channel referenced above.
+
+.. toctree::
+   :titlesonly:
+
+    GSOC Ideas List <gsoc-ideas-list>

--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -157,7 +157,7 @@ Full Table of Contents
     How The Team Works <docs/how-the-team-works>
     Events <docs/events>
     Training Centers <docs/common-training-centers>
-    GSoC 2021 project ideas <docs/gsoc-ideas-list>
+    GSoC <docs/gsoc>
     2021 Developers Conference<docs/2021-conference>
     Wiki Editing Guide <docs/common-wiki_editing_guide>
     USB IDs <docs/USB-IDs>


### PR DESCRIPTION
in prep to add GSOC as a main bar menu subitem in new  non concrete web page