### PR TITLE
Dev: update SITL Binaries Install Instructions

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -166,8 +166,9 @@ You can run SITL just as you can with any other build environment. To see the te
 Build SITL binaries for Windows
 ===============================
 
-You can build 32-bit binaries to be run outside of Cygwin with a small set of companion files. This can be useful when used in conjunction with Mission Planner to run SITL with a stable release build rather than a build from the development branch of ArduPilot. This can be done by compiling using the command below in Cygwin and copying the binary the "sitl" folder typically found at C:\\Users\\user\\Documents\\Mission Planner\\sitl. Mission Planner will download the required files during the first time running SITL. After the initial run, the vehicle-specific binary file can be replaced with the file you built.
+You can build 32-bit binaries to be run outside of Cygwin with a small set of companion files. This can be useful when used in conjunction with Mission Planner to run SITL with a stable release build rather than a build from the development branch of ArduPilot. This can be done by compiling using the command below in Cygwin and copying the binary the "sitl" folder typically found at C:\\Users\\user\\Documents\\Mission Planner\\sitl. Mission Planner will download the required files during the first time running SITL. After the initial run, the vehicle-specific binary file can be replaced with the file you built. The custom SITL binaries should be located at /ardupilot/build/sitl.
+
 
 ::
 
-      ./waf --board sitl configure
+      ./waf configure --board=sitl --toolchain i686-pc-cygwin


### PR DESCRIPTION
This adds the toolchain option required to build custom binaries for mission planner's sitl.

From discord, @stephendade,

"Mission Planner needs a 32bit build of ArduPilot. Issue is that cygwin64 gcc builds a 64bit by default. Changing the toolchain to i686-pc-cygwin tells Cygwin to use the 32bit toolchain. See https://stackoverflow.com/questions/27344540/what-do-the-c-compilers-on-cygwin-generate for details of the Cygwin64 toolchains.
To be precise, the supplied dlls in the Mission Planner sitl folder are all 32bit, so the sitl exe needs to be 32bit as well"