### PR TITLE
Fixing wiki build script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -108,7 +108,7 @@ git fetch origin
 git submodule update
 git reset --hard origin/master
 git clean -f -f -x -d -d
-pip install --user -U .
+python -m pip install --user -U .
 popd
 
 cd ardupilot_wiki


### PR DESCRIPTION
In wiki server "python" is pyhton2.7 and it have PIP working correctaly.

For some reason calling PIP is now calling pip3 but server`s python3 is python3.5 without pip3.

The idea here is force the use of python2.7 because it is the default python on server.