### PR TITLE
Add last build date

### DIFF
--- a/ardupilot/source/index.rst
+++ b/ardupilot/source/index.rst
@@ -207,6 +207,7 @@ Features
 
 
 
+Last build: |today|
 
 --------------
 


### PR DESCRIPTION
This adds a date code to the wiki saying when it was last build. I put it on the front index page, but it could go anywhere. Tested with sphinx 4.2.0 and 1.8.5 with python 3 and 2 all in WSL 1 Ubuntu 20.04. This would be a quick way to tell if the wiki is building correctly without checking for recent commits to show up or looking at logs on the build server.

It would look like this:
![image](https://user-images.githubusercontent.com/5710309/137530444-222f5253-c621-4834-a7f3-6cbf2c626001.png)
