### PR TITLE
Wiki:Doc error: param load cmd, changed '\' to '/'

### DIFF
--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -163,15 +163,15 @@ The MAVProxy commands to load the parameters for Copter, Rover and Plane
 
 ::
 
-    param load ..\Tools\autotest\default_params\copter.parm
+    param load ../Tools/autotest/default_params/copter.parm
 
 ::
 
-    param load ..\Tools\autotest\default_params\plane.parm
+    param load ../Tools/autotest/default_params/plane.parm
 
 ::
 
-    param load ..\Tools\autotest\default_params\rover.parm
+    param load ../Tools/autotest/default_params/rover.parm
 
 You can re-load the parameters later if you choose, or revert to the
 default parameters by starting SITL (**sim_vehicle.py**) with the


### PR DESCRIPTION
Problem: param load command was having backslashes ' \ ' instead of forward slashes ' / ' . causing error in parameters loading.
Changes: Changed Backslashes to forward slashes