### PR TITLE
Fixed: Page Not found error, Vscode WSL link

### DIFF
--- a/dev/source/docs/editing-the-code-with-vscode.rst
+++ b/dev/source/docs/editing-the-code-with-vscode.rst
@@ -10,4 +10,4 @@ VSCode can be downloaded from `here <https://code.visualstudio.com/>`__.
 
 It bundles all tools need to build ArduPilot : C/C++ support, python support, git support, :ref:`debugging support <debugging-with-gdb-on-linux>`.
 
-For Windows 10 users, the Remote - WSL extension lets you use the Windows Subsystem for Linux (WSL) as your full-time development environment right from VS Code: https://code.visualstudio.com/remote-tutorials/wsl/getting-started
+For Windows 10 users, the Remote - WSL extension lets you use the Windows Subsystem for Linux (WSL) as your full-time development environment right from VS Code: https://docs.microsoft.com/en-us/windows/wsl/tutorials/wsl-vscode


### PR DESCRIPTION
The existing link was not working. Added another working link.