### PR TITLE
Common: autopilots page gets link to schematics

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -122,3 +122,7 @@ available if you're still working on those platforms:
    PX4FMU
    Qualcomm Snapdragon Flight Kit
 
+Schematics
+----------
+
+Schematics for some of the "Open hardware" autopilots `can be found here <https://github.com/ArduPilot/Schematics>`__


### PR DESCRIPTION
This adds a link to find schematics for **some** of the open hardware boards

I have tested this change on my local WSL machine and it seems OK.