### PR TITLE
Dev: small update to mavlink interface section

### DIFF
--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -4,13 +4,13 @@
 Copter Commands in Guided Mode
 ==============================
 
-This article lists the MAVLink commands that Copter accepts.  Normally these commands are sent by a ground station or :ref:`Companion Computers <companion-computers>` often running `DroneKit <http://dronekit.io/>`__.
+This article lists the MAVLink commands that affect the movement of a Copter.  Normally these commands are sent by a ground station or :ref:`Companion Computers <companion-computers>` often running `DroneKit <http://dronekit.io/>`__.
 
 .. note::
 
    The Copter code which processes these commands can be found `here in GCS_Mavlink.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/GCS_Mavlink.cpp#L683>`__
 
-Movement commands
+Movement Commands
 =================
 
 These commands can be used to control the vehicle's position, velocity or attitude while in :ref:`Guided Mode <copter:ac2_guidedmode>`
@@ -27,77 +27,14 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavl
 - :ref:`MAV_CMD_COMPONENT_ARM_DISARM <copter:mav_cmd_component_arm_disarm>`
 - :ref:`MAV_CMD_CONDITION_YAW <copter:mav_cmd_condition_yaw>`
 - :ref:`MAV_CMD_DO_CHANGE_SPEED <copter:mav_cmd_do_change_speed>`
-- :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <copter:mav_cmd_do_digicam_configure>`
-- :ref:`MAV_CMD_DO_DIGICAM_CONTROL <copter:mav_cmd_do_digicam_control>`
-- :ref:`MAV_CMD_DO_FENCE_ENABLE <copter:mav_cmd_do_fence_enable>`
 - `MAV_CMD_DO_FLIGHTTERMINATION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FLIGHTTERMINATION>`__ - disarms motors immediately (Copter falls!).
-- :ref:`MAV_CMD_DO_GRIPPER <copter:mav_cmd_do_gripper>`
-- `MAV_CMD_DO_MOTOR_TEST <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_MOTOR_TEST>`__
 - :ref:`MAV_CMD_DO_PARACHUTE <copter:mav_cmd_do_parachute>`
-- :ref:`MAV_CMD_DO_REPEAT_SERVO <copter:mav_cmd_do_repeat_servo>`
-- :ref:`MAV_CMD_DO_REPEAT_RELAY <copter:mav_cmd_do_repeat_relay>`
-- `MAV_CMD_DO_SEND_BANNER <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_SEND_BANNER>`__
-- :ref:`MAV_CMD_DO_SET_HOME <copter:mav_cmd_do_set_home>`
-- :ref:`MAV_CMD_DO_SET_RELAY <copter:mav_cmd_do_set_relay>`
 - :ref:`MAV_CMD_DO_SET_ROI <copter:mav_cmd_do_set_roi>`
-- :ref:`MAV_CMD_DO_SET_SERVO <copter:mav_cmd_do_set_servo>`
-- `MAV_CMD_DO_MOUNT_CONFIGURE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONFIGURE>`__
-- :ref:`MAV_CMD_DO_MOUNT_CONTROL <copter:mav_cmd_do_mount_control>`
-- `MAV_CMD_GET_HOME_POSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_GET_HOME_POSITION>`__
-- :ref:`MAV_CMD_MISSION_START <copter:mav_cmd_mission_start>`
 - :ref:`MAV_CMD_NAV_TAKEOFF <copter:mav_cmd_nav_takeoff>`
 - :ref:`MAV_CMD_NAV_LOITER_UNLIM <copter:mav_cmd_nav_loiter_unlim>`
 - :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <copter:mav_cmd_nav_return_to_launch>`
 - :ref:`MAV_CMD_NAV_LAND <copter:mav_cmd_nav_land>`
-- `MAV_CMD_PREFLIGHT_CALIBRATION <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_CALIBRATION>`__
-- `MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS>`__
 - `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
-- `MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES <https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES>`__
-- `MAV_CMD_START_RX_PAIR <https://mavlink.io/en/messages/common.html#MAV_CMD_START_RX_PAIR>`__ - starts receiver pairing
-- `MAV_CMD_DO_START_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_START_MAG_CAL>`__
-- `MAV_CMD_DO_ACCEPT_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_ACCEPT_MAG_CAL>`__
-- `MAV_CMD_DO_CANCEL_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_CANCEL_MAG_CAL>`__
-
-Other commands
-==============
-
-Below are other commands that will be handled by Copter
-
-- `ADSB_VEHICLE <https://mavlink.io/en/messages/common.html#ADSB_VEHICLE>`__
-- `AUTOPILOT_VERSION_REQUEST <https://mavlink.io/en/messages/ardupilotmega.html#AUTOPILOT_VERSION_REQUEST>`__
-- `COMMAND_ACK <https://mavlink.io/en/messages/common.html#COMMAND_ACK>`__
-- `GIMBAL_REPORT <https://mavlink.io/en/messages/ardupilotmega.html#GIMBAL_REPORT>`__
-- `GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
-- `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__
-- `HIL_STATE <https://mavlink.io/en/messages/common.html#HIL_STATE>`__
-- `LANDING_TARGET <https://mavlink.io/en/messages/common.html#LANDING_TARGET>`__
-- `LED_CONTROL <https://mavlink.io/en/messages/ardupilotmega.html#LED_CONTROL>`__
-- `LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__
-- `LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__
-- `LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__
-- `LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__
-- `MISSION_CLEAR_ALL <https://mavlink.io/en/messages/common.html#MISSION_CLEAR_ALL>`__
-- `MISSION_COUNT <https://mavlink.io/en/messages/common.html#MISSION_COUNT>`__
-- `MISSION_ITEM <https://mavlink.io/en/messages/common.html#MISSION_ITEM>`__
-- `MISSION_REQUEST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST>`__
-- `MISSION_REQUEST_LIST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST_LIST>`__
-- `MISSION_SET_CURRENT <https://mavlink.io/en/messages/common.html#MISSION_SET_CURRENT>`__
-- `MISSION_WRITE_PARTIAL_LIST <https://mavlink.io/en/messages/common.html#MISSION_WRITE_PARTIAL_LIST>`__
-- `PARAM_REQUEST_READ <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_READ>`__
-- `PARAM_REQUEST_LIST <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_LIST>`__
-- `PARAM_SET <https://mavlink.io/en/messages/common.html#PARAM_SET>`__
-- `RADIO <https://mavlink.io/en/messages/ardupilotmega.html#RADIO>`__
-- `RADIO_STATUS <https://mavlink.io/en/messages/common.html#RADIO_STATUS>`__
-- `RALLY_FETCH_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_FETCH_POINT>`__
-- `RALLY_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_POINT>`__
-- `RC_CHANNELS_OVERRIDE <https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE>`__
-- `REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__
-- `REMOTE_LOG_BLOCK_STATUS <https://mavlink.io/en/messages/ardupilotmega.html#REMOTE_LOG_BLOCK_STATUS>`__
-- `SERIAL_CONTROL <https://mavlink.io/en/messages/common.html#SERIAL_CONTROL>`__
-- :ref:`SET_HOME_POSITION <mavlink-get-set-home-and-origin_set_home_position>`
-- `SET_MODE <https://mavlink.io/en/messages/common.html#SET_MODE>`__
-- `TERRAIN_DATA <https://mavlink.io/en/messages/common.html#TERRAIN_DATA>`__
-- `TERRAIN_CHECK <https://mavlink.io/en/messages/common.html#TERRAIN_CHECK>`__
 
 Movement Command Details
 ========================

--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -20,6 +20,7 @@ ArduPilot supports the MAVLink protocol for communication with Ground Stations a
     Get and Set FlightMode <mavlink-get-set-flightmode>
     Mission Upload/Download <mavlink-mission-upload-download>
     MAVLink Routing <mavlink-routing-in-ardupilot>
+    Other Commands <mavlink-other-commands>
 
 External References
 -------------------

--- a/dev/source/docs/mavlink-get-set-home-and-origin.rst
+++ b/dev/source/docs/mavlink-get-set-home-and-origin.rst
@@ -15,6 +15,8 @@ The "EKF origin" is the location that the EKF (aka AHRS) uses for internal calcu
 
 Whenever the Home or EKF origin is updated the vehicle will send a `HOME_POSITION <https://mavlink.io/en/messages/common.html#HOME_POSITION>`__ or `GPS_GLOBAL_ORIGIN <https://mavlink.io/en/messages/common.html#GPS_GLOBAL_ORIGIN>`__ message (respectively) on all active mavlink channels.
 
+The home will also be sent in response to a `MAV_CMD_GET_HOME_POSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_GET_HOME_POSITION>`__ sent within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
+
 .. _mavlink-get-set-home-and-origin_set_home_position:
 
 SET_HOME_POSITION

--- a/dev/source/docs/mavlink-other-commands.rst
+++ b/dev/source/docs/mavlink-other-commands.rst
@@ -1,0 +1,64 @@
+.. _mavlink-other-commands:
+
+==================================
+MAVLink Interface's Other Commands
+==================================
+
+This article lists other commonly used MAVLink commands that do not directly affect how a vehicle moves and that are not covered by other pages.
+
+MAV_CMDs
+=========
+
+These MAV_CMDs should be packaged within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
+
+- :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <copter:mav_cmd_do_digicam_configure>`
+- :ref:`MAV_CMD_DO_DIGICAM_CONTROL <copter:mav_cmd_do_digicam_control>`
+- :ref:`MAV_CMD_DO_FENCE_ENABLE <copter:mav_cmd_do_fence_enable>`
+- :ref:`MAV_CMD_DO_GRIPPER <copter:mav_cmd_do_gripper>`
+- `MAV_CMD_DO_MOTOR_TEST <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_MOTOR_TEST>`__
+- :ref:`MAV_CMD_DO_PARACHUTE <copter:mav_cmd_do_parachute>`
+- :ref:`MAV_CMD_DO_REPEAT_SERVO <copter:mav_cmd_do_repeat_servo>`
+- :ref:`MAV_CMD_DO_REPEAT_RELAY <copter:mav_cmd_do_repeat_relay>`
+- `MAV_CMD_DO_SEND_BANNER <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_SEND_BANNER>`__
+- :ref:`MAV_CMD_DO_SET_RELAY <copter:mav_cmd_do_set_relay>`
+- :ref:`MAV_CMD_DO_SET_SERVO <copter:mav_cmd_do_set_servo>`
+- `MAV_CMD_DO_MOUNT_CONFIGURE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_MOUNT_CONFIGURE>`__
+- :ref:`MAV_CMD_DO_MOUNT_CONTROL <copter:mav_cmd_do_mount_control>`
+- :ref:`MAV_CMD_MISSION_START <copter:mav_cmd_mission_start>`
+- `MAV_CMD_PREFLIGHT_CALIBRATION <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_CALIBRATION>`__
+- `MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS>`__
+- `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
+- `MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES <https://mavlink.io/en/messages/common.html#MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES>`__
+- `MAV_CMD_START_RX_PAIR <https://mavlink.io/en/messages/common.html#MAV_CMD_START_RX_PAIR>`__ - starts receiver pairing
+- `MAV_CMD_DO_START_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_START_MAG_CAL>`__
+- `MAV_CMD_DO_ACCEPT_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_ACCEPT_MAG_CAL>`__
+- `MAV_CMD_DO_CANCEL_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_CANCEL_MAG_CAL>`__
+
+Other commands
+==============
+
+Below are other commands that will be handled by Copter
+
+- `ADSB_VEHICLE <https://mavlink.io/en/messages/common.html#ADSB_VEHICLE>`__
+- `AUTOPILOT_VERSION_REQUEST <https://mavlink.io/en/messages/ardupilotmega.html#AUTOPILOT_VERSION_REQUEST>`__
+- `COMMAND_ACK <https://mavlink.io/en/messages/common.html#COMMAND_ACK>`__
+- `GIMBAL_REPORT <https://mavlink.io/en/messages/ardupilotmega.html#GIMBAL_REPORT>`__
+- `GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
+- `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__
+- `HIL_STATE <https://mavlink.io/en/messages/common.html#HIL_STATE>`__
+- `LANDING_TARGET <https://mavlink.io/en/messages/common.html#LANDING_TARGET>`__
+- `LED_CONTROL <https://mavlink.io/en/messages/ardupilotmega.html#LED_CONTROL>`__
+- `LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__
+- `LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__
+- `LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__
+- `LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__
+- `RADIO <https://mavlink.io/en/messages/ardupilotmega.html#RADIO>`__
+- `RADIO_STATUS <https://mavlink.io/en/messages/common.html#RADIO_STATUS>`__
+- `RALLY_FETCH_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_FETCH_POINT>`__
+- `RALLY_POINT <https://mavlink.io/en/messages/ardupilotmega.html#RALLY_POINT>`__
+- `RC_CHANNELS_OVERRIDE <https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE>`__
+- `REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__
+- `REMOTE_LOG_BLOCK_STATUS <https://mavlink.io/en/messages/ardupilotmega.html#REMOTE_LOG_BLOCK_STATUS>`__
+- `SERIAL_CONTROL <https://mavlink.io/en/messages/common.html#SERIAL_CONTROL>`__
+- `TERRAIN_DATA <https://mavlink.io/en/messages/common.html#TERRAIN_DATA>`__
+- `TERRAIN_CHECK <https://mavlink.io/en/messages/common.html#TERRAIN_CHECK>`__


### PR DESCRIPTION
This PR attempts to make it easier for developers to find the mavlink interface messages they are looking for by splitting upC Copter's commands page into two pages.  One for movement related commands (which is what most devs want) and non-movement related commands (which actually apply to all vehicles I think)

I have tested these changes on my local WSL machine and they seem OK.