### PR TITLE
Dev: mavlink interface for Plane

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -166,75 +166,38 @@ Commands supported by Copter
 This list of commands was inferred from the command handler in
 `/ArduCopter/mode_auto.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_auto.cpp#L388>`__. 
 
-:ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
-
-:ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
-
-:ref:`MAV_CMD_NAV_TAKEOFF <mav_cmd_nav_takeoff>`
-
-:ref:`MAV_CMD_NAV_LAND <mav_cmd_nav_land>`
-
-:ref:`MAV_CMD_NAV_LOITER_UNLIM <mav_cmd_nav_loiter_unlim>`
-
-:ref:`MAV_CMD_NAV_LOITER_TURNS <mav_cmd_nav_loiter_turns>`
-
-:ref:`MAV_CMD_NAV_LOITER_TIME <mav_cmd_nav_loiter_time>`
-
-:ref:`MAV_CMD_NAV_SPLINE_WAYPOINT <mav_cmd_nav_spline_waypoint>`
-
-:ref:`MAV_CMD_NAV_GUIDED_ENABLE <mav_cmd_nav_guided_enable>`
-(NAV_GUIDED only)
-
-:ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
-
-:ref:`MAV_CMD_MISSION_START <mav_cmd_mission_start>`
-
-:ref:`MAV_CMD_COMPONENT_ARM_DISARM <mav_cmd_component_arm_disarm>`
-
-:ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
-
-:ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
-
-:ref:`MAV_CMD_CONDITION_YAW <mav_cmd_condition_yaw>`
-
-:ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
-
-:ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
-
-:ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
-
-:ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
-
-:ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
-
-:ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
-
-:ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera
-enabled only)
-
-:ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>`
-
-:ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
-
-:ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
-
-:ref:`MAV_CMD_DO_PARACHUTE <mav_cmd_do_parachute>` (Parachute enabled
-only)
-
-:ref:`MAV_CMD_DO_GRIPPER <mav_cmd_do_gripper>` (EPM enabled only)
-
-:ref:`MAV_CMD_DO_GUIDED_LIMITS <mav_cmd_do_guided_limits>`
-(NAV_GUIDED only)
-
-:ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
-
-:ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
+- :ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
+- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
+- :ref:`MAV_CMD_NAV_TAKEOFF <mav_cmd_nav_takeoff>`
+- :ref:`MAV_CMD_NAV_LAND <mav_cmd_nav_land>`
+- :ref:`MAV_CMD_NAV_LOITER_UNLIM <mav_cmd_nav_loiter_unlim>`
+- :ref:`MAV_CMD_NAV_LOITER_TURNS <mav_cmd_nav_loiter_turns>`
+- :ref:`MAV_CMD_NAV_LOITER_TIME <mav_cmd_nav_loiter_time>`
+- :ref:`MAV_CMD_NAV_SPLINE_WAYPOINT <mav_cmd_nav_spline_waypoint>`
+- :ref:`MAV_CMD_NAV_GUIDED_ENABLE <mav_cmd_nav_guided_enable>` (NAV_GUIDED only)
+- :ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
+- :ref:`MAV_CMD_MISSION_START <mav_cmd_mission_start>`
+- :ref:`MAV_CMD_COMPONENT_ARM_DISARM <mav_cmd_component_arm_disarm>`
+- :ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
+- :ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
+- :ref:`MAV_CMD_CONDITION_YAW <mav_cmd_condition_yaw>`
+- :ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
+- :ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
+- :ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
+- :ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
+- :ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
+- :ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
+- :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>`
+- :ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
+- :ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
+- :ref:`MAV_CMD_DO_PARACHUTE <mav_cmd_do_parachute>` (Parachute enabled only)
+- :ref:`MAV_CMD_DO_GRIPPER <mav_cmd_do_gripper>` (EPM enabled only)
+- :ref:`MAV_CMD_DO_GUIDED_LIMITS <mav_cmd_do_guided_limits>` (NAV_GUIDED only)
+- :ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
+- :ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
 
 [/site]
 
@@ -245,80 +208,40 @@ Commands supported by Plane
 This list of commands was inferred from the command handler in
 `/ArduPlane/commands_logic.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/commands_logic.cpp#L33>`__. 
 
-:ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
-
-:ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
-
-:ref:`MAV_CMD_NAV_TAKEOFF <mav_cmd_nav_takeoff>`
-
-:ref:`MAV_CMD_NAV_LAND <mav_cmd_nav_land>`
-
-:ref:`MAV_CMD_NAV_LOITER_UNLIM <mav_cmd_nav_loiter_unlim>`
-
-:ref:`MAV_CMD_NAV_LOITER_TURNS <mav_cmd_nav_loiter_turns>`
-
-:ref:`MAV_CMD_NAV_LOITER_TIME <mav_cmd_nav_loiter_time>`
-
-:ref:`MAV_CMD_NAV_ALTITUDE_WAIT <mav_cmd_nav_altitude_wait>`
-
-:ref:`MAV_CMD_NAV_LOITER_TO_ALT <mav_cmd_nav_loiter_to_alt>`
-
-:ref:`MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT <mav_cmd_nav_continue_and_change_alt>`
-
-:ref:`MAV_CMD_NAV_VTOL_TAKEOFF <mav_cmd_nav_vtol_takeoff>`
-
-:ref:`MAV_CMD_NAV_VTOL_LAND <mav_cmd_nav_vtol_land>`
-
-
-
-:ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
-
-:ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
-
-
-:ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
-
-:ref:`MAV_CMD_DO_ENGINE_CONTROL <mav_cmd_do_engine_control>`
-
-:ref:`MAV_CMD_DO_VTOL_TRANSITION <mav_cmd_do_vtol_transition>`
-
-:ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
-
-:ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
-
-:ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
-
-:ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
-
-:ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
-
-:ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera
-enabled only)
-
-:ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>` (Gimbal/mount enabled
-only)
-
-:ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
-
-:ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
-
-:ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
-
-:ref:`MAV_CMD_DO_INVERTED_FLIGHT <mav_cmd_do_inverted_flight>`
-
-:ref:`MAV_CMD_DO_LAND_START <mav_cmd_do_land_start>`
-
-:ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
-
-:ref:`MAV_CMD_DO_AUTOTUNE_ENABLE <mav_cmd_do_autotune_enable>`
-
-:ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
+- :ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
+- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
+- :ref:`MAV_CMD_NAV_TAKEOFF <mav_cmd_nav_takeoff>`
+- :ref:`MAV_CMD_NAV_LAND <mav_cmd_nav_land>`
+- :ref:`MAV_CMD_NAV_LOITER_UNLIM <mav_cmd_nav_loiter_unlim>`
+- :ref:`MAV_CMD_NAV_LOITER_TURNS <mav_cmd_nav_loiter_turns>`
+- :ref:`MAV_CMD_NAV_LOITER_TIME <mav_cmd_nav_loiter_time>`
+- :ref:`MAV_CMD_NAV_ALTITUDE_WAIT <mav_cmd_nav_altitude_wait>`
+- :ref:`MAV_CMD_NAV_LOITER_TO_ALT <mav_cmd_nav_loiter_to_alt>`
+- :ref:`MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT <mav_cmd_nav_continue_and_change_alt>`
+- :ref:`MAV_CMD_NAV_VTOL_TAKEOFF <mav_cmd_nav_vtol_takeoff>`
+- :ref:`MAV_CMD_NAV_VTOL_LAND <mav_cmd_nav_vtol_land>`
+- :ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
+- :ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
+- :ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
+- :ref:`MAV_CMD_DO_ENGINE_CONTROL <mav_cmd_do_engine_control>`
+- :ref:`MAV_CMD_DO_VTOL_TRANSITION <mav_cmd_do_vtol_transition>`
+- :ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
+- :ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
+- :ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
+- :ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
+- :ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
+- :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>` (Gimbal/mount enabled only)
+- :ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
+- :ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
+- :ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
+- :ref:`MAV_CMD_DO_INVERTED_FLIGHT <mav_cmd_do_inverted_flight>`
+- :ref:`MAV_CMD_DO_LAND_START <mav_cmd_do_land_start>`
+- :ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
+- :ref:`MAV_CMD_DO_AUTOTUNE_ENABLE <mav_cmd_do_autotune_enable>`
+- :ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
 
 [/site]
 
@@ -333,47 +256,25 @@ Commands supported by Rover
 This list of commands was inferred from the command handler in
 `/Rover/commands_logic.cpp <https://github.com/ArduPilot/ardupilot/blob/master/Rover/commands_logic.cpp#L25>`__. 
 
-:ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
-
-:ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
-
-:ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
-
-:ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
-
-:ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
-
-:ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
-
-:ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
-
-:ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
-
-:ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
-
-:ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
-
-:ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
-
-:ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera
-enabled only)
-
-:ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
-
-:ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>`
-(Camera enabled only)
-
-:ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>` (Gimbal/mount enabled
-only)
-
-:ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
-
-:ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
-
-:ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
+- :ref:`MAV_CMD_NAV_WAYPOINT <mav_cmd_nav_waypoint>`
+- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <mav_cmd_nav_return_to_launch>`
+- :ref:`MAV_CMD_DO_JUMP <mav_cmd_do_jump>`
+- :ref:`MAV_CMD_CONDITION_DELAY <mav_cmd_condition_delay>`
+- :ref:`MAV_CMD_CONDITION_DISTANCE <mav_cmd_condition_distance>`
+- :ref:`MAV_CMD_DO_CHANGE_SPEED <mav_cmd_do_change_speed>`
+- :ref:`MAV_CMD_DO_SET_HOME <mav_cmd_do_set_home>`
+- :ref:`MAV_CMD_DO_SET_SERVO <mav_cmd_do_set_servo>`
+- :ref:`MAV_CMD_DO_SET_RELAY <mav_cmd_do_set_relay>`
+- :ref:`MAV_CMD_DO_REPEAT_SERVO <mav_cmd_do_repeat_servo>`
+- :ref:`MAV_CMD_DO_REPEAT_RELAY <mav_cmd_do_repeat_relay>`
+- :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <mav_cmd_do_digicam_configure>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_DIGICAM_CONTROL <mav_cmd_do_digicam_control>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_MOUNT_CONTROL <mav_cmd_do_mount_control>`
+- :ref:`MAV_CMD_DO_SET_CAM_TRIGG_DIST <mav_cmd_do_set_cam_trigg_dist>` (Camera enabled only)
+- :ref:`MAV_CMD_DO_SET_ROI <mav_cmd_do_set_roi>` (Gimbal/mount enabled only)
+- :ref:`MAV_CMD_DO_SET_MODE <mav_cmd_do_set_mode>`
+- :ref:`MAV_CMD_DO_SET_RESUME_DIST <mav_cmd_do_set_resume_dist>`
+- :ref:`MAV_CMD_DO_FENCE_ENABLE <mav_cmd_do_fence_enable>`
 
 [/site]
 

--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -24,7 +24,6 @@ MAV_CMDs
 
 These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
 
-- :ref:`MAV_CMD_COMPONENT_ARM_DISARM <copter:mav_cmd_component_arm_disarm>`
 - :ref:`MAV_CMD_CONDITION_YAW <copter:mav_cmd_condition_yaw>`
 - :ref:`MAV_CMD_DO_CHANGE_SPEED <copter:mav_cmd_do_change_speed>`
 - `MAV_CMD_DO_FLIGHTTERMINATION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_FLIGHTTERMINATION>`__ - disarms motors immediately (Copter falls!).
@@ -35,6 +34,10 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavl
 - :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <copter:mav_cmd_nav_return_to_launch>`
 - :ref:`MAV_CMD_NAV_LAND <copter:mav_cmd_nav_land>`
 - `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
+
+These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ message
+
+- `MAV_CMD_DO_REPOSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION>`__
 
 Movement Command Details
 ========================

--- a/dev/source/docs/mavlink-other-commands.rst
+++ b/dev/source/docs/mavlink-other-commands.rst
@@ -11,12 +11,16 @@ MAV_CMDs
 
 These MAV_CMDs should be packaged within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
 
+- :ref:`MAV_CMD_DO_AUTOTUNE_ENABLE <plane:mav_cmd_do_autotune_enable>` (Plane only)
 - :ref:`MAV_CMD_DO_DIGICAM_CONFIGURE <copter:mav_cmd_do_digicam_configure>`
 - :ref:`MAV_CMD_DO_DIGICAM_CONTROL <copter:mav_cmd_do_digicam_control>`
 - :ref:`MAV_CMD_DO_FENCE_ENABLE <copter:mav_cmd_do_fence_enable>`
+- `MAV_CMD_DO_GO_AROUND <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_GO_AROUND>`__ (Plane only)
+- `MAV_CMD_DO_LAND_START <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_LAND_START>`__ (Plane only)
 - :ref:`MAV_CMD_DO_GRIPPER <copter:mav_cmd_do_gripper>`
 - `MAV_CMD_DO_MOTOR_TEST <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_MOTOR_TEST>`__
 - :ref:`MAV_CMD_DO_PARACHUTE <copter:mav_cmd_do_parachute>`
+- `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
 - :ref:`MAV_CMD_DO_REPEAT_SERVO <copter:mav_cmd_do_repeat_servo>`
 - :ref:`MAV_CMD_DO_REPEAT_RELAY <copter:mav_cmd_do_repeat_relay>`
 - `MAV_CMD_DO_SEND_BANNER <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_SEND_BANNER>`__
@@ -42,6 +46,8 @@ Below are other commands that will be handled by Copter
 - `ADSB_VEHICLE <https://mavlink.io/en/messages/common.html#ADSB_VEHICLE>`__
 - `AUTOPILOT_VERSION_REQUEST <https://mavlink.io/en/messages/ardupilotmega.html#AUTOPILOT_VERSION_REQUEST>`__
 - `COMMAND_ACK <https://mavlink.io/en/messages/common.html#COMMAND_ACK>`__
+- `FENCE_POINT <https://mavlink.io/en/messages/ardupilotmega.html#FENCE_POINT>`__
+- `FENCE_FETCH_POINT <https://mavlink.io/en/messages/ardupilotmega.html#FENCE_FETCH_POINT>`__
 - `GIMBAL_REPORT <https://mavlink.io/en/messages/ardupilotmega.html#GIMBAL_REPORT>`__
 - `GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
 - `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__

--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -4,158 +4,54 @@
 Plane Commands in Guided Mode
 =============================
 
-This article lists the commands that are handled by Plane in GUIDED mode
-(for example, when writing GCS or Companion Computer apps in
-`DroneKit <http://dronekit.io/>`__). Except where explicitly stated,
-most of these can also be called in other modes too.
+This article lists the MAVLink commands that affect the movement of a Plane or Quadplane.  Normally these commands are sent by a ground station or :ref:`Companion Computers <companion-computers>` often running `DroneKit <http://dronekit.io/>`__.
 
 .. note::
 
-   The list is inferred from Plane's
-   `GCS_Mavlink.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/GCS_Mavlink.cpp>`__
+   The code which processes these commands can be found `here in GCS_Mavlink.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/GCS_Mavlink.cpp>`__
 
 Movement commands
 =================
 
-For movement, Plane uses:
+To command a plane to move to a particular lat, lon, alt send a :ref:`MAV_CMD_NAV_WAYPOINT <plane:mav_cmd_nav_waypoint>` (16) within a `MISSION_ITEM_INT <https://mavlink.io/en/messages/common.html#MISSION_ITEM_INT>`__ with the following fields set as follows:
 
-:ref:`MAV_CMD_NAV_WAYPOINT <plane:mav_cmd_nav_waypoint>`
-message encoded with the "current" parameter set to "2" to indicate that
-it is a guided mode "goto" message.
+- "current" = 2 to indicate that it is a guided mode "goto" message
+- "frame" = 0 or 3 for alt-above-sea-level, 6 for alt-above-home or 11 for alt-above-terrain
+- "x" = longitude * 1e7
+- "y" = latitude * 1e7
+- "z" = altitude in meters
+
+**Examples**
+
+Here are some example commands that can be copy-pasted into MAVProxy (aka SITL) to test this command.  Before running these commands:
+
+- module load message
+- create an Auto mission ("wp editor") with a NAV_TAKEOFF command with Alt of 100m
+- arm throttle
+- Auto (wait until vehicle begins circling)
+- GUIDED (and enter one of the commands below)
+
++--------------------------------------------------------------------------------+----------------------------------------------------------+
+| Example MAVProxy/SITL Command                                                  | Description                                              |
++================================================================================+==========================================================+
+| ``message MISSION_ITEM_INT 0 0 0 0 16 2 0 0 0 0 0 -353621474 1491651746 700``  | fly to lat,lon of -35.36,149.16 and 700m above sea level |
++--------------------------------------------------------------------------------+----------------------------------------------------------+
+| ``message MISSION_ITEM_INT 0 0 0 6 16 2 0 0 0 0 0 -353621474 1491651746 100``  | fly to lat,lon of -35.36,149.16 and 100m above home      |
++--------------------------------------------------------------------------------+----------------------------------------------------------+
+| ``message MISSION_ITEM_INT 0 0 0 11 16 2 0 0 0 0 0 -353621474 1491651746 100`` | fly to lat,lon of -35.36,149.16 and 100m above terrain   |
++--------------------------------------------------------------------------------+----------------------------------------------------------+
 
 MAV_CMDs
 =========
 
-These MAV_CMDs can be processed if packaged within a
-`COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message.
+These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message
 
-:ref:`MAV_CMD_NAV_LOITER_UNLIM <plane:mav_cmd_nav_loiter_unlim>`
+- :ref:`MAV_CMD_NAV_LOITER_UNLIM <plane:mav_cmd_nav_loiter_unlim>`
+- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <plane:mav_cmd_nav_return_to_launch>`
 
-:ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <plane:mav_cmd_nav_return_to_launch>`
+These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ message
 
-:ref:`MAV_CMD_DO_SET_ROI <plane:mav_cmd_do_set_roi>`
+- `MAV_CMD_DO_REPOSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION>`__
 
-MAV_CMD_MISSION_START 
 
-MAV_CMD_COMPONENT_ARM_DISARM
 
-.. todo::
-
-    MAV_CMD_MISSION_START and MAV_CMD_COMPONENT_ARM_DISARM not implemented as
-    auto commands (or at least not when I did the master doc. Need to
-    confirm that they aren't AUTO commands, that they are guided commands,
-    and if so then document either here or in the command list.
-
-:ref:`MAV_CMD_DO_SET_SERVO <plane:mav_cmd_do_set_servo>`
-
-:ref:`MAV_CMD_DO_REPEAT_SERVO <plane:mav_cmd_do_repeat_servo>`
-
-:ref:`MAV_CMD_DO_SET_RELAY <plane:mav_cmd_do_set_relay>`
-
-:ref:`MAV_CMD_DO_REPEAT_RELAY <plane:mav_cmd_do_repeat_relay>`
-
-:ref:`MAV_CMD_DO_FENCE_ENABLE <plane:mav_cmd_do_fence_enable>`
-
-:ref:`MAV_CMD_DO_SET_HOME <plane:mav_cmd_do_set_home>`
-
-MAV_CMD_START_RX_PAIR
-
-MAV_CMD_PREFLIGHT_CALIBRATION
-
-MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS
-
-MAV_CMD_DO_SET_MODE
-
-MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN
-
-MAV_CMD_DO_LAND_START
-
-MAV_CMD_DO_GO_AROUND
-
-MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES
-
-:ref:`MAV_CMD_DO_AUTOTUNE_ENABLE <plane:mav_cmd_do_autotune_enable>`
-
-These MAV_CMD commands can be sent as their own message type (not
-inside `:ref:`COMMAND_LONG``): `MAV_CMD_DO_DIGICAM_CONFIGURE <plane:mav_cmd_do_digicam_configure>`
-
-:ref:`MAV_CMD_DO_DIGICAM_CONTROL <plane:mav_cmd_do_digicam_control>`
-
-MAV_CMD_DO_MOUNT_CONFIGURE
-
-:ref:`MAV_CMD_DO_MOUNT_CONTROL <plane:mav_cmd_do_mount_control>`
-
-Other commands
-==============
-
-Below are other (non-MAV_CMD) commands that will be handled by Plane in
-GUIDED mode.
-
-.. note::
-
-   Most of these commands are not relevant to DroneKit-Python apps or
-   are already provided through the API.
-
-`SET_MODE <https://mavlink.io/en/messages/common.html#SET_MODE>`__
-
-`MISSION_REQUEST_LIST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST_LIST>`__
-
-`MISSION_REQUEST <https://mavlink.io/en/messages/common.html#MISSION_REQUEST>`__
-
-MISSION_ACK:
-
-`PARAM_REQUEST_LIST <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_LIST>`__
-
-`PARAM_REQUEST_READ <https://mavlink.io/en/messages/common.html#PARAM_REQUEST_READ>`__
-
-`MISSION_CLEAR_ALL <https://mavlink.io/en/messages/common.html#MISSION_CLEAR_ALL>`__
-
-`MISSION_SET_CURRENT <https://mavlink.io/en/messages/common.html#MISSION_SET_CURRENT>`__
-
-`MISSION_COUNT <https://mavlink.io/en/messages/common.html#MISSION_COUNT>`__
-
-`MISSION_WRITE_PARTIAL_LIST <https://mavlink.io/en/messages/common.html#MISSION_WRITE_PARTIAL_LIST>`__
-
-`MISSION_ITEM <https://mavlink.io/en/messages/common.html#MISSION_ITEM>`__
-
-MAVLINK_MSG_ID_FENCE_POINT
-
-MAVLINK_MSG_ID_FENCE_FETCH_POINT
-
-RALLY_POINT
-
-RALLY_FETCH_POINT
-
-`PARAM_SET <https://mavlink.io/en/messages/common.html#PARAM_SET>`__
-
-GIMBAL_REPORT
-
-`RC_CHANNELS_OVERRIDE <https://mavlink.io/en/messages/common.html#RC_CHANNELS_OVERRIDE>`__
-
-`HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__
-
-`HIL_STATE <https://mavlink.io/en/messages/common.html#HIL_STATE>`__
-
-RADIO
-
-`RADIO_STATUS <https://mavlink.io/en/messages/common.html#RADIO_STATUS>`__
-
-`LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__
-
-`LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__
-
-`LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__
-
-`LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__
-
-`SERIAL_CONTROL <https://mavlink.io/en/messages/common.html#SERIAL_CONTROL>`__
-
-`GPS_INJECT_DATA <https://mavlink.io/en/messages/common.html#GPS_INJECT_DATA>`__
-
-`TERRAIN_DATA <https://mavlink.io/en/messages/common.html#TERRAIN_DATA>`__
-
-`TERRAIN_CHECK <https://mavlink.io/en/messages/common.html#TERRAIN_CHECK>`__
-
-AUTOPILOT_VERSION_REQUEST
-
-`REQUEST_DATA_STREAM <https://mavlink.io/en/messages/common.html#REQUEST_DATA_STREAM>`__


### PR DESCRIPTION
This PR improves the "MAVLink Interface" page for Plane by:

- Reducing the scope of the page so it only covers movement commands.  Non-movement commands are mostly consistent across vehicles so we have new pages for these.  All commands removed from the Plane page have been added to other pages (if they weren't there already)
- clarifies that the MAV_CMD_NAV_WAYPOINT must be within a MISSION_ITEM_INT and provides details on what fields to set and even gives 3 examples that can be copy-pasted into SITL/MAVProxy
- adds DO_REPOSITION message to the list of MAV_CMDs supported

This PR also includes a couple of drive-by improvement:

- Improved formatting of the mavlink-mission-command-messages page by removing the blank lines between each command.  This makes it easier for readers to scan the page
- MAVLink Interface page for Copter loses the arm/disarm command which is already covered on another page.  Also adds DO_REPOSITION message to the list of MAV_CMDs supported

This has been tested by building and manually reviewing the pages on my local PC