### PR TITLE
update Holybro RTK wiki

### DIFF
--- a/common/source/docs/common-holybro-rtk-f9p.rst
+++ b/common/source/docs/common-holybro-rtk-f9p.rst
@@ -41,6 +41,8 @@ For normal operation, ArduPilot's GPS parameter defaults will work for any seria
 
 .. note:: ArduPilot does not currently configure UBlox F9P GPS constellations. User must assure that the GPS is properly configured for his region and application. See :ref:`common-gps-ublox-firmware-update`
 
+If you are unable to preform a normal compass calibration ("compass dance") for any reason, then set parameter COMPASS_ORIENT=6 (Yaw270) for proper compass orientation.
+
 GPS Accessories
 ===============
 

--- a/common/source/docs/common-holybro-rtk-m8p.rst
+++ b/common/source/docs/common-holybro-rtk-m8p.rst
@@ -37,6 +37,8 @@ Configuration
 
 For normal operation, ArduPilot's GPS parameter defaults will work for any serial port configured for ``SERIALx_PROTOCOL`` = 5. 
 
+If you are unable to preform a normal compass calibration ("compass dance") for any reason, set parameter COMPASS_ORIENT=6 (Yaw270) for proper compass orientation.
+
 GPS Accessories
 ===============
 


### PR DESCRIPTION
add "If unable to preform normal compass calibration "compass dance" for any reason, set parameter COMPASS_ORIENT=6 (Yaw270) for proper compass orientation."