### PR TITLE
Fix case error with log messages

### DIFF
--- a/common/source/docs/common-logs.rst
+++ b/common/source/docs/common-logs.rst
@@ -15,16 +15,16 @@ Topics related to logging and analysis
     Dataflash Logs <common-downloading-and-analyzing-data-logs-in-mission-planner>
 [/site]
 [site wiki="plane"]
-    Plane Log Messages <LogMessages>
+    Plane Log Messages <logmessages>
 [/site]
 [site wiki="copter"]
-    Copter Log Messages <LogMessages>
+    Copter Log Messages <logmessages>
 [/site]
 [site wiki="rover"]
-    Rover Log Messages <LogMessages>
+    Rover Log Messages <logmessages>
 [/site]
 [site wiki="antennatracker"]
-    Antenna Tracker Log Messages <LogMessages>
+    Antenna Tracker Log Messages <logmessages>
 [/site]
 [site wiki="plane"]
     Log Analysis Case Study: Fly-by-Wire <case-study-fly-by-wire>

--- a/update.py
+++ b/update.py
@@ -151,7 +151,7 @@ def fetchlogmessages(site=None, cache=None):
     """
     for key, value in LOGMESSAGE_SITE.items():
         fetchurl = 'https://autotest.ardupilot.org/LogMessages/%s/LogMessages.rst' % value  # noqa
-        targetfile = './%s/source/docs/LogMessages.rst' % key
+        targetfile = './%s/source/docs/logmessages.rst' % key
         if cache:
             if not os.path.exists(targetfile):
                 raise(Exception("Asked to use cached parameter files, but (%s) does not exist" % (targetfile,)))  # noqa


### PR DESCRIPTION
The log message page had the wrong case (logmessages.rst vs LogMessages.rst).

This PR restores it back to all lower-case