### PR TITLE
Add details in video transmitter setup.

### DIFF
--- a/common/source/docs/common-vtx.rst
+++ b/common/source/docs/common-vtx.rst
@@ -28,7 +28,7 @@ CRSF (Crossfire)
 
 CRSF is a bi-directional protocol that requires both TX and RX of a serial port to be connected. Follow the instructions for CRSF telemetry to setup CRSF support (See :ref:`common-tbs-rc`). If you only wish to use CRSF for VTX support, then (again using SERIAL5 as an example) :ref:`SERIAL5_PROTOCOL <SERIAL5_PROTOCOL>` should be set to 29 rather than 23. You will also need to make sure your VTX is configured for CRSF control.
 
-When using CRSF for both RC and VTX control it is important to disable "my VTX" support on Open TX transmitters. Follow your transmitters' instructions.
+When using CRSF for both RC/Telem and VTX control it is important to disable "my VTX" support on Open TX transmitters. Follow your transmitters' instructions. In this scenario, you must connect your flight controller's UART to your CRSF receiver, and then connect your CRSF receiver to the VTX to forward CRSF commands, you cannot connect to the FC using CRSF directly for both the Receiver and VTX using two UARTs.
 
 Reboot your flight controller and power your video transmitter. At startup you should see a video message indicating the current video settings. All the video settings are stored in the ``VTX_x`` parameters and by default these will be changed to reflect the currently configured VTX settings. Once booted you can modify these settings and they will be reflected in the VTX configuration.
 
@@ -50,7 +50,7 @@ Setting video transmitter settings
 Video transmitter settings can be changed in multiple ways but always go via the ``VTX_x`` parameters. So any option which advertises VTX control will be setting a ``VTX_x`` parameter which in turn will interface with the protocol backends. Here are the current ways that video transmitter settings can be modified:
 
 - Parameter modification through your ground station
-- Transmitter power via RC switch (``RCx_OPTION`` = 94).
+- Transmitter power via RC switch (``RCx_OPTION`` = 94). With this setting, the RC channel is interpreted as a 6-position switch (dividing the PWM range 1200 to 1800), and then this is assigned to power values based on the ``VTX_MAX_POWER``. For example if max power is 200-499mW, switch positions 0 results in 0mw (pit mode), 1 and 2 result in 25mw, 3 and 4 result in 100mw, and 5 results in 200mw.
 - Parameter modification via the OSD (See :ref:`common-paramosd`)
 - Parameter modification via CRSF OpenTX lua scripts (or OpenTX AgentX lua scripts) - CRSF only
 - Spektrum VTX support. VTX settings on your Spektrum transmitter will be translated by either the DSMX or SRXL2 drivers and the appropriate VTX settings updated


### PR DESCRIPTION
* Clarify CRSF setup when Vtx and RC receiver both use the protocol. I saw a thread w/ someone who was trying to use CRSF w/ both rx and Vtx and wanted to record the info here, I made the same mistake of trying to use CRSF directly from the FC for both. I ended up just using SmartAudio instead, which is working great.
* Add details to RCx_OPTION usage around PWM range and output power settings. The most important part here was PWM range for me (my tx sends 1000-2000 so a 3-position switch wasn't overlapping with the 6-position switch interpretation well). Short of copying the code for assigning vtx power levels into here as a table (which could be useful!) I figured one example would help folks figure out what's going on.