### PR TITLE
Common: Optical Flow inflight calibration instructions

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -92,7 +92,7 @@ tuning options for the vehicle.
 [/site]
     Object Avoidance <common-object-avoidance-landing-page>
 [site wiki="copter,plane"]
-    Optical Flow Sensor <common-optical-flow-sensor-setup>
+    Optical Flow Sensor <common-optical-flow-sensors-landingpage>
 [/site]
     OSD Parameter Editor <common-paramosd>
     Parameter List (Full) <parameters>

--- a/common/source/docs/common-cheerson-cxof.rst
+++ b/common/source/docs/common-cheerson-cxof.rst
@@ -11,8 +11,6 @@ The Cheerson CX-OF optical flow sensor is a lightweight and low cost optical flo
 ..  youtube:: SSISkG58cDk
     :width: 100%
 
-Support for this sensor is available in Copter-3.6.4 (and higher)
-
 Where to Buy
 ------------
 
@@ -48,7 +46,7 @@ Additional Notes
 - As with the :ref:`PX4Flow sensor <common-px4flow-overview>` a range finder is required to use the sensor for autonomous modes including :ref:`Loiter <loiter-mode>` and :ref:`RTL <rtl-mode>`
 - :ref:`FlowHold <flowhold-mode>` does not require the use of a rangefinder
 - The sensor has been successfully tested to altitudes of about 40m
-- Uncheck the :ref:`ARMING_CHECK <ARMING_CHECK>` parameter's "Parameters" bit to remove the need to manually lift the vehicle to 1m once before takeoff (this pre-arm check is designed to ensure the range finder is working)
+- Performance can be improved by setting the :ref:`sensors position parameters <common-sensor-offset-compensation>`.  For example if the sensor is mounted 2cm forward and 5cm below the frame's center of rotation set :ref:`FLOW_POS_X <FLOW_POS_X>` to 0.02 and :ref:`FLOW_POS_Z <FLOW_POS_Z>` to 0.05.
 
 Testing and Setup
 -----------------

--- a/common/source/docs/common-hereflow.rst
+++ b/common/source/docs/common-hereflow.rst
@@ -11,8 +11,6 @@ The `HereFlow optical flow sensor <http://www.proficnc.com/all-products/185-pixh
 ..  youtube:: MKJB_7cA_0s
     :width: 100%
 
-Support for this sensor is available in Copter-4.0.0 (and higher)
-
 .. warning::
 
    The lidar included with the HereFlow is very short range especially outdoors.  We strongly recommend using a :ref:`longer range lidar instead <common-rangefinder-landingpage>`.
@@ -45,6 +43,7 @@ Additional Notes
 
 - As with the :ref:`PX4Flow sensor <common-px4flow-overview>` a range finder is required to use the sensor for autonomous modes including :ref:`Loiter <loiter-mode>` and :ref:`RTL <rtl-mode>`
 - :ref:`FlowHold <flowhold-mode>` does not require the use of a rangefinder
+- Performance can be improved by setting the :ref:`sensors position parameters <common-sensor-offset-compensation>`.  For example if the sensor is mounted 2cm forward and 5cm below the frame's center of rotation set :ref:`FLOW_POS_X <FLOW_POS_X>` to 0.02 and :ref:`FLOW_POS_Z <FLOW_POS_Z>` to 0.05.
 
 Testing and Setup
 -----------------

--- a/common/source/docs/common-openmv-optflow.rst
+++ b/common/source/docs/common-openmv-optflow.rst
@@ -11,10 +11,6 @@ The `OpenMV camera <https://openmv.io/>`__ is a programmable camera which includ
 ..  youtube:: BmixVDBiIbA
     :width: 100%
 
-.. warning::
-
-   Support for this sensor will be included in Copter-4.0 (and higher)
-
 Where to Buy
 ------------
 
@@ -60,6 +56,7 @@ Additional Notes
 - As with the :ref:`PX4Flow sensor <common-px4flow-overview>` a range finder is required to use the sensor for autonomous modes including :ref:`Loiter <loiter-mode>` and :ref:`RTL <rtl-mode>`
 - :ref:`FlowHold <flowhold-mode>` does not require the use of a rangefinder
 - The sensor has been successfully tested to altitudes of about 10m
+- Performance can be improved by setting the :ref:`sensors position parameters <common-sensor-offset-compensation>`.  For example if the sensor is mounted 2cm forward and 5cm below the frame's center of rotation set :ref:`FLOW_POS_X <FLOW_POS_X>` to 0.02 and :ref:`FLOW_POS_Z <FLOW_POS_Z>` to 0.05.
 
 Testing and Setup
 -----------------

--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -9,7 +9,7 @@ Optical Flow Sensor Testing and Setup
 Testing the sensor
 ==================
 
-With the sensor connected to the autopilot, connect to the autopilot with the Mission Planner and open the Flight Data screen's Status tab.  If the sensor is operating you should see non-zero opt_m_x, opt_m_y and an opt_qua values.
+With the sensor connected to the autopilot, connect to the autopilot with the Mission Planner and open the Flight Data screen's Status tab.  If the sensor is operating you should see non-zero opt_m_x, opt_m_y and opt_qua values.
 
 .. image:: ../../../images/PX4Flow_CheckForData_MP.png
     :target: ../_images/PX4Flow_CheckForData_MP.png
@@ -145,3 +145,67 @@ Example Video (Copter-3.4)
 
 ..  youtube:: Bzgey8iR69Q
     :width: 100%
+
+---------------------------------
+
+Inflight Calibration
+====================
+
+Copter-4.2.0 includes an inflight calibration procedure:
+
+- Set :ref:`RCx_OPTION <RC8_OPTION>` = 158 (Optflow Calibration) to allow starting the calibration from an :ref:`auxiliary switch <common-auxiliary-functions>`
+- Setup the EKF3 to use GPS (the default)
+
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+- Fly the vehicle in Loiter mode to at least 10m (higher is better but stay within the limits of the rangefinder)
+- Pull the auxiliary switch high to start the calibration
+- Use the roll and pitch sticks to rock the vehicle back and forth in both roll and pitch
+- Check the GCS "Messages" tab for output like below confirming the calibration is complete
+
+::
+
+   FlowCal: Started
+   FlowCal: x:0% y:0%
+   FlowCal: x:66% y:6%
+   FlowCal: x:100% y:74%
+   FlowCal: samples collected
+   FlowCal: scalarx:0.976 fit: 0.10   <-- lower "fit" values are better
+   FlowCal: scalary:0.858 fit: 0.04
+   FlowCal: FLOW_FXSCALER=30.00000, FLOW_FYSCALER=171.0000
+
+- Land the vehicle and setup the EKF3 to use OpticalFlow
+
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 (None)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 0 (None)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+- Fly the vehicle again to check performance
+
+An alternative method which avoids the need to land and change EKF3 parameters between calibration and testing is to setup :ref:`GPS/Non-GPS transitions <common-non-gps-to-gps>` so the pilot can manually change between GPS and Optical Flow inflight.  The full parameter list is below assuming the pilot will engage the calibration using RC input 8 (a 2-position switch) and switch between GPS and Optical flow using RC input 9 (a 3-position switch)
+
+  - :ref:`RC8_OPTION <RC8_OPTION>` = 158 (Optflow Calibration)
+  - :ref:`RC9_OPTION <RC9_OPTION>` = 90 (EKF Pos Source) low is GPS, middle is OpticalFlow, high is unused
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC2_POSXY <EK3_SRC1_POSXY>` = 0 (None)
+  - :ref:`EK3_SRC2_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
+  - :ref:`EK3_SRC2_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC2_VELZ <EK3_SRC1_VELZ>` = 0 (None)
+  - :ref:`EK3_SRC2_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+.. note::
+
+   To use the inflight calibration EKF3 must be enabled.  This is the default for ArduPilot 4.1 and higher

--- a/common/source/docs/common-upixels-upflow.rst
+++ b/common/source/docs/common-upixels-upflow.rst
@@ -43,7 +43,7 @@ Additional Notes
 
 - As with the :ref:`PX4Flow sensor <common-px4flow-overview>` a range finder is required to use the sensor for autonomous modes including :ref:`Loiter <loiter-mode>` and :ref:`RTL <rtl-mode>`
 - :ref:`FlowHold <flowhold-mode>` does not require the use of a rangefinder
-- Uncheck the :ref:`ARMING_CHECK <ARMING_CHECK>` parameter's "Parameters" bit to remove the need to manually lift the vehicle to 1m once before takeoff (this pre-arm check is designed to ensure the range finder is working)
+- Performance can be improved by setting the :ref:`sensors position parameters <common-sensor-offset-compensation>`.  For example if the sensor is mounted 2cm forward and 5cm below the frame's center of rotation set :ref:`FLOW_POS_X <FLOW_POS_X>` to 0.02 and :ref:`FLOW_POS_Z <FLOW_POS_Z>` to 0.05.
 
 Testing and Setup
 -----------------


### PR DESCRIPTION
This adds insturctions for the inflight optical flow calibration that will be in 4.2 once this PR is merged. 
https://github.com/ArduPilot/ardupilot/pull/19874

I'm pretty confident that this will go in and it will help us get more people testing it.

I've also included a bit of a drive-by change to remove some old notes on version and the recommend that users set the FLOW_POS_XYZ parameters to improve performance.  In my testing it makes a significant difference at least at higher altitudes.

.. and finally I changed the link on the Advanced Configuration page to point to the landing page instead of jumping straight to the setup page.

I've tested this on my local machine.