### PR TITLE
Update common-accelerometer-calibration.rst

### DIFF
--- a/common/source/docs/common-accelerometer-calibration.rst
+++ b/common/source/docs/common-accelerometer-calibration.rst
@@ -15,7 +15,7 @@ This article shows how to perform basic accelerometer calibration (using
 
 .. important::
 
-   Accelerometer calibration cannot be performed while vehicle is armed.
+   Accelerometer calibration cannot be performed while vehicle is armed. 
 
 Calibration steps
 =================
@@ -44,9 +44,11 @@ Calibration steps
       Accelerometer Calibration Positions (Copter)
 
    It is important that the vehicle is kept still immediately after pressing the key for each step. This is more important than getting the angle exactly right, ie. left being 90deg to horizontal, etc. Except for the first "LEVEL", the positions can be within 20 degs of being exact. Being still in each position as you press the key is much more important.
-
+   
+   -  You should calibrate the board mounted in the vehicle if possible. 
    -  You may need to calibrate the board before it is mounted if the size/shape of the vehicle makes this difficult.
    -  The level position is the most important to get right as this will be the attitude that your controller considers level while flying.
+   -  You can recalibrate LEVEL using Mission Planner, after you have installed the flight controller and are ready to fly.
 
 [site wiki="plane"]
    .. tip:: For planes, the "level" angle for pitch is important for steady altitude flight. See :ref:`tuning-cruise` for more details.


### PR DESCRIPTION
I've seen videos online showing new 'unboxed' flight controllers being calibrated before installing in a vehicle. I guess this might work ok in a quad, but I'm thinking that it might lead to sub-optimal performance in a plane. I'm suggesting making it clearer that the ideal is to calibrate in the vehicle, especially for a plane.