### PR TITLE
Sphinxsetup.sh: Add WSL pip DISPLAY workaround

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -29,6 +29,13 @@ else
     fi
 fi
 
+# For WSL (esp. version 2) make DISPLAY empty to allow pip to run
+STORED_DISPLAY_VALUE=$DISPLAY
+if grep -qi -E '(Microsoft|WSL)' /proc/version; then
+  echo "Temporarily clearing the DISPLAY variable because this is WSL"
+  export DISPLAY=
+fi
+
 # Get pip through the official website to get the latest release
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python3 get-pip.py
@@ -51,5 +58,11 @@ python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxc
 
 # and a parser to use getting posts from Discourse (forum) and insert in FrontEnd
 python3 -m pip install --user --upgrade beautifulsoup4
+
+# Reset the value of DISPLAY
+if grep -qi -E '(Microsoft|WSL)' /proc/version; then
+  echo "Returning DISPLAY to the previous value in WSL"
+  export DISPLAY=$STORED_DISPLAY_VALUE
+fi
 
 echo "Setup completed successfully!"


### PR DESCRIPTION
Ran into an issue where setting up the environment without firewall access for xserver on WSL 2 leads to pip not running. Haven't tracked down why that is, but disabling display output fixes the issue. So while we get the environment set up in WSL 2, just clear the variable and then return it after we are done. This will cause an issue if pip bails out at some point in the middle of installed packages. There might be a better way to handle that case in bash.

See https://stackoverflow.com/questions/33925566/pip-install-hangs