### PR TITLE
Rover/Common: add a couple of links to a reference frame and mounting-the-flight-controller pages

### DIFF
--- a/common/source/docs/common-mounting-the-flight-controller.rst
+++ b/common/source/docs/common-mounting-the-flight-controller.rst
@@ -20,7 +20,7 @@ horizontally and vertically).  Generally this means it should be placed
 within a few centimeters of the middle of the vehicle and level with the
 motors.  It is not critical that it is placed exactly at the middle but
 closer is better (there are no recorded cases of problems caused by the
-controller being far from the centre of gravity).
+controller being far from the centre of gravity).  If the autopilot cannot be placed at the center of the vehicle setting the :ref:`IMU position offset parameters <common-sensor-offset-compensation>` may improve performance slightly.
 
 [site wiki="rover"]
 .. image:: ../../../images/mounting-flight-controller-rover.png

--- a/rover/source/docs/reference-frames-deset-mapping-boat.rst
+++ b/rover/source/docs/reference-frames-deset-mapping-boat.rst
@@ -31,6 +31,8 @@ Parts List
 
 The steering mechanism is a custom built servo and pulley system but we hope to eventually provide a 3D printable steering mechanism
 
+More details can be found in `this blog post <https://discuss.ardupilot.org/t/deset-mapping-boat-in-okinoshima-japan/78035>`__
+
 Parameters: `deset-mapping-boat.param <https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/deset-mapping-boat.param>`__
 
 Firmware used: Rover-4.2.0


### PR DESCRIPTION
This PR includes two unrelated changes:

1. the DeSET boat reference frame gets a link to a blog post I wrote with some more info on the frame
2. the mounting-the-flight-controller page gets a link to the sensor-position-offset-compensation page to resolve [this issue](https://github.com/ArduPilot/ardupilot/issues/20135)

This has been tested on my machine so I'm pretty sure it is OK.