### PR TITLE
Clarify requirements for setting up an Airspeed sensor on a new build

### DIFF
--- a/plane/source/docs/airspeed-parameters-setup.rst
+++ b/plane/source/docs/airspeed-parameters-setup.rst
@@ -4,7 +4,7 @@
 Airspeed Parameters Setup
 =========================
 
-.. note: ArduPlane does not require an airspeed sensor. However, some airspeed related parameters are used even if no airspeed sensor is present or being used, notably for the scaling of tuning parameters with speed.
+.. note: ArduPlane does not require an airspeed sensor. However, some airspeed related parameters are used even if no airspeed sensor is present or being used, notably for the scaling of tuning parameters with speed. If you are not using an airspeed sensor set ARSPD_TYPE to 0. 
 
 Speed Scaling
 =============

--- a/plane/source/docs/plane-configuration-landing-page.rst
+++ b/plane/source/docs/plane-configuration-landing-page.rst
@@ -13,6 +13,8 @@ components, including those required for the operation of the autopilot.
    may also choose to :ref:`Configure Optional Hardware <common-optional-hardware>` including battery monitor, sonar,
    airspeed sensor, optical flow, OSD, camera gimbal, antenna tracker
    etc.
+   
+.. note:: Airspeed sensor defaults to MS4525. If you don't have an Airspeed sensor or don't have an MS4525 then it's probably a good idea to at least check the settings.
 
 .. toctree::
     :maxdepth: 1

--- a/plane/source/docs/plane-configuration-landing-page.rst
+++ b/plane/source/docs/plane-configuration-landing-page.rst
@@ -14,7 +14,7 @@ components, including those required for the operation of the autopilot.
    airspeed sensor, optical flow, OSD, camera gimbal, antenna tracker
    etc.
    
-.. note:: Airspeed sensor defaults to MS4525. If you don't have an Airspeed sensor or don't have an MS4525 then it's probably a good idea to at least check the settings.
+.. note::  :ref:`ARSPD_TYPE<ARSPD_TYPE>`  defaults to MS4525. If you don't have an Airspeed sensor or don't have an MS4525 then you should change it and other airspeed related parameters, appropriately.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
ArduPlane defaults the Airspeed sensor to MS4525, which the code in ArduPlane 4.2 will flag as an error if there is no airspeed sensor or a different one. In the past this would have happened silently, but now an error will appear on the GCS, which might be confusing. 

This doc change attempts to clarify that if there is no airspeed sensor, the ARSPD_TYPE should be set to 0 otherwise an error will occur.