### PR TITLE
Rover: move torqeedo to ESCs-and-Motors

### DIFF
--- a/common/source/docs/common-escs-and-motors.rst
+++ b/common/source/docs/common-escs-and-motors.rst
@@ -26,6 +26,7 @@ ArduPilot supports a wide variety of ESCs and motors.  The pages below provide s
     Serial ESCs <common-serial-escs>
 [site wiki="rover"]
     Thrusters (for boats) <thrusters>
+    Torqeedo Electric Motor (for boats) <common-torqeedo>
 [/site]
     Toshiba CAN ESCs <common-toshiba-can-escs>
 [site wiki="rover"]

--- a/common/source/docs/common-optional-hardware.rst
+++ b/common/source/docs/common-optional-hardware.rst
@@ -80,9 +80,6 @@ information related to Autopilot selection see :ref:`Autopilot Hardware Options 
     Start/Stop Switch <startstop-switch>
 [/site]
     Telemetry Radio <common-telemetry-landingpage>
-[site wiki="rover"]
-    Torqeedo Electric Motor <common-torqeedo>
-[/site]
     DroneCAN Adapter Node <common-uavcan-adapter-node>
     DroneCAN Peripherals <common-uavcan-peripherals>
     Video (High Definition) <common-video-landingpage>

--- a/rover/source/docs/boat-configuration.rst
+++ b/rover/source/docs/boat-configuration.rst
@@ -11,9 +11,10 @@ Boats can also be controlled with the standard Rover firmware.  To specify that 
 
 The special features for Boats include:
 
-- Boats appear as boats on the ground station (version 3.3.0 and higher)
-- In :ref:`Auto <auto-mode>`, :ref:`Guided <guided-mode>`, :ref:`RTL <rtl-mode>` and :ref:`SmartRTL <smartrtl-mode>` modes the vehicle will attempt to maintain its position even after it reaches its destination (version 3.2.0 and higher)
-- :ref:`Vectored Thrust <rover-vectored-thrust>` can be enabled to improve steering response on boats which use the steering servo to aim the motors (version 3.3.1 and higher)
-- :ref:`Loiter mode <loiter-mode>` for holding position
+- Boats appear as boats on the ground station
+- In :ref:`Auto <auto-mode>`, :ref:`Guided <guided-mode>`, :ref:`RTL <rtl-mode>` and :ref:`SmartRTL <smartrtl-mode>` modes the vehicle will attempt to maintain its position even after it reaches its destination
 - :ref:`Echosounders <common-underwater-sonars-landingpage>` for underwater mapping
+- :ref:`Loiter mode <loiter-mode>` for holding position
 - :ref:`ReefMaster for bathymetry <reefmaster-for-bathymetry>`
+- :ref:`Torqeedo electric motors <common-torqeedo>`
+- :ref:`Vectored Thrust <rover-vectored-thrust>` can be enabled to improve steering response on boats which use the steering servo to aim the motors


### PR DESCRIPTION
This moves the Torqeedo page to the ESC-and-motors landing page instead of on it's own page in the Peripheral Hardware section.

I've also updated the "boat" page:

- added torqeedo to the page
- removed mentions of ancient versions
- reordered alphabetically

This has been tested on my local machine