### PR TITLE
Dev: fixup SITL preclanding setup instructions

### DIFF
--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -474,6 +474,9 @@ Enable Precision Landing, and set the precision landing backend type to SITL:
    param set PLND_ENABLED 1
    param fetch
    param set PLND_TYPE 4
+   param set SIM_PLD_ENABLE 1
+   param set SIM_PLD_LAT -35.3632
+   param set SIM_PLD_LON 149.1652
 
 A rangefinder is currently required for precision landing.  Enable a simulated rangefinder:
 


### PR DESCRIPTION
I found that the SITL instructions were missing some critical parameter settings so here they are.  I've tested these changes on my local machine.

FYI @peterbarker 