### PR TITLE
Common: minimosd gets serial-protocol note

### DIFF
--- a/common/source/docs/common-minim-osd-quick-installation-guide.rst
+++ b/common/source/docs/common-minim-osd-quick-installation-guide.rst
@@ -6,27 +6,20 @@ Minim OSD Quick Installation Guide
 
 `MinimOSD <https://code.google.com/archive/p/arducam-osd/wikis/minimosd.wiki>`__
 "On-Screen Display" is a small circuit board that pulls telemetry data
-from your APM or Pixhawk autopilot and over-lays it on your
-:ref:`First Person View <common-fpv-first-person-view>` monitor.
+from your autopilot and over-lays it on your :ref:`First Person View <common-fpv-first-person-view>` monitor.  The Minim OSD was designed and programmed by Sandro Benigno and Jani Hirvinen
 
 This article provides brief instructions for how to connect the board.
 For more detailed instructions please refer to the `MinimOSD Project wiki <https://code.google.com/archive/p/arducam-osd/wikis/minimosd.wiki>`__.
 
-.. note::
-
-   The Minim OSD was designed and programmed by Sandro Benigno and
-   Jani Hirvinen. It is `available from jDrones here <http://store.jdrones.com/jD_MiniOSD_V12_p/jdminiosd12.htm>`__.
-
 Overview
 ========
 
-To connect to Pixhawk, use this `DF13 6-pin cable <https://www.unmannedtechshop.co.uk/df13-6-position-connector-30cm-pack-of-5/>`__
-to connect to the TELEM2 port. To connect to APM 2.5 and 2.6, use a
-5-pin splitter cable that allows the telemetry port to be connected to
-both a :ref:`SiK Radio <common-sik-telemetry-radio>` and the MinimOSD.
+Connect the MinimOSD to the any of the autopilot's serial ports as shown below.  Note that the MinimOSD only "listens" so it is possible (but not recommended) to connect it in parallel with a telemetry radio (e.g. :ref:`SiK Radio <common-sik-telemetry-radio>` or similar).
 
 .. image:: ../../../images/MinimOSD_Pixhawk.jpg
     :target: ../_images/MinimOSD_Pixhawk.jpg
+
+Set :ref:`SERIALx_PROTOCOL <SERIAL2_PROTOCOL>` = 1 (MAVLink1) because MinimOSD does not understand MAVLink2
 
 Basic wiring Diagram
 ====================
@@ -56,7 +49,7 @@ Optional setup for critical cooling conditions
 The second stage regulator from the MinimOSD boards earlier than V1.1
 gets too hot on 12V video setups. If your frame has not a good air flow
 for cooling the OSD board you may want to feed the OSD entirely from
-APM. Probably it will add some noises from servos, but you'll be more
+the autopilot. Probably it will add some noises from servos, but you'll be more
 safe by this way:
 
 .. image:: ../../../images/DiagramaMinimOSD_OP.jpg
@@ -107,9 +100,9 @@ MWOSD continues to be actively developed and supported.
 * Choose to display pilot icon or callsigns
 
 The following links contain a quick start overview and an ardupilot specific installation guide 
-https://github.com/ShikOfTheRa/scarab-osd/wiki/Quick-start-guide
-https://github.com/ShikOfTheRa/scarab-osd/wiki/MAVLINK-installation
 
+- https://github.com/ShikOfTheRa/scarab-osd/wiki/Quick-start-guide
+- https://github.com/ShikOfTheRa/scarab-osd/wiki/MAVLINK-installation
 
 MinimOSD-extra NG
 ===============================

--- a/common/source/docs/common-minim-osd-quick-installation-guide.rst
+++ b/common/source/docs/common-minim-osd-quick-installation-guide.rst
@@ -47,10 +47,10 @@ Optional setup for critical cooling conditions
 (Hardware V0.1 and 1.0 only)
 
 The second stage regulator from the MinimOSD boards earlier than V1.1
-gets too hot on 12V video setups. If your frame has not a good air flow
+gets too hot on 12V video setups. If your frame does not have good air flow
 for cooling the OSD board you may want to feed the OSD entirely from
 the autopilot. Probably it will add some noises from servos, but you'll be more
-safe by this way:
+safe this way:
 
 .. image:: ../../../images/DiagramaMinimOSD_OP.jpg
     :target: ../_images/DiagramaMinimOSD_OP.jpg


### PR DESCRIPTION
As part of Copter-4.2 beta testing a user found that the MinimOSD didn't work.  This adds a note to specifying the SERIALx_PROTOCOL must be set to 1.

I've also included some minor fixes to remove dead links and make it less APM and pixhawk specific

This has been tested on my local machine