### PR TITLE
Common: fix links on or to dshot and BLHeli pages

### DIFF
--- a/common/source/docs/common-dshot-escs.rst
+++ b/common/source/docs/common-dshot-escs.rst
@@ -20,7 +20,7 @@ DShot is the underlying ESC control protocol used by :ref:`BLHeli <common-blheli
 .. note::
    Recently there is a growing number of proprietary and non-proprietary 16 / 32 bit ESCs with firmware that support DShot and other digital ESC protocols, but not BLHeli32 specific features like passthrough and telemetry. See your ESC's manual for further detail on supported features.
 
-.. note:: most DShot ESCs normally will also operate as normal :ref:PWM ESCs<common-brushless-escs>`.
+.. note:: most DShot ESCs normally will also operate as normal :ref:`PWM ESCs <common-brushless-escs>`.
 
 Connecting the ESCs
 ===================

--- a/common/source/docs/common-flywoo-f745.rst
+++ b/common/source/docs/common-flywoo-f745.rst
@@ -63,7 +63,7 @@ Default UART order
 - SERIAL4 = USER = USART4
 - SERIAL5 = USER = UART5
 - SERIAL6 = GPS = USART6
-- SERIAL7 = ESC Telem = UART7 (RX tied to ESC telemetry) See :ref:`common-dshot-blheli32-telemetry`
+- SERIAL7 = ESC Telem = UART7 (RX tied to ESC telemetry) See :ref:`blheli32-esc-telemetry`
 
 UART3 supports RX and TX DMA. UART1, UART2, UART4, and UART6 supports TX DMA. UART5 and UART7 do not support DMA. Serial port protocols (Telem, GPS, etc.) can be adjusted to personal preferences.
 

--- a/common/source/docs/common-imu-notch-filtering.rst
+++ b/common/source/docs/common-imu-notch-filtering.rst
@@ -29,7 +29,7 @@ Setup Instructions
 
 First you must select the mechanism used for controlling the harmonic notch frequency. By default (:ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` = 1) this mechanism is :ref:`throttle-based<common-imu-notch-filtering-throttle-based-setup>` since that will work on all Copters/QuadPlanes. However, a flight log analysis will be required to correlate the hover throttle position to the noise source's frequency.
 
-However, for Copters with an rpm sensor, :ref:`BLHeli ESC telemetry support<common-dshot-blheli32-telemetry>`, or is capable of using In-Flight FFT control of center frequency, setup can be radically simpler by using direct RPM or center frequency sensing, which will not require log analysis to determine center frequency:
+However, for Copters with an rpm sensor, :ref:`BLHeli ESC telemetry support<blheli32-esc-telemetry>`, or is capable of using In-Flight FFT control of center frequency, setup can be radically simpler by using direct RPM or center frequency sensing, which will not require log analysis to determine center frequency:
 
 - Set :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` = 2 to use an RPM sensor to set the harmonic notch frequency. This is primarily used in :ref:`Helicopters<common-imu-notch-filtering-helicopter-setup>`
 - Set :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` = 3 to use BLHeli ESC telemetry support to set the harmonic notch frequency. This requires that your ESCs are configured correctly to support BLHeli telemetry via :ref:`a serial port<common-dshot-blheli32-telemetry>`

--- a/common/source/docs/common-omnibusnanov6.rst
+++ b/common/source/docs/common-omnibusnanov6.rst
@@ -137,7 +137,7 @@ Default pin values:
 
 :ref:`BATT_VOLT_MULT <BATT_VOLT_MULT>` = 11
 
-Optionally add voltage and / or current monitoring using ESC telemetry capable ESCs. See instructions :ref:`here <esc-telemetry>`.
+Optionally add voltage and / or current monitoring using ESC telemetry capable ESCs. See instructions :ref:`here <blheli32-esc-telemetry>`.
 
 
 V6.x revision

--- a/common/source/docs/common-power-module-configuration-in-mission-planner.rst
+++ b/common/source/docs/common-power-module-configuration-in-mission-planner.rst
@@ -58,7 +58,7 @@ These are selected via the ``BATTx_MONITOR`` parameter for each battery monitor.
 6 	                                    Bebop
 7 	                                    :ref:`SMBus-Generic<common-smart-battery-landingpage>`
 8 	                                    DroneCAN-BatteryInfo
-9 	                                    :ref:`ESC<common-dshot-blheli32-telemetry>`
+9 	                                    :ref:`ESC<blheli32-esc-telemetry>`
 10 	                                    Sum Of Selected Monitors, see BATTx_SUM_MASK parameter
 11 	                                    :ref:`FuelFlow <common-fuel-sensors>`
 12 	                                    :ref:`FuelLevelPWM <common-fuel-sensors>`

--- a/common/source/docs/common-rpm.rst
+++ b/common/source/docs/common-rpm.rst
@@ -112,7 +112,7 @@ RPM history can be reviewed in the logs.
 ESC Telemetry - Average Motor RPM
 =================================
 
-The RPM library can also be used to setup an 'RPM sensor' that computes and logs the average RPM for selected motors on the vehicle that are controlled by BLHeli_32 or BLHeli_S capable ESCs.  First the ESC telemetry will need to be setup.  See :ref:`BLHeli Telemetry<common-dshot-blheli32-telemetry>` for details on how to do this.  Once complete set ``RPMx_TYPE`` to 5 and write the parameters to ArduPilot.  Then refresh/fetch the parameters.  You will find a number of additional parameters are now available for that instance.  Find and set ``RPMx_ESC_MASK`` to add which ESC channels you want to be included in the average. For example for the second RPM instance:
+The RPM library can also be used to setup an 'RPM sensor' that computes and logs the average RPM for selected motors on the vehicle that are controlled by BLHeli_32 or BLHeli_S capable ESCs.  First the ESC telemetry will need to be setup.  See :ref:`BLHeli Telemetry<blheli32-esc-telemetry>` for details on how to do this.  Once complete set ``RPMx_TYPE`` to 5 and write the parameters to ArduPilot.  Then refresh/fetch the parameters.  You will find a number of additional parameters are now available for that instance.  Find and set ``RPMx_ESC_MASK`` to add which ESC channels you want to be included in the average. For example for the second RPM instance:
 
 :ref:`RPM2_ESC_MASK<RPM2_ESC_MASK>` is a bitmask, with each bit corresponding to a channel. If you wanted the average RPM for motors 1 to 4 you would set :ref:`RPM2_ESC_MASK<RPM2_ESC_MASK>` = 1 + 2 + 4 + 8 = 15.
 
@@ -123,8 +123,7 @@ Electrical commutation RPM sensors can be added retrospectively using something 
 series, that have an auxiliary output, can be configured to output a pulse per commutation.
 
 For clarification, this is not the same as the RPM that can be passed 
-via serial telemetry with ESCs.  For information on how to set up RPM reporting with capable ESCs, see the :ref:`ESC Telemetry<esc-telemetry>`.
-For information on how to set up RPM logging with BL Heli see the :ref:`BLHeli Telemetry<common-dshot-blheli32-telemetry>`.
+via serial telemetry with ESCs.  For information on how to set up RPM reporting with capable ESCs, see the :ref:`ESC Telemetry<blheli32-esc-telemetry>`.
 
 The setup for electrical commutation RPM sensors is much the same as hall effect sensors, so the steps above are applicable.  The only difference is the scaling value 
 to be entered in the :ref:`RP2_SCALING<RPM2_SCALING>` parameter.  Now, the scaling value is a function of the number of poles in the motor and should be the reciprocal of the number of 

--- a/common/source/docs/common-serial-options.rst
+++ b/common/source/docs/common-serial-options.rst
@@ -189,7 +189,7 @@ SBus Servo, See :ref:`common-sbus-output`
    <td>16</td>
    <td>
 
-ESC Telemetry, See :ref:`common-dshot-blheli32-telemetry` 
+ESC Telemetry, See :ref:`blheli32-esc-telemetry` 
 
 .. raw:: html
 


### PR DESCRIPTION
This PR fixes a number of broken links that appeared with the recent update to the DShot and BLHeli pages.

- Fixed small typo affecting a link on the new dshot wiki page.
- Fixed various links to ESC telemetry.  One page had two links, one to the DShot page and another to the BLHeli page.. these have now been combined together so I removed one of the links.  It's possible that we could have instead provided a link to the Bi-directional dshot section that can also provide RPM but without the need for a separate telemetry wire.

This has been tested on my local PC.