### PR TITLE
Common: dshot command parameters put in list

### DIFF
--- a/common/source/docs/common-dshot-escs.rst
+++ b/common/source/docs/common-dshot-escs.rst
@@ -91,7 +91,11 @@ The frequency at which DShot pulses are sent can be configured through :ref:`SER
 DShot Commands
 --------------
 
-On certain ESCs DShot commands are supported. These allow functions such as ESC LEDs, beeps and motor direction to be manipulated by the flight controller. In order to use DShot commands :ref:`SERVO_DSHOT_ESC<SERVO_DSHOT_ESC>` must be set to the type of ESC that is in use. Notify functions (e.g. LEDs :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` and Buzzer :ref:`NTF_BUZZ_TYPES<NTF_BUZZ_TYPES>`) can then be configured to include DShot as an output type.
+On certain ESCs DShot commands are supported. These allow functions such as ESC LEDs, beeps and motor direction to be manipulated by the flight controller. In order to use DShot commands:
+
+- set :ref:`SERVO_DSHOT_ESC<SERVO_DSHOT_ESC>` = 1 (BLHeli32/BLHeli_S/Kiss)
+- set :ref:`NTF_LED_TYPES<NTF_LED_TYPES>`'s "DShot" checkbox to enable controlling the ESCs LEDs
+- set :ref:`NTF_BUZZ_TYPES<NTF_BUZZ_TYPES>`'s "DShot" checkbox to enable usingthe motors as buzzers
 
 The current commands supported are:
 


### PR DESCRIPTION
This makes the DShot Commands section slightly more clear (I think) by putting the relevant parameters in a list.

I've tested this on my local machine and after this PR it looks like this
![image](https://user-images.githubusercontent.com/1498098/164216560-7d0e83cb-322f-42eb-9fe2-5df71412b2c1.png)

It's still not great because this section starts with the "how" (e.g. dshot commands) instead of the "what" or "why" (e.g. "Using DShot to reverse the direction of the motors, use the ESCs LEDs for autopilot status, use the motors as buzzers".