### PR TITLE
Wiki:ROS Removed Note for protobuf removal

### DIFF
--- a/dev/source/docs/ros-cartographer-slam.rst
+++ b/dev/source/docs/ros-cartographer-slam.rst
@@ -106,10 +106,6 @@ Install proto3 and deb dependencies
     rosdep update
     rosdep install --from-paths src --ignore-src --rosdistro=${ROS_DISTRO} -y
 
-.. note::
-
-   Cartographer installs a version of protobuf that overrides the system defaults and can only be removed with "make uninstall"
-
 Clone the `Robot Pose Publisher <http://wiki.ros.org/robot_pose_publisher>`__ package into the workspace
 
 ::


### PR DESCRIPTION
```make uninstall``` is no longer working i have tested many times. catkin build gives error everytime until the package is removed. I solved (or ignored) this problem by just removing this package from the list everytime when i do a ```catkin build```. (Note that compiled package is still in ROS build folder i am using that from my first compilation). until anyone get a solution we should remove this Instruction.