### PR TITLE
Copter: fixup wind speed est param range

### DIFF
--- a/copter/source/docs/airspeed-estimation.rst
+++ b/copter/source/docs/airspeed-estimation.rst
@@ -65,7 +65,7 @@ The :ref:`EK3_DRAG_MCOEF <EK3_DRAG_MCOEF>` should be calculated after performing
 11. Repeat step 8 but with the vehicle's right side facing into the wind (pilot should apply full right roll to accelerate into the wind)
 12. Download the :ref:`onboard logs <common-downloading-and-analyzing-data-logs-in-mission-planner>` for analysis as described in the video
 
-The final value for :ref:`EK3_DRAG_MCOEF <EK3_DRAG_MCOEF>` is normally between 1.1 and 2.0.
+The final value for :ref:`EK3_DRAG_MCOEF <EK3_DRAG_MCOEF>` is normally between 0.1 and 1.0.
 
 Viewing Windspeed and Direction in Real-Time
 --------------------------------------------


### PR DESCRIPTION
This fixes up the copter wind speed estimation's page's statement re the expected range of the EK3_DRAG_MCOEF parameter.  I had incorrectly said it was 1 to 2 but in fact it is 0.1 to 1.0 which [matches the parameter description](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_NavEKF3/AP_NavEKF3.cpp#L693) and also my findings from actually flight tests.

I have not actually tested this change on my local PC but surely it's fine.