### PR TITLE
Fix wrong parametrer description for find_serial

### DIFF
--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -446,7 +446,7 @@ RC Channels (rc:)
 Serial/UART (serial:)
 ~~~~~~~~~~~~~~~~~~~~~
 
-- :code:`find_serial(protocol)` - Returns the first UART instance that allows the given protocol, or nil if not found.
+- :code:`find_serial(port_number)` - Returns the UART instance that allows connections from scripts (those with :code:`SERIALx_PROTOCOL = 28`). For :code:`port_number = 0`, returns first such UART, second for :code:`port_number = 1`, and so on. If the instance is not found, returns :code:`nil`.
 
 	- :code:`UART:begin(baud)` - Start serial connection at given baud rate.
 	- :code:`UART:read()` - Returns a sequence of bytes from UART instance.


### PR DESCRIPTION
The `find_serial` binding has two arguments in C++, the protocol and the instance number. In Lua bindings, the first argument is hardwired to 28, while the second one becomes the first Lua argument. The documentation referred to the first C++ argument instead, which caused a lot of confusion.

Now it seems to reflect the current state better.