### PR TITLE
Minor fixup for BlueRobotics Thrusters, demote title line of two of BLHeli's subsections

### DIFF
--- a/common/source/docs/common-blheli32-passthru.rst
+++ b/common/source/docs/common-blheli32-passthru.rst
@@ -1,5 +1,6 @@
 .. _common-blheli32-passthru:
 
+==========================
 BLHeli32 and BLHeli_S ESCs
 ==========================
 

--- a/rover/source/docs/boat-configuration.rst
+++ b/rover/source/docs/boat-configuration.rst
@@ -13,6 +13,7 @@ The special features for Boats include:
 
 - Boats appear as boats on the ground station
 - In :ref:`Auto <auto-mode>`, :ref:`Guided <guided-mode>`, :ref:`RTL <rtl-mode>` and :ref:`SmartRTL <smartrtl-mode>` modes the vehicle will attempt to maintain its position even after it reaches its destination
+- :ref:`Thrusters <thrusters>`
 - :ref:`Echosounders <common-underwater-sonars-landingpage>` for underwater mapping
 - :ref:`Loiter mode <loiter-mode>` for holding position
 - :ref:`ReefMaster for bathymetry <reefmaster-for-bathymetry>`

--- a/rover/source/docs/thrusters.rst
+++ b/rover/source/docs/thrusters.rst
@@ -6,11 +6,11 @@ Thrusters (for boats and submarines)
 
 .. image:: ../images/thruster.png
 
-The `BlueRobotics T100 and T200 thrusters <https://www.bluerobotics.com/product-category/thrusters/>`__ are commonly used thrusters that can be controlled using a regular reversible brushless motor ESCs  :ref:`common-brushless-escs`
+The `BlueRobotics T100, T200 and T500 thrusters <https://www.bluerobotics.com/product-category/thrusters/>`__ are commonly used thrusters that can be controlled using :ref:`regular reversible brushless motor ESCs <common-brushless-escs>`
 
 Clockwise and Counter-Clockwise propellers are included and should be used for skid-steering and omni vehicles to better balance the torque which could affect the vehicle's heading control
 
-If using reversible BLHeli DShot ESCs, use :ref:`common-blheli32-passthru` to set:
+If using :ref:`BLHeli ESCs <common-blheli32-passthru>` use the configuration app to set:
 
 - "Motor Direction" to "Bidirectional 3D" 
 - "Low RPM Power Protect" to "Off" 


### PR DESCRIPTION
This PR makes two mostly unrelated changes:

- the thrusters page is change to "BlueRobotics Thrusters" which is more specific and accurate
- Two subsections of the BLHeli page have their title underlines demoted to stop them from appearing on the "ESCs and Motors" landing page

![image](https://user-images.githubusercontent.com/1498098/170151354-1d6b5ddb-ac0b-487f-b5ac-0900c63bd3b5.png)

I have tested this on my local machine.