### PR TITLE
LOITER_TURNS: Add a radius item

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -940,7 +940,7 @@ This is the command equivalent of the :ref:`Circle flight mode <copter:circle-mo
    <tr>
    <td><strong>param3</strong></td>
    <td>Radius</td>
-   <td>Empty</td>
+   <td>Loiter radius around waypoint. Units are in meters. Values over 255 will be in units of 10 meters. and values greater than 2550 will be 2550.</td>
    </tr>
    <tr style="color: #c0c0c0">
    <td><strong>param4</strong></td>

--- a/copter/source/docs/mission-command-list.rst
+++ b/copter/source/docs/mission-command-list.rst
@@ -113,6 +113,15 @@ part of the mission).  The direction can be changed to counter-clockwise by sett
 
 **Turn** - the number of full rotations to complete around the point.
 
+**Radius** - Loiter radius around waypoint. Units are in meters.
+
+-  0-255 is 0-255 meters.
+-  256-259 is 250 meters. Note: The radius will be smaller than the set value.
+-  260-269 is 260 meters.
+-  270-279 is 270 meters.
+-  :
+-  2550 and above, 2550 meters.
+
 **Lat, Lon** - the latitude and longitude targets.  If left as zero it
 will circle around the current location.
 


### PR DESCRIPTION
Changed implementation for radius of LOITER_TURNS at "ArduCopter: support *10 multipler when storing/retrieving radius in NAV_LOITER_TURNS" .
I would like to note in the WIKI that the radius does not change smoothly.