### PR TITLE
Update ESC calibration page for DShot and active braking

### DIFF
--- a/copter/source/docs/esc-calibration.rst
+++ b/copter/source/docs/esc-calibration.rst
@@ -26,6 +26,7 @@ fails try the "Manual ESC-by-ESC" method.
 
 -  Refer to :ref:`common-brushless-escs` for setup of the ESC protocol (:ref:`MOT_PWM_TYPE <MOT_PWM_TYPE>`) according to your type of ESC.
 -  Some ESCs like the DJI Opto ESCs do not require and do not support calibration, so skip this page completely.
+-  If you are using a digital esc protocol like DShot or are using CAN ESCs then you also don't need to calibrate them, so skip this page. The section at the end on ESC settings is still applicable, however.
 -  Some brands of ESC do not allow calibration and will not arm unless you adjust your radio's throttle end-points so that the minimum throttle is around 1000 PWM and maximum is around 2000.  Note that if you change the end-points on your TX you must re-do the :ref:`Radio Calibration <common-radio-control-calibration>`.  Alternatively, you may manually set the :ref:`MOT_PWM_MIN <MOT_PWM_MIN>` to 1000 and :ref:`MOT_PWM_MAX <MOT_PWM_MAX>` to 2000.
 -  Begin this procedure only after you have completed the :ref:`radio control calibration <common-radio-control-calibration>` and :ref:`Connect ESCs and motors <connect-escs-and-motors>` part of the :ref:`Autopilot System Assembly Instructions <autopilot-assembly-instructions>`.  Next follow these steps:
 
@@ -174,11 +175,14 @@ the APM the way it is now. This is an unfortunately necessary but true
 disclaimer.
 
 Recommended ESC settings as follows:
+====================================
 
-#. Brake: OFF
-#. Battery Type: Ni-xx(NiMH or NiCd)  (even if you're using Li-po
-   batteries this setting reduces the likelihood that the ESC's low
-   voltage detection will turn off the motors)
+#. Brake on stop: OFF
+#. Active braking/"Damped light": ON (Also known as "Non Damped mode" set to OFF)
+#. Low voltage protection: OFF (alternatively, you can set battery type 
+   to Ni-xx(NiMH or NiCd) (even if you're using Li-po batteries because
+   this setting reduces the likelihood that the ESC's low voltage detection 
+   will turn off the motors)
 #. CutOff Mode: Soft-Cut (Default)
 #. CutOff Threshold: Low
 #. Start Mode: Normal (Default)

--- a/copter/source/docs/esc-calibration.rst
+++ b/copter/source/docs/esc-calibration.rst
@@ -75,9 +75,7 @@ All at once calibration
     :width: 400px
     
 #. For Autopilots with a safety switch, push it until the LED displays solid red
-#. The autopilot is now in ESC calibration mode. (On an APM you may
-   notice the red and blue LEDs blinking alternatively on and off like a
-   police car).
+#. The autopilot is now in ESC calibration mode.
 #. Wait for your ESCs to emit the musical tone, the regular number of
    beeps indicating your battery's cell count (i.e. 3 for 3S, 4 for 4S)
    and then an additional two beeps to indicate that the maximum
@@ -120,7 +118,7 @@ Manual ESC-by-ESC Calibration
 #. If you are still having trouble after trying these methods (for
    example, ESCs still beep continuously) try lowering your throttle
    trim 50%.
-#. You can also try powering your APM board via the USB first to boot it
+#. You can also try powering your ArduPilot board via the USB first to boot it
    up before plugging in the LiPo.
 
 Semi Automatic ESC-by-ESC Calibration
@@ -171,7 +169,7 @@ you will also need to do an additional final automatic calibration).
 Finally, there are a huge number of brands and types of ESCs available
 and some of them do not adhere to the normal programming conventions
 (sometimes even though they claim to) and they may simply not work with
-the APM the way it is now. This is an unfortunately necessary but true
+ArduPilot the way it is now. This is an unfortunately necessary but true
 disclaimer.
 
 Recommended ESC settings as follows:


### PR DESCRIPTION
Updates the ESC calibration page to clarify that digital protocols like DShot don't need to be calibrated.
Also the difference between brake on stop and active braking in ESC settings as current settings are unclear as to which is referred to.
Also removed some references to the APMs.

@tridge I've added CAN ESCs in here as well as you suggested, though it seems like this would only apply to integrated CAN ESCs - ESCs that use PWM but via a CAN adapter would still need to be calibrated somehow, right? Not sure if we need to mention this on the page or if it's clear enough?