### PR TITLE
Add VSCode tasks and recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "streetsidesoftware.code-spell-checker",
+        "lextudio.restructuredtext",
+        "shuworks.vscode-table-formatter",
+        "znck.grammarly"
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "ArduPilot Build Wiki (All)",
+            "type": "shell",
+            "command": "./update.py",
+            "args": ["--parallel", "-1"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}


### PR DESCRIPTION
A few extensions and a task to get new wiki writers using VSCode up to speed quickly. The wiki structure we have is not the greatest with the preview extension, but changing the conf.py file used for building the preview is pretty easy in the bottom left. Previewing common pages is not really possible though. 