### PR TITLE
correcting relay pin settings for omnibusf4pro.

### DIFF
--- a/common/source/docs/common-omnibusf4pro.rst
+++ b/common/source/docs/common-omnibusf4pro.rst
@@ -212,10 +212,10 @@ How to trigger a camera with relay pin
 
 Any PWM output can be used as a relay pin. See :ref:`common-gpios`
 
-:ref:`RELAY_PIN<RELAY_PIN>` = 15 # for output PWM 5
+:ref:`RELAY_PIN<RELAY_PIN>` = 54 # for output PWM 5
 
 if we want to set PWM 6 as relay pin :
-:ref:`RELAY_PIN<RELAY_PIN>` = 41 # for output PWM 6
+:ref:`RELAY_PIN<RELAY_PIN>` = 55 # for output PWM 6
 
 Hardware definition is available `here <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/omnibusf4pro/hwdef.dat>`__.
 


### PR DESCRIPTION
current wiki is incorrect , in HWDAT it says that the pins 54 and 55 for output 5 and 6.
PA1 TIM2_CH2  TIM2 PWM(5) GPIO(54)
PA8 TIM1_CH1  TIM1 PWM(6) GPIO(55)