### PR TITLE
Add board name tip for 13 character issue

### DIFF
--- a/dev/source/docs/porting.rst
+++ b/dev/source/docs/porting.rst
@@ -17,6 +17,8 @@ Step 1 - getting started
 - determine which microcontroller the new flight controllers uses.  if it is a CPU we already support (STM32F42x, STM32F40x STM32F41x, STM32F745, STM32F765, STM32F777 or STM32H743 where “x” can be any number), then the port should be relatively straight forward.  If it is another CPU, ping us on the `ArduPilot Discord Chat <https://ardupilot.org/discord>`__ for advice on how to proceed.
 - determine the crystal frequency (normally 8Mhz or 24Mhz).  refer to the schematic or read the writing on the crystal which is normally a small silver square.
 
+.. tip:: Choose your board name carefully! Use 13 characters or less for your board name, otherwise it may be truncated when the board name is sent from the flight controller to a ground station such as Mission Planner.
+
 Step 2 - create a hwdef.dat file for the board
 ----------------------------------------------
 


### PR DESCRIPTION
When a board name is sent in status messages to the ground station, the name is truncated at 13 characters. The board can be named longer than 13 characters, but only 13 are sent, so a suggestion to keep to 13 characters or less when naming the board might help prevent confusion.