### PR TITLE
Common: minor fixes to Remote id page

### DIFF
--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -15,7 +15,7 @@ Remote IDs are becoming a legal requirement in some countries.  Below is a list 
 MAVLink enabled devices that connect to the autopilot:
 
 - `Aerobits idME <https://www.aerobits.pl/product/idme/>`__
-- `BlueMark DroneBeacon MAVLink (EU, US, Japan) <https://dronescout.co/dronebeacon-mavlink-remote-id-transponder/>`__ (support expected to be added in ArduPilot-4.3.0)
+- `BlueMark DroneBeacon MAVLink (EU, US) <https://dronescout.co/dronebeacon-mavlink-remote-id-transponder/>`__ (support expected to be added in ArduPilot-4.3.0)
 - `Dronetag Mini <https://dronetag.cz/en/products/mini/>`__
 
 Stand-alone devices:

--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -16,11 +16,11 @@ MAVLink enabled devices that connect to the autopilot:
 
 - `Aerobits idME <https://www.aerobits.pl/product/idme/>`__
 - `BlueMark DroneBeacon MAVLink (EU, US, Japan) <https://dronescout.co/dronebeacon-mavlink-remote-id-transponder/>`__ (support expected to be added in ArduPilot-4.3.0)
+- `Dronetag Mini <https://dronetag.cz/en/products/mini/>`__
 
 Stand-alone devices:
 
 - `Aerobits idME+ <https://www.aerobits.pl/product/idme-remoteid/>`__
-- `Dronetag Mini <https://dronetag.cz/en/products/mini/>`__
 - `EAMS Robotics remote id (Japan) <http://www.eams-robo.co.jp/remoteid.html>`__
 
 The `OpenDroneID OSM <https://play.google.com/store/apps/details?id=org.opendroneid.android_osm>`__ android app can be used to check the Remote Id is working (`source code is here <https://github.com/opendroneid/receiver-android>`__)

--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -23,6 +23,9 @@ Stand-alone devices:
 - `Aerobits idME+ <https://www.aerobits.pl/product/idme-remoteid/>`__
 - `EAMS Robotics remote id (Japan) <http://www.eams-robo.co.jp/remoteid.html>`__
 
-The `OpenDroneID OSM <https://play.google.com/store/apps/details?id=org.opendroneid.android_osm>`__ android app can be used to check the Remote Id is working (`source code is here <https://github.com/opendroneid/receiver-android>`__)
+Other references:
+
+- The `OpenDroneID OSM <https://play.google.com/store/apps/details?id=org.opendroneid.android_osm>`__ android app can be used to check the Remote Id is working (`source code is here <https://github.com/opendroneid/receiver-android>`__)
+- `OpenDroneID list of remote id devices for the US and EU <https://github.com/opendroneid/receiver-android/blob/master/transmitter-devices.md>`__
 
 If you know if other available devices please `add a comment in this issue <https://github.com/ArduPilot/ardupilot_wiki/issues/4414>`__


### PR DESCRIPTION
This PR makes three changes:

-  moves Dronetag Mini up into the "MAVLink enabled devices" section
- removes the "JP" label next to BlueMark's device.  [This list from the Japanese ministry of transportation](https://www.mlit.go.jp/koku/content/001484158.pdf) is the official list of devices that can be used in Japan (as expected a "giteki" is required I think).
- adds a link to the OpenDroneId list of transmitter devices

I've tested this on my local machine and it looks OK.