### PR TITLE
Fix FFT documentation: FREQ=>REF

### DIFF
--- a/common/source/docs/common-imu-fft.rst
+++ b/common/source/docs/common-imu-fft.rst
@@ -18,7 +18,7 @@ ArduPilot comes pre-configured with appropriate defaults for all FFT settings. T
 
 - Set :ref:`INS_HNTCH_ENABLE <INS_HNTCH_ENABLE>` and/or :ref:`INS_HNTC2_ENABLE <INS_HNTC2_ENABLE>` = 1 to enable the harmonic notch = 1 to enable the harmonic notch
 - Set :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` and/or :ref:`INS_HNTC2_MODE <INS_HNTC2_MODE>` = 4 to use the FFT detected frequency for controlling the harmonic notch frequency.
-- Set :ref:`INS_HNTCH_FREQ <INS_HNTCH_FREQ>` and/or :ref:`INS_HNTC2_FREQ <INS_HNTC2_FREQ>` = 1 to set the harmonic notch reference value, which for FFT analysis generally means no scaling
+- Set :ref:`INS_HNTCH_REF <INS_HNTCH_REF>` and/or :ref:`INS_HNTC2_REF <INS_HNTC2_REF>` = 1 to set the harmonic notch reference value, which for FFT analysis generally means no scaling
 
 For most uses with other FFT related advanced parameters at their default, this is all that is required. The user can do optimization of the filtering setup by analyzing the test flight logs and adjusting notch bandwidth, if desired, by following the :ref:`In-flight FFT Advanced Setup <common-imu-fft-advanced-setup>` instructions.
 


### PR DESCRIPTION
An obvious bug has been introduced when updating the docs to include HNTC2 parameters.

I know at least one person who followed the new doc and got a mystically unflyable copter. Effectively, every input was filtered out with FREQ=1 and BW=120.

This fixes it.