### PR TITLE
Update setting-up-sitl-using-vagrant.rst

### DIFF
--- a/dev/source/docs/setting-up-sitl-using-vagrant.rst
+++ b/dev/source/docs/setting-up-sitl-using-vagrant.rst
@@ -83,10 +83,7 @@ Set up the Vagrant and the virtual machine
 
 #. Start a vagrant instance
 
-   -  Open a command prompt and navigate to any directory in the
-      `/ArduPilot/ardupilot/Tools/vagrant/ <https://github.com/ArduPilot/ardupilot/blob/master/Tools/vagrant/>`__
-      source tree.
-   -  Run the command:
+   -  Inside the ardupilot folder, run the command:
 
       ::
 


### PR DESCRIPTION
The `Vagrantfile` (required for the vagrant up command) is located on the root folder of the ardupilot repository. Update to the documentation to correctly use Vagrant.