### PR TITLE
Common: Gremsy setup fixes

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -19,7 +19,7 @@ ArduPilot supports both brushless direct drive gimbals (Tarot, SimpleBGC, SToRM3
 that have their own self-stabilization controllers and the simpler servo-driven
 gimbals in which ArduPilot controls the stabilisation.
 
--  :ref:`Gremsy Pixy and Mio <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
+-  :ref:`Gremsy T3, T7, Pixy and Mio <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
 -  :ref:`Servo Gimbals <common-camera-gimbal>` — older-style servo-driven gimbal where ArduPilot provides stabilisation
 -  :ref:`SimpleBGC (aka AlexMos) Gimbal Controller <common-simplebgc-gimbal>` - a popular 2-axis or 3-axis brushess gimbal controller which uses a custom serial interface
 -  :ref:`SToRM32 Gimbal Controller <common-storm32-gimbal>` — an inexpensive 2-axis or 3-axis brushless gimbal controller which responds to MAVLink commands (a richer format than PWM) over a serial interface

--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -104,6 +104,7 @@ Connect with a ground station and set the following parameters:
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 2 for "MAVLink2"
 - :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` to 1024 for "Don't forward mavlink to/from"
+- Optionally set :ref:`RC9_OPTION <RC9_OPTION>` to 163 for "Mount Lock" to allow the pilot to switch between "lock" and "follow" modes during "RC Targetting".  Note "RC9" can be replaced with any RC input channel
 
 Configuring the Gimbal
 ----------------------

--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -1,10 +1,10 @@
 .. _common-gremsy-pixyu-gimbal:
 
-==================================
-Gremsy Pixy and Mio 3-Axis Gimbals
-==================================
+==========================================
+Gremsy T3, T7, Pixy and Mio 3-Axis Gimbals
+==========================================
 
-Gremsy `Pixy SM <https://gremsy.com/products/pixy-sm>`__, `Pixy WP <https://gremsy.com/products/pixy-wp>`__, `Pixy U <https://gremsy.com/products/pixy-u>`__, `Pixy F <https://gremsy.com/products/pixy-f>`__ and `Mio <https://gremsy.com/products/mio>`__ 3-axis gimbals can communicate with the flight controller using the MAVLink protocol and are compatible with a range of cameras for real-time video or mapping purposes.
+Gremsy `T3 <https://gremsy.com/products/gremsy-t3v3>`__, `T7 <https://gremsy.com/products/gremsy-t7>`__, `Pixy WP <https://gremsy.com/products/pixy-wp>`__, `Pixy U <https://gremsy.com/products/pixy-u>`__, `Pixy F <https://gremsy.com/products/pixy-f>`__ and `Mio <https://gremsy.com/products/mio>`__ 3-axis gimbals can communicate with the flight controller using the MAVLink protocol and are compatible with a range of cameras for real-time video or mapping purposes.
 
 .. image:: ../../../images/gremsy-pixyu-gimbal.png
     :target: https://gremsy.com/products/pixy-u
@@ -120,7 +120,7 @@ Configuring the Gimbal
       :target: ../_images/gremsy-firmware-version-check.png
       :width: 450px
 
-  - If the gimbal firmware is older than 7.7.1 download the latest .hex for `Pixy SM <https://github.com/Gremsy/PixySM-Firmware/releases>`__, `Pixy W <https://github.com/Gremsy/PixyW-Firmware/releases>`__, `Pixy U <https://github.com/Gremsy/PixyU-Firmware/releases>`__, `Pixy F <https://github.com/Gremsy/PixyF-Firmware/releases>`__ or `Mio <https://github.com/Gremsy/Mio-Firmware/releases>`__
+  - If the gimbal firmware is older than 7.7.1 download the latest .hex for `T3 <https://github.com/Gremsy/T3V3-Firmware/releases>`__, `T7 <https://github.com/Gremsy/T7-Firmware/releases>`__, `Pixy W <https://github.com/Gremsy/PixyW-Firmware/releases>`__, `Pixy U <https://github.com/Gremsy/PixyU-Firmware/releases>`__, `Pixy F <https://github.com/Gremsy/PixyF-Firmware/releases>`__ or `Mio <https://github.com/Gremsy/Mio-Firmware/releases>`__
   - Select "UPGRADE", "BROWSE" and select the file downloaded above
   - Press the other "UPGRADE" button and the upgrade should complete within 30 seconds
 


### PR DESCRIPTION
This PR makes two changes:

- Removes the Pixy SM and adds T3 and T7 to the list of supported gimbals
- Adds RC9_OPTION parameter setting for "lock" vs "follow"

This has been tested on my local machine