### PR TITLE
RenoteID: Add external remote ID development and sales company in Japan

### DIFF
--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -22,6 +22,7 @@ Stand-alone devices:
 
 - `Aerobits idME+ <https://www.aerobits.pl/product/idme-remoteid/>`__
 - `EAMS Robotics remote id (Japan) <http://www.eams-robo.co.jp/remoteid.html>`__
+- `TEAD remote id (Japan) <https://www.tead.co.jp/product/remote-id/>`__
 
 OpenDroneID
 ===========


### PR DESCRIPTION
TEAD Corporation is another company that develops and sells external remote IDs in Japan.

I have confirmed that I can receive the remote ID information reported by TEAD Corporation's Remote ID in the ANDROID application of the OPEN DRONE ID project.

TEAD CO.LTD.
https://www.tead.co.jp/product/remote-id/