### PR TITLE
Add AP_Periph DShot and PWM example

### DIFF
--- a/common/source/docs/common-ap-periph-usage-examples.rst
+++ b/common/source/docs/common-ap-periph-usage-examples.rst
@@ -1,0 +1,87 @@
+.. _common-ap-periph-usage-examples:
+
+======================
+DroneCAN Adapter Setup
+======================
+
+These are several ways that a DroneCAN adapter node running AP_Periph can be used and this page is a small selection of the possibilities. These sections should walk you through setting up the autopilot and the node so that they work together.
+
+.. note:: DroneCAN Adapter nodes usually come with firmware that supports a subset of ArduPilot's large peripheral capability. Be sure to check that the firmware supplied supports the peripherals you are attemptime to setup. If not, check the `Firmware <https://firmware.ardupilot.org/AP_Periph/>`__  page for possible alternative firmware for that adapter that may have the capability.
+
+GPS Setup
+=========
+Attach the GPS to a DroneCAN Adapter's serial port
+
+- set :ref:`GPS_TYPE<GPS_TYPE>` = 9 on the autopilot
+- set the DroneCAN adapter's ``SERIALx_PROTOCOL`` on which the GPS is connected to 5 (GPS)
+
+Compass Setup
+=============
+Attach the Compass to the DroneCAN Adapter's external I2C port. It will appear as a normal Compass in ArduPilot and normal :ref:`compass setup procedures<common-compass-calibration-in-mission-planner>` would apply.
+
+.. note:: The MatekL431 CAN Adapter comes setup for a SPI connected Compass (RM3100). If an I2C Compass is attached, different firmware must be loaded for it to function.
+
+I2C Airspeed Sensor
+===================
+Attach to the I2C bus pinned out from the DroneCAN Adapter.
+
+- set :ref:`ARSPD_TYPE<ARSPD_TYPE>` =8 (DroneCAN)
+- set the DroneCAN's ``ARSPD_TYPE`` parameter to match the type of airspeed sensor connected.
+
+Rangefinder Setup
+=================
+To use rangefinders, follow the instructions at  :ref:`DroneCAN Setup Advanced<common-uavcan-setup-advanced>` to set up the ArduPilot parameters. Using MissionPlanner or DroneCAN Gui, set the parameters on the adaptor node following the instructions for the relevant rangefinder.
+
+.. note:: The orientation of the rangefinder (RNGFND1_ORIENT) must be set to 0 on the adaptor node.
+
+.. note:: The RNGFNDx_ADDR ArduPilot parameter must be set above 0 and be equal to the number set on the DroneCAN adapter node.
+
+PWM or DShot Output Node
+========================
+Adapters that have timer outputs available can be used as PWM and DShot output nodes.
+
+The `MatekL431 DroneCAN PWM device <https://www.mateksys.com/?portfolio=can-l4-pwm>`__ is an example of this.
+
+This can be useful for providing additional servo outputs beyond what the autopilot provides, but is most useful for allowing the ESCs and Sevos to be remotely located, far from the autopilot using the CAN bus to communicate. A maximum of 32 outputs in ArduPilot is possible.
+
+In addition, the autopilot outputs can be configured for GPIO use, and still allow up to 32 servo/motor outputs to be realized with DroneCAN peripherals.
+
+.. note:: In order to use DShot output, the node must have a DShot-capable firmware installed.
+
+DShot ESC Adapter
+-----------------
+In this example, a quadplane with outputs 5-8 used for 4 DShot ESCs with telemetry will be shown. 3 wires from each ESC should be connected to the DroneCAN adapter node: Ground, DShot signal, and serial telemetry. The ground from each ESC should be connected to a ground pad on the DroneCAN node. The signal wires from the 4 ESCs should be connected to the first 4 PWM pads on the node, marked as outputs “1”, “2”, “3”, and “4”. The serial telemetry pin from all 4 ESCs should be all connected to the same UART RX pin on the adapter node.
+
+On the main autopilot you need to set:
+
+- :ref:`CAN_Px_DRIVER <CAN_P1_DRIVER>` = 1
+- :ref:`CAN_Dx_PROTOCOL <CAN_D1_PROTOCOL>` = 1
+- :ref:`CAN_Dx_UC_ESC_BM <CAN_D1_UC_ESC_BM>` = 240 or the bitmask of motor outputs
+- :ref:`CAN_Dx_UC_ESC_OF <CAN_D1_UC_ESC_OF>` = 4 or the offset number to the first ESC output. This makes the transmission of CAN packets much more efficient
+
+On the DroneCAN PWM node you need to set:
+
+- :ref:`OUTx_FUNCTION <dev:OUT1_FUNCTION>` = 33 + ESC number
+- :ref:`OUT_BLH_MASK <dev:OUT_BLH_MASK>` = 15 or a bitmask of which ESCs are active
+
+PWM Output
+----------
+On the main autopilot you need to set:
+
+- :ref:`CAN_Dx_UC_SRV_BM <CAN_D1_UC_SRV_BM>` to a bitmask of servos you want to send over CAN.
+- :ref:`CAN_Dx_UC_SRV_RT <CAN_D1_UC_SRV_RT>` to the output rate. This is typically 50 Hz for most servos.
+
+On the CAN node you need to set:
+
+- :ref:`OUT_BLH_MASK <dev:OUT_BLH_MASK>` = 0 to disable DShot
+- :ref:`ESC_PWM_TYPE <dev:ESC_PWM_TYPE>` = 0 for normal PWM
+- :ref:`OUTx_FUNCTION <dev:OUT1_FUNCTION>` to a value of 50 plus the servo number for each output you want to be enabled as PWM output
+- :ref:`OUTx_FUNCTION <dev:OUT1_FUNCTION>` = 0 for any outputs you do not have connected. Do not leave them at the default of 33 + ESC number
+
+For example, if you had an elevator servo on SERVO2 on the main autopilot and you want this to appear on the first output of the CAN node (on the node's pin marked “1”) then you would set OUT1_FUNCTION = 52 (that is 50 + the servo number on the flight controller). If you wanted a rudder that is on SERVO4 to appear on output 4 then you would set OUT4_FUNCTION=54.
+
+.. note:: It is also recommended to set OUTn_MIN to 1000, OUTn_MAX to 2000, and OUTn_TRIM to 1500. That will allow you to use the SERVOn_MIN, SERVOn_MAX, and SERVOn_TRIM values on the main autopilot to control the outputs range and center in the usual way. It is possible to use other values on the node, but it gets more complicated to understand the mapping of the PWM values, so using 1000, 1500, 2000 is recommended. Doing this also means the PWM value in your flight controller logs matches what is output by the node.
+
+Combining DShot and PWM outputs
+-------------------------------
+There are a few rules to follow when combining PWM and DShot outputs on the same node. If you are familiar with doing this on autopilot, it is the same rules. The pins are grouped by timer and all of the pins attached to a timer must be the same type. For example, on the MatekL431 node the first 4 outputs are all on the same timer. This means that those output pins must all be DShot outputs and 1 PWM on the fifth output or the first 4 as PWM and 1 DShot.

--- a/common/source/docs/common-uavcan-adapter-node.rst
+++ b/common/source/docs/common-uavcan-adapter-node.rst
@@ -4,32 +4,35 @@
 DroneCAN Adapter Node
 =====================
 
-These allow existing ArduPilot supported peripherals to be adapted to the CAN bus as DroneCAN devices.
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   
+   common-ap-periph-usage-examples
+
+These nodes allow existing ArduPilot supported peripherals to be adapted to the CAN bus as DroneCAN or MSP devices. This also allows for extending the capabilities of the autopilot hardware. Such as allowing I2C devices (e.g. a compass or airspeed) to be located more than 1 meter from the autopilot and enabling up to 32 servo output channels.
 
 .. image:: ../../../images/uavcan-node.jpg
 
-They utilize the `AP_Periph <https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Periph>`__ library to remotely locate existing ArduPilot drivers onto an STMF103 or STMF303 based device, translating UART,SPI, I2C, or GPIO-based peripheral devices supported by ArduPilot into DroneCAN devices on the CAN bus.
+They utilize the `AP_Periph <https://github.com/ArduPilot/ardupilot/tree/master/Tools/AP_Periph>`__ library to use existing ArduPilot drivers on a supported hardware board. Translating UART, SPI, I2C, or GPIO-based peripheral devices supported by ArduPilot into DroneCAN devices on the CAN bus or MSP.
 
-GPS adapted to DroneCAN:
+For example, a serial GPS adapted to DroneCAN:
 
 .. image:: ../../../images/uavcan-node-gps.jpg
    :width: 450px
 
+This provides an easy method to develop integrated DroneCAN peripherals which can be used with ArduPilot or other systems that support DroneCAN.
 
-This provides an easy method to develop integrated DroneCAN peripherals which can be used with ArduPilot or other DroneCAN systems.
-
-The first adapter was manufactured by `mRobotics <https://store.mrobotics.io/product-p/mro10042.htm>`__ , is shown below,and provides socketed outputs for a UART+I2C and another I2C connection, and board pads for a second UART, SPI bus, GPIOs, and ADC inputs.
+The first adapter was manufactured by `mRobotics <https://store.mrobotics.io/product-p/mro10042.htm>`__, is shown below, and provides socketed outputs for a UART+I2C and another I2C connection, and solder pads for a second UART, SPI bus, GPIOs, and ADC inputs.
 
 .. image:: ../../../images/mRo-can-node.jpg
 
-The first generation was based on the f103 processor, while current generation uses an f303 for more memory, allowing more peripheral options to be accommodated simultaneously in the firmware.
+The first generation was based on the f103 processor, while the current generation uses an f303 for more memory, allowing more peripheral options to be accommodated simultaneously in the firmware. The L431 processor is now supported, as well as any ArduPilot compatible autopilot can be adapted for use as a DroneCAN Adapter Node.
 
-
-`Schematic <https://github.com/ArduPilot/Schematics/blob/master/mRobotics/mRo_CANnode_V1_R1.pdf>`__
+Developers might find the AP_Periph section of the dev docs useful for more details about creating AP_Periph nodes. :ref:`dev:ap-peripheral-landing-page`
 
 Features
 ========
-
 The AP_Periph DroneCAN firmware can be configured to enable a wide range of
 DroneCAN sensor types. Support is included for:
 
@@ -39,47 +42,47 @@ DroneCAN sensor types. Support is included for:
  - Airspeed sensors (I2C)
  - Rangefinders (UART or I2C)
  - ADSB (Ping ADSB receiver on UART)
- - LEDs (GPIO, I2C or WS2812 serial)
+ - LEDs (GPIO, I2C, or WS2812 serial)
  - Safety LED and Safety Switch
  - Buzzer (tonealarm or simple GPIO)
+ - PWM and DShot output
 
-And AP_Periph DroneCAN firmware supports these DroneCAN features:
+Setting up the autopilot and a general purpose adapter node to enable these features (assuming the node supports them) is detailed on :ref:`common-ap-periph-usage-examples`.
 
- - dynamic or static CAN node allocation
- - firmware upload
- - automatically generated bootloader
- - parameter storage in flash
- - easy bootloader update
- - high resiliance features using watchdog, CRC and board checks
- - firmware update via MissionPlanner or uavcan-gui-tool
+.. note:: In some cases, different firmware must be loaded onto the adapter node to enable the desired subset of the peripherals to be supported. See "Firmware" below.
+
+The AP_Periph DroneCAN firmware supports these DroneCAN features:
+
+ - Dynamic or static CAN node allocation
+ - Firmware upload
+ - Automatically generated bootloader
+ - Parameter storage in flash
+ - Easy bootloader update
+ - High resilience features using watchdog, CRC, and board checks
+ - Firmware update via MissionPlanner or DroneCAN-gui-tool
 
 Firmware
 ========
-
-`Firmware <https://firmware.ardupilot.org/AP_Periph/>`__ is provided in the AP_Periph folder for several DroneCAN devices based on this concept. Currently, the following firmware is pre-built, but the code allows for easy customization for any given peripheral or adapter based on the F103/303 processors. Firmware can be installed using either :ref:`DroneCAN GUI<common-uavcan-gui>` or :ref:`MissionPlanner SLCAN.<common-mp-slcan>` when the device is attaced to a DroneCAN port on an autopilot and the autopilot has enabled that port, see :ref:`common-uavcan-setup-advanced`.
-
+`Firmware <https://firmware.ardupilot.org/AP_Periph/>`__ is provided in the AP_Periph folder for supported DroneCAN devices as well as the conversion of some autopilots to DroneCAN adapter use. Currently, the following firmware is pre-built, but the code allows for easy customization. Firmware can be installed using either :ref:`DroneCAN GUI<common-uavcan-gui>` or :ref:`MissionPlanner SLCAN <common-mp-slcan>` when the device is attached to a DroneCAN port on an autopilot and the autopilot has that port enabled. See :ref:`common-uavcan-setup-advanced`. Since the size of all the ArduPilot driver libraries would exceed the smaller processors, several variations, supporting different peripheral sets, are provided.
 
 F103 Based
 ----------
-
-- f103-GPS         :Serial GPS, I2C Compass, I2C RGB LED
-- f103-ADSB        :Serial ADS_B, I2C Compass, I2C Airspeed
-- f103-Rangefinder :Serial Rangefinder, I2C Airspeed
+- f103-GPS: Serial GPS, I2C Compass, I2C RGB LED
+- f103-ADSB: Serial ADS_B, I2C Compass, I2C Airspeed
+- f103-Rangefinder: Serial Rangefinder, I2C Airspeed
 
 F303 Based
 ----------
-
-- f303-GPS         :Serial GPS, SPI RM3100 Compass, I2C Compass, I2C RGB LED
-- f303-M10025      :Serial GPS, SPI RM3100 Compass, SPI DPS310 Baro, I2C RGB LED, I2C Airspeed, Safety Switch
-- f303-Universal   :Serial GPS/Rangefinder/ADS-B, I2C Compass, I2C Baro, I2C RGB LED, I2C Airspeed
+- f303-GPS: Serial GPS, SPI RM3100 Compass, I2C Compass, I2C RGB LED
+- f303-M10025: Serial GPS, SPI RM3100 Compass, SPI DPS310 Baro, I2C RGB LED, I2C Airspeed, Safety Switch
+- f303-Universal: Serial GPS/Rangefinder/ADS-B, I2C Compass, I2C Baro, I2C RGB LED, I2C Airspeed
 
 L431 Based
 ----------
-
-- MatekL431-Periph      :Serial GPS, I2C QMC5883L Compass, I2C SPL06 Baro, I2C RGB LED, I2C Airspeed (MS4525 default), Passive Buzzer, Battery Monitor, MSP, 5 PWM outputs(not recommended for use, use MatekL431-DShot for those applications)
-- MatekL431-Airspeed    :I2C Airspeed, DLVR 10" default type
-- MatekL431-DShot       :5 Bi-Directional DShot(default)/PWM outputs starting at SERVO5 by default, ESC telem on UART1 RX ( see `setup instructions here <https://discuss.ardupilot.org/t/using-matekl431-adapters-for-pwm-and-dshot>`__ )
-- MatekL431-Rangefinder :Serial Rangefinders
+- MatekL431-Periph: Serial GPS, I2C QMC5883L Compass, I2C SPL06 Baro, I2C RGB LED, I2C Airspeed (MS4525 default), Passive Buzzer, Battery Monitor, MSP, 5 PWM outputs (it is recommended to use MatekL431-DShot for this application)
+- MatekL431-Airspeed: I2C Airspeed, DLVR 10" default type
+- MatekL431-DShot: 5 Bi-Directional DShot(default)/PWM outputs starting at SERVO5 by default, ESC telem on UART1 RX (see `setup instructions here <https://discuss.ardupilot.org/t/using-matekl431-adapters-for-pwm-and-dshot>`__)
+- MatekL431-Rangefinder: Serial Rangefinders
 
 
 ArduPilot Firmware DroneCAN Setup
@@ -89,12 +92,11 @@ ArduPilot Firmware DroneCAN Setup
 
 DroneCAN Adapters can support various devices and configurations. Often, its configuration parameters will need to be altered. To achieve this, either use :ref:`DroneCAN GUI<common-uavcan-gui>` or :ref:`MissionPlanner SLCAN.<common-mp-slcan>` to change the device's parameters.
 
-For example, when using the MatekL431-Airspeed, you may need to change the ARSPD_TYPE parameter in the device to match the actual I2C airpseed sensor you are using.
+For example, when using the MatekL431-Airspeed, you may need to change the ARSPD_TYPE parameter in the device to match the actual I2C airspeed sensor you are using.
 
-f303-Universal Setup
---------------------
-
-The f303-Universal firmware has the ability to be used for several serial devices but only one can be enabled to use the single UART. Once Firmware is uploaded, the default device connected to the UART port is set to GPS, to use another device such as Rangefinder, the GPS has to be turned off and Rangefinder or other device enabled.
+f303-Universal Example Setup
+----------------------------
+The f303-Universal firmware has the ability to be used for several serial devices but only one can be enabled to use the single UART. Once Firmware is uploaded, the default device connected to the UART port is set to GPS, to use another device such as Rangefinder, the GPS has to be turned off and Rangefinder or other devices enabled.
 
 Options for serial devices are:
 
@@ -102,7 +104,7 @@ Options for serial devices are:
  - RNGFND1_TYPE=0
  - ADSB_BAUDRATE=0
 
- The above settings would disable all of the devices, then you should enable just the one you want, knowing that you can’t have two serial devices as there is just one UART.
+ The above adapter DroneCAN parameter settings would disable all of the devices, then you should enable just the one you want, knowing that you can't have two serial devices as there is just one UART.
 
 The firmware can also be used for I2C peripherals.
 
@@ -111,22 +113,11 @@ The firmware can also be used for I2C peripherals.
  - AIRSPEED SENSOR
  - NCP5623 LED
 
-Rangefinder Setup
-=================
-
- To use rangefinders, follow the instructions at  :ref:`DroneCAN Setup Advanced<common-uavcan-setup-advanced>` to set up the ArduPilot parameters. Using MissionPlanner or DroneCAN Gui, set the parameters on the adaptor node following the instructions for the relevant rangefinder.
-
- .. note::
-
- 	The orientation of the rangefinder (RNGFND1_ORIENT) must be set to 0 on the adaptor node.
-
-
- .. note::
-
- 	The RNGFNDx_ADDR ArduPilot parameter must be set above 0 and be equal to the number set on the DroneCAN adapter node.
-
 DroneCAN Adapter Nodes
 ======================
 
+Several devices are manufactured specifically for use as general-purpose adapter nodes:
+
 :ref:`mRo DroneCAN Adapter Node <common-mro-uavcan-adapter-node>`
-`MatekL431 DroneCAN Adapter Node <http://www.mateksys.com/?portfolio=can-l431>`__
+
+`MatekL431 DroneCAN Adapter Node <http://www.mateksys.com/?portfolio=can-l431>`_

--- a/common/source/docs/common-uavcan-peripherals.rst
+++ b/common/source/docs/common-uavcan-peripherals.rst
@@ -19,6 +19,8 @@ DroneCAN was created to continue the development of the widely used UAVCAN v0 pr
     CUAV DroneCAN Power Module <common-can-pmu>
     Matek M8Q-CAN/DroneCAN GPS+Compass+Baro+Airspeed I2C port <common-matek-m8q>
     Matek DroneCAN DLVR-10 Airspeed Sensor <common-matek-uavcan-dlvr>
+    Matek DroneCAN Adapter Node <https://www.mateksys.com/?portfolio=can-l431>
+    Matek DroneCAN PWM <https://www.mateksys.com/?portfolio=can-l4-pwm>
     mRo GPS, GPS+Compass,RTK, and DroneCAN modules <https://store.mrobotics.io/category-s/109.htm>
     mRo KitCAN CAN/DroneCAN Adapter Node+Compass+Baro <common-mro-kitcan>
     mRo Location One GPS GPS+Compass+LED+Safety Switch <common-mrobotics-location-one-gps>

--- a/dev/source/docs/ap-peripheral-landing-page.rst
+++ b/dev/source/docs/ap-peripheral-landing-page.rst
@@ -15,9 +15,9 @@ The Peripheral device supports a wide range of STM32 processors,
 including F103, F303, F4xx, F7xx, G4xx and H7. Both sensors (distance
 sensor, GNSS, IMU, Barometer, battery, etc.) and output ports (I2C,
 SPI, PWM, UART, ESC, LED, etc.) can be used to build new peripherals,
-as well as providing bus expansion for CAN, MSP, I2C,SPI, etc.
+as well as providing bus expansion for CAN, MSP, I2C, SPI, etc.
 
-The software uses the same build system as ArduPilot for autopilot boards. All the firmware build configuration for an AP_Periph board done using a single configuration file (hwdef.dat) defines the inputs / outputs of the device and what device drivers will be included, in the same manner as an autopilot board. This makes it possible, for example, to define a AP_Periph device for UAVCAN with only a micro-controller of the STM32F103 type and 128 KB of flash memory, although processors with larger memory will be required depending on the number of drivers.
+The software uses the same build system as ArduPilot for autopilot boards. All the firmware build configuration for an AP_Periph board done using a single configuration file (hwdef.dat) defines the inputs/outputs of the device and what device drivers will be included, in the same manner as an autopilot board. This makes it possible, for example, to define an AP_Periph device for UAVCAN with only a micro-controller of the STM32F103 type and 128 KB of flash memory, although processors with larger memory will be required depending on the number of drivers.
 
 
 .. images/ap-periph-block-diagram.png
@@ -32,6 +32,13 @@ Capabilities
 - Self-diagnostic and security: watchdog, CRC, autotest, etc.
 - Updates with MissionPlanner or UAVCAN tools like :ref:`common-uavcan-gui`
 
+Examples of using generic AP_Periph nodes are shown here:
+
+.. toctree::
+   :maxdepth: 1
+
+   AP_Periph Usage Examples <ap-periph-usage-examples>
+
 Existing Products
 =================
 
@@ -40,7 +47,7 @@ Some (but not all) product examples using AP-Periph:
 - :ref:`Mateksys M8Q<common-matek-m8q>`
 - Hitec GNSS (`Septentrio Mosaic <https://hitecnology.com/drone-peripherals/hcs-positionpro-gnss-receiver>`__ )
 - :ref:`mRo UAVCAN Adapter node<common-mro-uavcan-adapter-node>`
-- :ref:`Orange Cube<common-thecubeorange-overview>` ( it's a flight controller,but it can also be used in AP_Periph..many others to follow)
+- :ref:`Orange Cube<common-thecubeorange-overview>` (It is a flight controller, but it can also be used in AP_Periph. Similar node types to follow.)
 
 Firmware
 ========
@@ -63,7 +70,7 @@ With the exception of the following parameters, AP_Periph parameters are simply 
 - :ref:`DEBUG<DEBUG>`
 - :ref:`BRD_SERIAL_NUM<BRD_SERIAL_NUM>`
 
-And, depending on driver library included, several parameters needed in addition to those included normally in those libraries:
+And, depending on the driver library included, several parameters are needed in addition to those included normally in those libraries:
 
 - :ref:`BUZZER_VOLUME<BUZZER_VOLUME>`
 - :ref:`BARO_ENABLE<BARO_ENABLE>`


### PR DESCRIPTION
Adds a page to hold examples of using AP_Periph for different use cases. First one up is the DShot and PWM example.

Covers one item in #3688.