### PR TITLE
Fix characters before ref tags causing issues and add step to Linux CI job

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -8,7 +8,7 @@ env:
   TEST: "1"
 jobs:
 
-  build:
+  build-windows:
 
     runs-on: 'windows-latest'
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
   TEST: "1"
 jobs:
 
-  build:
+  build-linux:
 
     runs-on: ubuntu-20.04
     strategy:
@@ -33,6 +33,11 @@ jobs:
         shell: bash {0}
         run: |
           grep --include=\*.rst -Rn -E '(:ref:`.*?`[_]{0,2}) ([\.,:])' .
+          test $? -eq 1
+      - name: Check for bad characters before ref directives
+        shell: bash {0}
+        run: |
+          grep --include=\*.rst -Rn -E '[a-zA-Z0-9_:]:ref:' .
           test $? -eq 1
       - name: Check python flake8 formatting
         run : |

--- a/common/source/docs/common-choosing-a-ground-station.rst
+++ b/common/source/docs/common-choosing-a-ground-station.rst
@@ -260,9 +260,9 @@ iOS
 
 For iOS devices, you will need:
 
--  iOS Based device such as an iPad or iPhone. If running iPad, the cellular version is recommended for better GPS support.
+-  iOS Based devices such as an iPad or iPhone. If running iPad, the cellular version is recommended for better GPS support.
 -  Wifi or Bluetooth LE link to the Drone
--  Bridge Connection to a:ref:`SiK Telemetry Radio System <common-sik-telemetry-radio>` via Wifi or Bluetooth LE
+-  Bridge Connection to a :ref:`SiK Telemetry Radio System <common-sik-telemetry-radio>` via Wifi or Bluetooth LE
 
   See iOS App Vendors for more details.
 

--- a/common/source/docs/common-imu-fft-advanced-setup.rst
+++ b/common/source/docs/common-imu-fft-advanced-setup.rst
@@ -41,7 +41,7 @@ It is also possible to use the in-flight FFT in a test flight to generate a prec
 
 - Set :ref:`FFT_ENABLE <FFT_ENABLE>` = 0 to disable the FFT engine.
 - Set :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` and/or :ref:`INS_HNTC2_MODE <INS_HNTC2_MODE>` = 1 to use the throttle-based dynamic harmonic notch.
-- Set ::ref:`INS_HNTCH_FREQ <INS_HNTCH_FREQ>` and/or :ref:`INS_HNTC2_FREQ <INS_HNTC2_FREQ>` = :ref:`FFT_MINHZ <FFT_MINHZ>`
+- Set :ref:`INS_HNTCH_FREQ <INS_HNTCH_FREQ>` and/or :ref:`INS_HNTC2_FREQ <INS_HNTC2_FREQ>` = :ref:`FFT_MINHZ <FFT_MINHZ>`
 - Set :ref:`INS_HNTCH_REF <INS_HNTCH_REF>` and/or :ref:`INS_HNTC2_REF <INS_HNTC2_REF>` = :ref:`FFT_THR_REF <FFT_THR_REF>`
 
 Alternatively, if you wish the hover frequency to be the lowest value for the harmonic notch:

--- a/common/source/docs/common-transmitter-tuning.rst
+++ b/common/source/docs/common-transmitter-tuning.rst
@@ -44,7 +44,7 @@ Concepts
 The two key controls for transmitter based tuning are:
 
 - A "tuning knob", setup on your transmitter to a convenient knob or
-  slider and linked to a RC channel that your board receives
+  slider and linked to an RC channel that your board receives
 
 - An optional "selector switch" for controlling advanced features of
   the tune. This should be linked to a two position switch mapped to
@@ -139,7 +139,7 @@ tuning knob around the current value. Toggle the selector switch
 briefly high then low and the center-value will change to whatever the
 tubing knob is set to. When you re-center the tuning knob will
 de-activate again until you move it to the mid-point position. This
-prevents you getting a jump in the tuning value when you re-center.
+prevents you from getting a jump in the tuning value when you re-center.
 
 Tuning multiple parameters
 ==========================
@@ -168,8 +168,8 @@ Holding the selector switch for more than 2 seconds will switch you to
 the next parameter and will also change the tuning knob back to its
 "wait for mid-point" state on the new parameter. The buzzer on the
 board will give a loud BEEP sequence to indicate which parameter in
-the set you have changed to. For the first parameter in the set you
-will get one loud BEEP. For the second parameter you will get two loud
+the set you have changed to. For the first parameter in the set, you
+will get one loud BEEP. For the second parameter, you will get two loud
 BEEPs and so on.
 
 When you have cycled through all of the parameters in the tuning set
@@ -244,7 +244,7 @@ The first parameter you will be tuning will be RateRollD. To tune that
 parameter (and the other parameters in the rate roll/pitch set) you
 should follow this process:
 
-- move the tuning knob to the mid-point to active the knob. You will
+- move the tuning knob to the mid-point to activate the knob. You will
   hear a rapid bup-bip from the board to indicate the tuning knob is
   activated.
 - start raising the tuning knob slowly, stopping immediately if the
@@ -277,16 +277,16 @@ holding the selector switch for more than five seconds. You will know
 the 5 seconds is up when you hear the distinctive rapid
 bup-bip-bup-bip sound from the buzzer.
 
-At that point you can land the vehicle, or just enjoy flying it.
+At that point, you can land the vehicle, or just enjoy flying it.
 
 The first time you do a full tune in this way it will probably take
-about five minutes of flight time to do a tune. With some practice you
+about five minutes of flight time to do a tune. With some practice, you
 can do a full tune in a bit over a minute.
 
 [/site]
 [site wiki="copter"]
 
-With transmitter based tuning you can tune a single or multiple parameters in flight using Channel 6 of the transmitter.
+With transmitter based tuning you can tune single or multiple parameters in flight using Channel 6 of the transmitter.
 
 The :ref:`TUNE<TUNE>` parameter determines which parameter is being tuned.
 
@@ -398,7 +398,7 @@ Rate Roll P and Rate Pitch P will be used in the following example procedure
 #. Turn your transmitter's CH6 tuning knob to the minimum position,
    press the "Refresh Params" button and ensure that the Rate Roll P and
    Rate Pitch P values become 0.08 (or something very close)
-#. Turn the CH6 knob to it's maximum position, press "Refresh Params"
+#. Turn the CH6 knob to its maximum position, press "Refresh Params"
    and ensure the Rate Roll P moves to 0.20
 #. Move the CH6 knob back to the middle
 #. Arm and fly your copter in Stabilize mode adjusting the ch6 knob
@@ -407,19 +407,16 @@ Rate Roll P and Rate Pitch P will be used in the following example procedure
 #. With the CH6 knob in the position that gave the best performance,
    return to the Copter Pids screen and push the "Refresh Params" button
 #. In the Rate Roll P and Rate Pitch P fields re-type the value that you
-   see but just slightly modified so that the mission planner recongises
+   see but just slightly modified so that the mission planner recognizes
    that it's changed and resends to the autopilot (Note: if you re-type
    exactly the same number as what appears in Rate Roll P it won't be
-   updated).  So for example if the Rate Roll P appears as "0.1213" make
+   updated).  So for example, if the Rate Roll P appears as "0.1213" make
    it "0.1200"
 #. Set Ch6 Opt back to "None" and push "Write Params"
 #. Push the Disconnect button on the top right, and the Connect
 #. Ensure that the Rate Roll P value is the value that you retyped in
    step #12
 
-Note: while you are moving the tuning knob the values update at 3 times
-per second.  The need to press the Refresh button in the mission planner
-in steps #6 and #7 above is just because the Copter is not sending the
-updates to the mission planner in real-time.
+.. note:: While you are moving the tuning knob the values update at 3 times per second.  The need to press the Refresh button in the mission planner in steps #6 and #7 above is just because the Copter is not sending the updates to the mission planner in real-time.
 
 [/site]

--- a/dev/source/docs/opendroneid.rst
+++ b/dev/source/docs/opendroneid.rst
@@ -105,7 +105,7 @@ this will return a rather lengthy path in a similar form to:
 **/dev/serial/by-id/usb-Silicon_Labs_CP2102N_USB_to_UART_Bridge_Controller_4e7564343210ec11a33426947a109228-if00-port0**
 
 
-Start SITL using the following,  and if you will be using the SERIAL1 interface in the code (ie ::ref:`DID_MAVPORT<DID_MAVPORT>` = 1) and the <path> discovered above:
+Start SITL using the following,  and if you will be using the SERIAL1 interface in the code (ie :ref:`DID_MAVPORT<DID_MAVPORT>` = 1) and the <path> discovered above:
 
 .. code::
 

--- a/plane/source/docs/advanced-failsafe-configuration.rst
+++ b/plane/source/docs/advanced-failsafe-configuration.rst
@@ -168,7 +168,7 @@ change current waypoint to the waypoint number specified in :ref:`AFS_WP_GPS_LOS
 will perform whatever actions you want on GPS loss. For example, you
 could have a set of waypoints starting at number 10 which first loiter
 on the spot for 30 seconds, and then proceed back to the airfield. You
-would then set ::ref:`AFS_WP_GPS_LOSS<AFS_WP_GPS_LOSS>` to 10 to enable that part of the
+would then set :ref:`AFS_WP_GPS_LOSS<AFS_WP_GPS_LOSS>` to 10 to enable that part of the
 mission on loss of GPS lock.
 
 When setting up mission items for GPS lock it is sometimes useful to

--- a/plane/source/docs/automatic-landing.rst
+++ b/plane/source/docs/automatic-landing.rst
@@ -411,7 +411,7 @@ If an RC channel's ``RCx_OPTION`` auxiliary function has been set to "64", then 
 ESC (Electronic Speed Controller)
 ---------------------------------
 
-Most important is to set the ::ref:`SERVO3_TRIM <SERVO3_TRIM>` (assuming the esc/motor is attached to output 3)to the point that the ESC is idle, usually around mid-range (1500us) to create an output curve that has :ref:`SERVO3_MAX<SERVO3_MAX>` for full forward thrust, and :ref:`SERVO3_MIN<SERVO3_MIN>` for full reverse thrust. This should be done AFTER the RC Calibrations setup step. 
+Most important is to set the :ref:`SERVO3_TRIM <SERVO3_TRIM>` (assuming the esc/motor is attached to output 3)to the point that the ESC is idle, usually around mid-range (1500us) to create an output curve that has :ref:`SERVO3_MAX<SERVO3_MAX>` for full forward thrust, and :ref:`SERVO3_MIN<SERVO3_MIN>` for full reverse thrust. This should be done AFTER the RC Calibrations setup step. 
 
 Hardware selection and programming
 ++++++++++++++++++++++++++++++++++

--- a/plane/source/docs/reverse-thrust-setup.rst
+++ b/plane/source/docs/reverse-thrust-setup.rst
@@ -70,5 +70,5 @@ In order to actually use this,an airspeed sensor must be in use, and the :ref:`T
 Use with pilot controlled forward thrust only
 +++++++++++++++++++++++++++++++++++++++++++++
 
-The autopilot controlled reverse thrust discussed above can be used without needing to have the throttle stick evoke any reverse thrust at all. Simply set :ref:`THR_MIN<THR_MIN>` for the maximum reverse thrust and :ref:`USE_REV_THRUST<USE_REV_THRUST>` as desired, and then set ::ref:`RC3_TRIM<RC3_TRIM>` =  :ref:`RC3_MIN<RC3_MIN>`. Low throttle stick will be zero thrust and above that, will only be forward thrust, however the autopilot can still command reverse thrust as needed.
+The autopilot controlled reverse thrust discussed above can be used without needing to have the throttle stick evoke any reverse thrust at all. Simply set :ref:`THR_MIN<THR_MIN>` for the maximum reverse thrust and :ref:`USE_REV_THRUST<USE_REV_THRUST>` as desired, and then set :ref:`RC3_TRIM<RC3_TRIM>` =  :ref:`RC3_MIN<RC3_MIN>`. Low throttle stick will be zero thrust and above that, will only be forward thrust, however the autopilot can still command reverse thrust as needed.
 

--- a/planner/source/docs/mission-planner-flight-data.rst
+++ b/planner/source/docs/mission-planner-flight-data.rst
@@ -7,7 +7,7 @@ Mission Planner Flight Data Screen
 
 This section covers the information you will need to use the features in
 the Mission Planner Flight DATA screen - selected in the Top menu of Mission
-Planner.:ref:`An Introduction <mission-planner-ground-control-station>` privodes a brief overview with pointers to the various areas of information.
+Planner. :ref:`An Introduction <mission-planner-ground-control-station>` provides a brief overview with pointers to the various areas of information.
 
 Heads Up Area  (HUD)
 ====================


### PR DESCRIPTION
Also one or two grammar things I caught on a quick glance. I also realized there are there are trailing spaces after refs sometimes. Doesn't break the creation of the hyperlink though. Just looks odd.