### PR TITLE
RemoteID: Add a Braveridge company in Japan

### DIFF
--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -22,6 +22,7 @@ Stand-alone devices:
 - `Aerobits idME+ <https://www.aerobits.pl/product/idme-remoteid/>`__
 - `EAMS Robotics remote id (Japan) <http://www.eams-robo.co.jp/remoteid.html>`__
 - `TEAD remote id (Japan) <https://www.tead.co.jp/product/remote-id/>`__
+- `Braveridge remote id (Japan) <https://www.braveridge.com/product/archives/49>`__
 
 OpenDroneID Compatible devices (support included in ArduPlane 4.0 and later)
 


### PR DESCRIPTION
Braveridge, a Japanese company, has developed and begun marketing a remote ID for external use.
The company's remote ID is 28,000 yen cheaper, including tax, than EAMS and TEAD.
The company also drills holes for installation with mini-drones in mind.
The price is open price.
At one dealer, it is 15180 yen including tax.

https://www.braveridge.com/product/archives/49