### PR TITLE
Fix serial port number in telemetry section of Holybro KakuteF4 Mini

### DIFF
--- a/common/source/docs/common-holybro-kakutef4-mini.rst
+++ b/common/source/docs/common-holybro-kakutef4-mini.rst
@@ -94,8 +94,8 @@ to set the following parameters to enable support for FrSky S.PORT. It
 has built-in inverters and a diode to allow for operation from a single
 pin with no special adapters.
 
-  - :ref:`SERIAL2_PROTOCOL<SERIAL2_PROTOCOL>` 4 or 10
-  - :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` 0
+  - :ref:`SERIAL1_PROTOCOL<SERIAL2_PROTOCOL>` 4 or 10
+  - :ref:`SERIAL1_OPTIONS<SERIAL2_OPTIONS>` 0
 
 OSD Support
 ===========


### PR DESCRIPTION
Subj. SP soldering pad is connected to UART1/Serial1 but not to Serial2