### PR TITLE
Fix build warning for common-dock-mode

### DIFF
--- a/common/source/docs/common-dock-mode.rst
+++ b/common/source/docs/common-dock-mode.rst
@@ -114,3 +114,5 @@ The docking process can be fine tuned using the following parameters.
 
    Be prepared to retake control if there are sudden unexpected
    movements (Change mode to Hold or manual).
+
+[copywiki destination="rover"]


### PR DESCRIPTION
Dock mode is only included in the rover wiki toctree right now. Changed the copy destination to match that. Was that page meant to be in the rover wiki and not in the common files?