### PR TITLE
Update common-here-plus-gps.rst

### DIFF
--- a/common/source/docs/common-here-plus-gps.rst
+++ b/common/source/docs/common-here-plus-gps.rst
@@ -155,7 +155,11 @@ Select the correct base module com port in the top left corner and click connect
 
 During the survey process, the right box will show the current survey status: Position is invalid: base station has not yet reached a valid location; In Progress: survey is still in progress; Duration: The number of seconds that the current surveying task has been executed; Observation: the number of observations acquired; Current Acc: Absolute geographic accuracy that the current base station can achieve. The green bar at the lower part of the Mission Planner page shows the satellites being detected and the signal strength related to each satellite. 
  
-The base station needs a certain amount of time to meet the accuracy requirements of your input. Testing shows that, in an open area without shelter, to achieve the absolute accuracy of 2m takes a few minutes; to reach the absolute accuracy of less than 30cm takes around an hour; to reach the accuracy of 10cm takes a few hours. 
+The base station needs a certain amount of time to meet the accuracy requirements of your input. Testing shows that, in an open area without shelter, to achieve the absolute accuracy of 2m takes a few minutes; to reach the absolute accuracy of less than 30cm takes around an hour; to reach the accuracy of 10cm takes a few hours.
+
+.. note::
+
+   These duration could vary greatly by various factors. For example, to achieve the absolute accuracy of 2m could take an hour.
  
 It should be noted that the absolute geographic accuracy of the base station here will affect the absolute geographic accuracy of the rover module without affecting the relative accuracy between the base station and rover. If your application does not require UAV with high absolute geographic accuracy, you do not need to set the base station's precision too high, resulting in long survey time. Even if the accuracy of the base station is 1.5 to 2 m, the position accuracy of the rover module relative to the base station can still reach centimeter level.
 


### PR DESCRIPTION
I had a chance to use ublox rtk and do some tests. During those test I observed inconsistent surveyin duration. I have asked this situation in some forums, but didnt get any answer.

I can share any data to prove this claim or try to do my tests again

below are some post where I asked relevant questions

https://discuss.ardupilot.org/t/here-rtk-surveyin-duration/90264
https://discuss.px4.io/t/rtk-surveyin-duration/28894
https://discuss.cubepilot.org/t/here-3-rtk-surveyin-duration-inconsistency/9516/2

ps: my changes only adds a note, I am not sure why it shows paragraph before as changed