### PR TITLE
Move ref directive regex check from CI to update.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,6 @@ jobs:
       - name: Check image formats
         run: |
           find ./images/ -exec file {} + | grep RIFF -vzq
-      - name: Check for extra characters after ref directives
-        shell: bash {0}
-        run: |
-          grep --include=\*.rst -Rn -E '(:ref:`.*?`[_]{0,2}) ([\.,:])' .
-          test $? -eq 1
-      - name: Check for bad characters before ref directives
-        shell: bash {0}
-        run: |
-          grep --include=\*.rst -Rn -E '[a-zA-Z0-9_:]:ref:' .
-          test $? -eq 1
       - name: Check python flake8 formatting
         run : |
           set -eux -o pipefail

--- a/update.py
+++ b/update.py
@@ -770,6 +770,20 @@ def check_imports():
     print("Imports OK")
 
 
+def check_ref_directives():
+    '''check formatting around ref directive that sphinx does not warn about'''
+    character_before_ref_tag = re.compile(r"[a-zA-Z0-9_:]:ref:")
+    character_after_ref_tag = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
+
+    for f in glob.glob("**/*.rst", recursive=True):
+        with open(f, "r", "utf-8") as file:
+            for i, line in enumerate(file.readlines()):
+                if character_before_ref_tag.search(line):
+                    error("Remove character before ref directive in \"%s\" on line number %s" % (f, i))
+                if character_after_ref_tag.search(line):
+                    error("Remove character after ref directive in \"%s\" on line number %s" % (f, i))
+
+
 #######################################################################
 if __name__ == "__main__":
     if platform.system() == "Windows":
@@ -847,6 +861,7 @@ if __name__ == "__main__":
     building_time = now.strftime("%Y-%m-%d-%H-%M-%S")
 
     check_imports()
+    check_ref_directives()
 
     if not args.fast:
         if args.paramversioning:


### PR DESCRIPTION
Move the regex for the ref directive formatting from a Linux only command to Python in update.py. This is working on Windows and Linux in CI.