### PR TITLE
Add minimum python version of 3.8

### DIFF
--- a/update.py
+++ b/update.py
@@ -52,6 +52,10 @@ from datetime import datetime
 # without the following import on old versions of Python:
 from distutils import dir_util  # noqa: F401
 
+if sys.version_info < (3, 8):
+    print("Minimum python version is 3.8")
+    sys.exit(1)
+
 DEFAULT_COPY_WIKIS = ['copter', 'plane', 'rover']
 ALL_WIKIS = [
     'copter',


### PR DESCRIPTION
@peterbarker

This might be a nice touch to add. Sphinx 5.1.1 supports >3.7. We can keep it level with Ubuntu 20.04 for now though. Would this also mean that the distutils import above could be removed? In fact, I'm not sure the difference to os.mkdirs or the pathlib method.