### PR TITLE
update.py: Check build only the wikis that were actually built when -…

### DIFF
--- a/update.py
+++ b/update.py
@@ -236,6 +236,8 @@ def check_build(site):
         print("Skipping check_build on windows")
         return
     for wiki in ALL_WIKIS:
+        if site is not None and site != wiki:
+            continue
         if wiki in ['common', 'frontend']:
             continue
         index_html = os.path.join(wiki, "build", "html", "index.html")
@@ -250,7 +252,7 @@ def copy_build(site, destdir):
     for wiki in ALL_WIKIS:
         if site == 'common':
             continue
-        if site is not None and not site == wiki:
+        if site is not None and site != wiki:
             continue
         if wiki == 'frontend':
             continue


### PR DESCRIPTION
…-site is used

This cleans up going to fatal even when everything finished ok. Useful when building only one wiki. Also change the written `not` to `!=`. That one was just an idle change. I don't have a preference. To me the value check is easier to read with `!=` and type checking as `is not`. /shrug

@peterbarker 