### PR TITLE
common: remove note in Swan-K1 about it not being in stable fw

### DIFF
--- a/common/source/docs/common-Swan-K1.rst
+++ b/common/source/docs/common-Swan-K1.rst
@@ -20,9 +20,7 @@ You will need to remove the access cover in order to attach a USB cable to the a
 
 Connect to Mission Planner or QGC, and upload the Plane firmware for the SWAN-K1 located `here <https://firmware.ardupilot.org>`__. 
 
-.. note:: Currently, it is only available as a "latest" firmware. It will be in a Stable version in the near future.
-
-The firmware will have defaults already set for optimum tuning and operation.
+The firmware has defaults already set for optimum tuning and operation.
 
 Calibration
 ===========


### PR DESCRIPTION
it is

In future we should probably phrase things "Swan-K1 support is in the Latest builds, and will be in Plane 4.2 stable and later versions".  Or something.
