### PR TITLE
Update copter for new RATE_TC params

### DIFF
--- a/copter/source/docs/input-shaping.rst
+++ b/copter/source/docs/input-shaping.rst
@@ -8,12 +8,15 @@ Copter has a set of parameters that define the way the aircraft feels to fly. Th
 
 The most important of these parameters is:
 
-- :ref:`ACRO_Y_RATE<ACRO_Y_RATE>`: desired maximum yaw rate / 45 degrees/s
+- :ref:`PILOT_Y_RATE<PILOT_Y_RATE>`: desired maximum yaw rate in deg/s
 - :ref:`ANGLE_MAX <ANGLE_MAX>`:  maximum lean angle
 - :ref:`ATC_ACCEL_P_MAX <ATC_ACCEL_P_MAX>`: Pitch rate acceleration
 - :ref:`ATC_ACCEL_R_MAX <ATC_ACCEL_R_MAX>`: Roll rate acceleration
 - :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>`: Yaw rate acceleration
 - :ref:`ATC_ANG_LIM_TC <ATC_ANG_LIM_TC>`: Aircraft smoothing time
+- :ref:`ATC_INPUT_TC <ATC_INPUT_TC>`: Time to achieve 63% seady state pitch and roll attitude. Mulitply by 3 to determine time to achieve steady state attitude.
+- :ref:`PILOT_Y_RATE_TC <PILOT_Y_RATE_TC>`: Time to achieve 63% steady state yaw rate. Multiply by 3 to determine time to achieve steady state rate.
+
 
 Autotune will set the :ref:`ATC_ACCEL_P_MAX <ATC_ACCEL_P_MAX>`, :ref:`ATC_ACCEL_R_MAX <ATC_ACCEL_R_MAX>` and :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>` parameters to their maximum based on measurements done during the Autotune tests. These values should not be increased beyond what Autotune suggests without careful testing. In most cases pilots will want to reduce these values significantly.
 
@@ -23,7 +26,7 @@ For aircraft designed to carry large directly mounted payloads, the maximum valu
 - :ref:`ATC_ACCEL_R_MAX <ATC_ACCEL_R_MAX>`  x (min_TOW / max_TOW)
 - :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>`  x (min_TOW / max_TOW)
 
-:ref:`ACRO_Y_RATE<ACRO_Y_RATE>` should be set to be approximately 0.5 x :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>` / 4500 to ensure that the aircraft can achieve full yaw rate in approximately half a second.
+:ref:`PILOT_Y_RATE<PILOT_Y_RATE>` should be set to be approximately 0.005 x :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>` to ensure that the aircraft can achieve full yaw rate in approximately half a second.
 
 :ref:`ATC_ANG_LIM_TC <ATC_ANG_LIM_TC>` may be increased to provide a very smooth feeling on the sticks at the expense of a slower reaction time.
 
@@ -33,10 +36,12 @@ Aerobatic aircraft should keep the :ref:`ATC_ACCEL_P_MAX <ATC_ACCEL_P_MAX>`, :re
 - :ref:`ACRO_BAL_ROLL <ACRO_BAL_ROLL>`
 - :ref:`ACRO_RP_EXPO <ACRO_RP_EXPO>`
 - :ref:`ACRO_RP_RATE <ACRO_RP_RATE>`
+- :ref:`ACRO_RP_RATE_TC <ACRO_RP_RATE_TC>`
 - :ref:`ACRO_THR_MID <ACRO_THR_MID>`
 - :ref:`ACRO_TRAINER <ACRO_TRAINER>`
 - :ref:`ACRO_Y_EXPO <ACRO_Y_EXPO>`
-- :ref:`ACRO_Y_RATE<ACRO_Y_RATE>`
+- :ref:`ACRO_Y_RATE <ACRO_Y_RATE>`
+- :ref:`ACRO_Y_RATE_TC<ACRO_Y_RATE_TC>`
 
 The full list of input shaping parameters are:
 
@@ -44,14 +49,17 @@ The full list of input shaping parameters are:
 - :ref:`ACRO_BAL_ROLL <ACRO_BAL_ROLL>`
 - :ref:`ACRO_RP_EXPO <ACRO_RP_EXPO>`
 - :ref:`ACRO_RP_RATE <ACRO_RP_RATE>`
+- :ref:`ACRO_RP_RATE_TC <ACRO_RP_RATE_TC>`
 - :ref:`ACRO_THR_MID <ACRO_THR_MID>`
 - :ref:`ACRO_TRAINER <ACRO_TRAINER>`
 - :ref:`ACRO_Y_EXPO <ACRO_Y_EXPO>`
-- :ref:`ACRO_Y_RATE<ACRO_Y_RATE>`
+- :ref:`ACRO_Y_RATE <ACRO_Y_RATE>`
+- :ref:`ACRO_Y_RATE_TC <ACRO_Y_RATE_TC>`
 - :ref:`ANGLE_MAX <ANGLE_MAX>`
 - :ref:`ATC_ACCEL_P_MAX <ATC_ACCEL_P_MAX>`
 - :ref:`ATC_ACCEL_R_MAX <ATC_ACCEL_R_MAX>`
 - :ref:`ATC_ACCEL_Y_MAX <ATC_ACCEL_Y_MAX>`
+- :ref:`ATC_INPUT_TC <ATC_INPUT_TC>`
 - :ref:`ATC_ANG_LIM_TC <ATC_ANG_LIM_TC>`
 - :ref:`ATC_RATE_P_MAX <ATC_RATE_P_MAX>`
 - :ref:`ATC_RATE_R_MAX <ATC_RATE_R_MAX>`
@@ -63,6 +71,8 @@ The full list of input shaping parameters are:
 - :ref:`PILOT_THR_BHV <PILOT_THR_BHV>`
 - :ref:`PILOT_THR_FILT <PILOT_THR_FILT>`
 - :ref:`PILOT_TKOFF_ALT <PILOT_TKOFF_ALT>`
+- :ref:`PILOT_Y_RATE <PILOT_Y_RATE>`
+- :ref:`PILOT_Y_RATE_TC <PILOT_Y_RATE_TC>`
 - :ref:`LOIT_ACC_MAX <LOIT_ACC_MAX>`
 - :ref:`LOIT_ANG_MAX <LOIT_ANG_MAX>`
 - :ref:`LOIT_BRK_ACCEL <LOIT_BRK_ACCEL>`


### PR DESCRIPTION
This PR updates the wiki for the new parameters introduced in Copter 4.3.  These parameters adjust the time constant for achieving steady state rate for axes that are rate command for a given mode.  
PILOT_Y_RATE_TC - yaw rate time constant for all  modes except acro
ACRO_RP_RATE_TC - acro roll/pitch rate time constant
ACRO_Y_RATE_TC  - acro yaw rate time constant

I also updated the Input shaping wiki for the max rate parameters which were updated in 4.1 ( i think).