### PR TITLE
Move python packages to requirements.txt

### DIFF
--- a/Sphinxsetup.bat
+++ b/Sphinxsetup.bat
@@ -1,17 +1,8 @@
 rem remove any existing packages that may cause conflicts
 pip uninstall -y sphinx lxml sphinx-rtd-theme sphinxcontrib-youtube beautifulsoup4
 
-rem Install sphinx
-pip install --upgrade sphinx==7.1.2 "docutils<0.19" requests>=2.31.0 sphinx-tabs==3.*
-
-rem lxml for parameter parsing:
-pip install --upgrade lxml
-
-rem Install sphinx theme from ArduPilot repository
-pip install --upgrade git+https://github.com/ArduPilot/sphinx_rtd_theme.git
-
-rem and a youtube plugin:
-pip install --upgrade git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
+rem Install required python packages
+pip install --user --upgrade -r requirements.txt
 
 echo "Setup completed successfully!"
 pause

--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -38,13 +38,6 @@ if [ "$(python --version)" == "Python 3.6.9" ]; then
     GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
 fi
 
-PYTHON_VERSION=$(python3 --version | cut -d' ' -f2)
-if [[ "${PYTHON_VERSION:0:3}" = "3.8" ]]; then
-    SPHINX_VERSION="7.1.2"
-else
-    SPHINX_VERSION="7.2.6"
-fi
-
 curl "$GET_PIP_URL" -o get-pip.py
 python3 get-pip.py
 rm -f get-pip.py

--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -49,23 +49,8 @@ curl "$GET_PIP_URL" -o get-pip.py
 python3 get-pip.py
 rm -f get-pip.py
 
-# Install python packages using known working versions
-# Install sphinx with a specific docutils version
-python3 -m pip install --user --upgrade sphinx==${SPHINX_VERSION} "docutils<0.19"  "requests>=2.31.0" sphinx-tabs==3.*
-
-# lxml for parameter parsing:
-python3 -m pip install --user --upgrade lxml
-
-# Install sphinx theme from ArduPilot repository
-python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinx_rtd_theme.git
-
-# and youtube and video plugins:
-# This command might require a --force option if you have and older extension installed
-# Rerun Sphinxsetup.sh after doing that
-python3 -m pip install --user --upgrade git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
-
-# Install flake8
-python3 -m pip install --user --upgrade flake8==3.7.9
+# Install required python packages
+python3 -m pip install --user --upgrade -r requirements.txt
 
 # Reset the value of DISPLAY
 if grep -qi -E '(Microsoft|WSL)' /proc/version; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+# Install sphinx with a specific docutils version
+# Docutils version is for correct bullet point rendering. Can be rolled forward after the theme is updated to >=0.5.1
+# See https://stackoverflow.com/a/68685753/2578171
+sphinx==7.1.2; python_version=="3.8"
+sphinx==7.2.6; python_version>"3.8"
+sphinx-tabs==3.*
+docutils<0.19
+requests>=2.31.0
+
+# lxml for parameter parsing:
+lxml
+
+# Install sphinx theme from ArduPilot repository
+git+https://github.com/ArduPilot/sphinx_rtd_theme.git
+
+# Sphinx youtube and video plugins:
+# This package will require a --force option if you have an older extension installed
+# Rerun Sphinxsetup.sh after doing that
+git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
+
+# and a parser to use getting posts from Discourse (forum) and insert in FrontEnd
+beautifulsoup4
+
+# Install flake8
+flake8==3.7.9


### PR DESCRIPTION
DELAY MERGE. There are dependencies that need to be merged before this can go in. See ArduPilot/sphinxcontrib-youtube#4.

This is a change for easier maintenance between the install scripts. Also works as an added bonus to check that the build dependencies are working on the packages ArduPilot maintains.

CI will fail on this PR. I ran this change using my sphinxcontrib-youtube repo and you can see the passing CI change over here.
https://github.com/TunaLobster/ardupilot_wiki/actions/runs/3106686180
https://github.com/TunaLobster/ardupilot_wiki/actions/runs/3106686182