### PR TITLE
Add python 3.10 to Github Actions CI

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: [3.8]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This is a future looking CI check. Not needed now, but will be helpful to catch error users might come across when building with newer python versions. Skipped python 3.9 for no specific reason.