### PR TITLE
Copter: reference page for edu-450 provides link to manufacturer's specifications

### DIFF
--- a/copter/source/docs/reference-frames-hexsoon-edu450.rst
+++ b/copter/source/docs/reference-frames-hexsoon-edu450.rst
@@ -1,12 +1,14 @@
 .. _reference-frames-hexsoon-edu450:
 
-==============
-Hexsoon EDU450
-==============
+===============
+Hexsoon EDU-450
+===============
 
 .. image:: ../images/reference-frames-hexsoon-edu450.jpg
 
-The Hexsoon EDU450 is a relatively low cost frame including motors, ESCs and propellers
+The Hexsoon EDU-450 is a relatively low cost frame including motors, ESCs and propellers
+
+CubePilot's `EDU-450 specfications can be found here <https://docs.cubepilot.org/user-guides/cubepilot-ecosystem/cubepilot-partners/hexsoon/multirotor-frame/edu-450>`__
 
 Parts List
 ----------

--- a/copter/source/docs/reference-frames.rst
+++ b/copter/source/docs/reference-frames.rst
@@ -11,8 +11,8 @@ This section includes details on tested frames to speed up DIY builds of multico
 .. toctree::
     :maxdepth: 1
 
-    Hexsoon EDU450 <reference-frames-hexsoon-edu450>
-    Hexsoon TD650 <reference-frames-hexsoon-td650>
+    Hexsoon EDU-450 <reference-frames-hexsoon-edu450>
+    Hexsoon TD-650 <reference-frames-hexsoon-td650>
 	Holybro S500 <reference-frames-holybro-s500>
     AmovLab P200 <reference-frames-amovlab-p200>
     iFlight Chimera 7 <reference-frames-iflight-chimera7>


### PR DESCRIPTION
Also add hyphen between EDU and 450 which is how CubePilot refers to the frame

I've tested this locally and it looks OK to me.