### PR TITLE
Add clarification to HNTCH_FREQ for RPM based

### DIFF
--- a/common/source/docs/common-rpm-based-notch.rst
+++ b/common/source/docs/common-rpm-based-notch.rst
@@ -9,7 +9,7 @@ RPM Sensor Based Dynamic Notch Setup
 - Set :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>` and/or :ref:`INS_HNTC2_MODE <INS_HNTC2_MODE>` = 2 or 5 to use an RPM sensor to set the harmonic notch frequency.
 - Set :ref:`INS_HNTCH_ENABLE <INS_HNTCH_ENABLE>` and/or :ref:`INS_HNTC2_ENABLE <INS_HNTC2_ENABLE>` = 1 to enable the harmonic notch
 - Set :ref:`INS_HNTCH_REF <INS_HNTCH_REF>` and/or :ref:`INS_HNTC2_REF <INS_HNTC2_REF>` = 1 to set the harmonic notch reference value to unscaled, unless the RPM sensor is reporting a fraction of the actual rotor speed. This might occur in a geared drive train setup. If the reported RPM is 1/3 the actual, for example, set this to 0.33.
-- Set :ref:`INS_HNTCH_FREQ <INS_HNTCH_FREQ>` and/or :ref:`INS_HNTC2_FREQ <INS_HNTC2_FREQ>` = below the hover frequency - you can easily determine this by performing a gentle hover and looking at the RPM sensor log data (RPM.rpm1)
+- Set :ref:`INS_HNTCH_FREQ <INS_HNTCH_FREQ>` and/or :ref:`INS_HNTC2_FREQ <INS_HNTC2_FREQ>` = below the hover frequency.  In the RPM based dynamic notch, this parameter sets the lower frequency limit of the notch.  So even if the RPM sensor reads a lower value, the notch's center frequency will remained constrainded to the value of this parameter.  You can easily determine the hover frequency by performing a hover and looking at the RPM sensor log data (e.g. RPM.rpm1).
 - Set :ref:`INS_HNTCH_BW <INS_HNTCH_BW>` and/or :ref:`INS_HNTC2_BW <INS_HNTC2_BW>` = half of INS_HNTCH_FREQ
 
 Checking Harmonic Notch Effectiveness


### PR DESCRIPTION
Added a few extra words to make it clearer that the INS_HNTCH_FREQ is a lower limit constrain.