### PR TITLE
Rover: small balance bot fixes

### DIFF
--- a/rover/source/docs/balance_bot-hardware.rst
+++ b/rover/source/docs/balance_bot-hardware.rst
@@ -3,45 +3,42 @@
 ================
 Hardware Options
 ================
-This page lists the hardware options that can meet all of the Balance Bot specific requirements. Though there is no limitation to running Balance Bot on any Rover compatible hardware, not all features and drive modes may be supported in certain configurations.
 
-Autopilot Board
-===============
-Autopilot Boards than can be used with Balance Bot are required to have sufficient PWM outputs for driving the motors (2 or more), and outputs which can be tasked as GPIOs (4 or more)(see :ref:`common-gpios`) for interfacing the wheel encoder pulse outputs. Some miniature versions of autopilots using an IOMCU will only have outputs that cannot be re-tasked as GPIOs and are therefore unsuitable.
+This page lists the hardware required for an autonomous Balance Bot
 
-Balance Bot Frame
-=================
+Frame
+=====
+
 Any readily available or custom made frame suitable for Balance Bots can be used. Ensure that there is sufficient space to hold all the components.
 
 For a 3d printable frame, check out :ref:`Arduroller<reference-frames-arduroller>`.
 
-Motors with encoders
-====================
-Brushed Motors with quadrature encoders(two pin output) are recommended for Balance Bots. There is no restriction on using brushless motors, but additional quadrature encoders will have to be added to run any mode other than Hold and Manual. Stepper Motors and motors that use UART/I2C interface are not currently supported.
+Autopilot
+=========
 
-Gear backlash is a problem with many geared dc motors and this can badly affect stability of Balance Bots. It is recommended to use motors that are specified to be zero-backlash or have very less backlash.
+The autopilot needs at least two PWM outputs for controlling the two motors and four :ref:`GPIO pins<common-gpios>` to connect to two :ref:`wheel encoders <wheel-encoder>`.  Some autopilots without an IOMCU will not have enough GPIOs to support wheel encoders.
 
-Motor Drivers/ESC
-=================
-For a full list of ArduPilot supported brushed motor drives/ESCs, refer the :ref:`brushed motors<common-brushed-motors>` page.
-
-Wheel Encoders
-==============
-When using motors without an an inbuilt encoder, external encoders that can be attached to the motor shaft, can be used. Only quadrature encoders with two output pins are currently supported. For more information, refer the :ref:`wheel encoder<wheel-encoder>` page.
-
-
-GPS + Compass(optional)
+Motors and Wheel Encoders
 =========================
-A GPS+Compass module is required for running Auto, Guided and RTL Modes. Using compass is also recommended for steering in Acro Mode. For more details on supported GPS hardware, refer :ref:`GPS<common-positioning-landing-page>` page.
+
+The recommended solution is to use brushed motors with built-in quadrature :ref:`wheel encoders <wheel-encoder>` but other motors may be used if external encoders are attached to the motor shafts.  Note that only quadrature encoders with two output pins are supported.  :ref:`Wheel encoders <wheel-encoder>` allow faster and more precise control of each wheel which greatly improves the vehicle's balance.
+
+Stepper Motors and motors that use UART/I2C interface are not currently supported.
+
+Gear backlash is a problem with many geared dc motors and this can negatively affect stability. It is recommended to use motors that are specified to be zero-backlash or have very little backlash.
+
+ESCs/Motor Drivers
+==================
+
+A list of verified ESCs/motor drivers can be fouind on the :ref:`brushed motors<common-brushed-motors>` page.
+
+GPS + Compass
+=============
+
+A GPS+Compass module is recommended if the balance bot will be used outdoors in autonomous modes (e.g. Auto, Guided, RTL).  A compass is required so the vehicle can estimate its heading.  For more details on supported GPS hardware, refer to the :ref:`GPS/Compass page<common-positioning-landing-page>`.
 
 Telemetry Radio(optional)
 =========================
+
 Telemetry radios are very useful for tuning and debugging. For more information on supported hardware options refer :ref:`telemetry<common-telemetry-landingpage>` page.
-
-
-
-
-
-
-
 

--- a/rover/source/docs/balance_bot-home.rst
+++ b/rover/source/docs/balance_bot-home.rst
@@ -21,12 +21,7 @@ Supported Control Modes
 - Auto
 - RTL
 
-.. note:: New or inexperienced ArduPilot users are recommended to go through the Rover :ref:`Intoduction<gettit>`, :ref:`Setup<apmrover-setup>` and :ref:`First drive<rover-first-drive>` sections before proceeding with this section.
-
-Before you proceed
-------------------
-
-Balance bot support will be officially included in Rover-3.5 (and higher).  Until this is released, it can be tested using "latest" which can be downloaded from the Mission Planner's Install Firmware screen by pressing Ctrl-Q.  Please note though that "latest" has not gone through beta testing and may have issues.
+.. note:: New or inexperienced ArduPilot users are recommended to go through the Rover :ref:`Introduction<gettit>`, :ref:`First Time Setup<apmrover-setup>` and :ref:`First drive<rover-first-drive>` sections before proceeding with this section.
 
 Get Started
 -----------

--- a/rover/source/docs/balance_bot-issues.rst
+++ b/rover/source/docs/balance_bot-issues.rst
@@ -20,7 +20,7 @@ This is bad:
 .. youtube:: 4Lkcze44W3E
     :width: 100%
 
-The only fix is to change motors. Make sure the backlash is as less as possible.
+The only fix is to change motors. Make sure the backlash is as low as possible.
 
 **2) Weight Distribution** : 
 If the center of gravity is near the wheels, the vehicle can topple quickly and if the motors are not fast enough to compensate, then the vehicle can become wobbly. The higher the center of gravity, the slower the vehicle falls. But more torque would be required from the motors to keep it balanced.

--- a/rover/source/docs/balance_bot-working.rst
+++ b/rover/source/docs/balance_bot-working.rst
@@ -28,7 +28,7 @@ As explained previously, when the pitch is non zero, the vehicle is forced to ac
 
 Rover vs Balance Bot:
 +++++++++++++++++++++
-The working of a Balance Bot is closer to that of a Copter than a conventional Rover. The motion of a Balance Bot is actually caused by the vehicle pitching, rather than simply a motor throttle. This is unlike in a Rover, where the user can directly control motor throttle, to control the vehicle's acceleration. In a Balance Bot, the user controls the pitch angle, which in turns causes the vehicle to accelerate. The motor throttle in a Balance Bot, is determined by the control system and is meant to correct and hold it's pitch.
+The working of a Balance Bot is closer to that of a Copter than a conventional Rover. The motion of a Balance Bot is actually caused by the vehicle pitching, rather than simply a motor throttle. This is unlike in a Rover, where the user can directly control motor throttle, to control the vehicle's acceleration. In a Balance Bot, the user controls the pitch angle, which in turns causes the vehicle to accelerate. The motor throttle in a Balance Bot, is determined by the control system and is meant to correct and hold its pitch.
 
 .. image:: /images/balance_bot-working.png
 


### PR DESCRIPTION
This removes an out-of-date version warning and improves conciseness of the balance bot setup pages.

I've tested this locally and it looks OK to me.