### PR TITLE
Common: move Gremsy setup instructions for AP4.3 above AP4.2

### DIFF
--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -94,7 +94,7 @@ If using ArduPilot 4.3 (or higher) please follow these setup instructions
 
 Connecting the Gimbals's COM2 port to one of the autopilot's Serial/Telemetry ports like Telem2 as shown above.
 
-Connect with a ground station and set the following parameters, if using the first mount::
+Connect with a ground station and set the following parameters, if using the first mount:
 
 - :ref:`MNT1_TYPE <MNT1_TYPE>` to "6" for "Gremsy" and reboot the autopilot
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection

--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -14,75 +14,6 @@ Where to Buy
 
 The Pixy and Mio gimbals can be purchased from the `Gremsy store <https://gremsy.com/online-store>`__
 
-Connecting to the Autopilot (4.2 or earlier)
-============================================
-
-.. image:: ../../../images/gremsy-pixyu-autopilot.png
-    :target: ../_images/gremsy-pixyu-autopilot.png
-    :width: 450px
-
-We recommend connecting the Gimbals's COM2 port to one of the autopilot's Serial/Telemetry ports like Telem2 as shown above.
-
-Connect with a ground station and set the following parameters, if using the first mount:
-
-- :ref:`MNT1_TYPE <MNT1_TYPE>` to "4" for "SToRM32 MavLink" and reboot the autopilot
-- :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection
-- :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 2 for "MAVLink2"
-- :ref:`SR2_EXTRA1 <SR2_EXTRA1>` to 10
-- :ref:`SR2_POSITION <SR2_POSITION>` to 10
-
-The gimbal's maximum angles can be set using these parameters (shown for the first mount):
-
-- :ref:`MNT1_ROLL_MIN <MNT1_ROLL_MIN>` to -30 to allow leaning left up to 30deg
-- :ref:`MNT1_ROLL_MAX <MNT1_ROLL_MAX>` to 30 to allow leaning right up to 30deg
-- :ref:`MNT1_PITCH_MIN <MNT1_PITCH_MIN>` to -90 to allow pointing 90deg down
-- :ref:`MNT1_PITCH_MAX <MNT1_PITCH_MAX>` to 30 to allow pointing 30deg up
-- :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>` to -180 to allow turning around to the left
-- :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to 180 to allow turning around to the right
-
-To control the gimbal's lean angles from a transmitter set the RC controls for roll, pitch, or yaw using ``RCx_OPTION`` 212 (Mount1 Roll), 213 (Mount1 Pitch), 214 (Mount1 Yaw) for the first mount, or 215-217 for the second mount, respectively.
-
-Gremsy's instructions can be found below:
-
-- `How to setup Gremsy gimbal with Pixhawk Cube <https://support.gremsy.com/support/solutions/articles/36000189926-how-to-setup-gremsy-gimbal-with-pixhawk-cube>`__
-- `Control Gremsy Gimbal with Herelink & Cube <https://support.gremsy.com/support/solutions/articles/36000222529-control-gremsy-gimbal-with-herelink-cube-pilot>`__
-
-Configuring the Gimbal
-----------------------
-
-The gimbal should work without any additional configuration but to improve performance you may need to adjust the gimbal's gains to match the camera's weight
-
-- Download, install and run the `gTune setup application <https://github.com/Gremsy/gTuneDesktop/releases>`__
-- Connect the gimbal to your Desktop PC using a USB cable
-- Push the "CONNECTION" button on the left side of the window, then select the COM port and press "Connect"
-- Select the "CONTROLS" tab and ensure "SYNC" is selected so the gimbal communicates with the autopilot using MAVLink
-- Select the "STIFFNESS" tab and adjust the Tilt, Roll, and Pan gains so that the gimbal holds the camera in position without shaking
-
-Testing Controlling the Gimbal from RC
---------------------------------------
-
-- Disconnect the USB cable connecting your PC to the gimbal
-- Powerup the vehicle and gimbal
-- Move the transmitter's channel 6 tuning knob to its minimum position, the camera should point straight down
-- Move the ch6 knob to maximum and the gimbal should point upwards
-
-.. note::
-
-   The RC's channel 6 input can be checked from Mission Planner's Radio calibration page
-
-Testing ROI
------------
-
-The ROI feature points the vehicle and/or camera to point at a target.  This can be tested by doing the following:
-
-- Ensure the vehicle has GPS lock
-- If using the Mission Planner, go to the Flight Data screen and right-mouse-button-click on a point about 50m ahead of the vehicle (the orange and red lines show the vehicle's current heading), select **Point Camera Here** and input an altitude of -50 (meters). The camera should point forward and then pitch down at about 45 degrees
-
-.. image:: ../../../images/Tarot_BenchTestROI.jpg
-    :target: ../_images/Tarot_BenchTestROI.jpg
-
-Pilot control of the gimbal can be restored by setting up an :ref:`auxiliary function switch <common-auxiliary-functions>` to "Retract Mount" (i.e. RCx_OPTION = 27) and then move the switch to the lower position
-
 Connecting to the Autopilot (4.3 or higher)
 ===========================================
 
@@ -92,9 +23,9 @@ If using ArduPilot 4.3 (or higher) please follow these setup instructions
     :target: ../_images/gremsy-pixyu-autopilot.png
     :width: 450px
 
-Connecting the Gimbals's COM2 port to one of the autopilot's Serial/Telemetry ports like Telem2 as shown above.
+Connect the gimbals's COM2 port to one of the autopilot's Serial/Telemetry ports like Telem2 as shown above.
 
-Connect with a ground station and set the following parameters, if using the first mount:
+Connect to the autopilot with a ground station and set the following parameters, if using the first mount:
 
 - :ref:`MNT1_TYPE <MNT1_TYPE>` to "6" for "Gremsy" and reboot the autopilot
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection
@@ -143,6 +74,31 @@ Configuring the Gimbal
 
 - Select the "STIFFNESS" tab and adjust the Tilt, Roll, and Pan gains so that the gimbal holds the camera in position without shaking
 
+Testing Controlling the Gimbal from RC
+--------------------------------------
+
+- Disconnect the USB cable connecting your PC to the gimbal
+- Powerup the vehicle and gimbal
+- Move the transmitter's channel 6 tuning knob to its minimum position, the camera should point straight down
+- Move the ch6 knob to maximum and the gimbal should point upwards
+
+.. note::
+
+   The RC's channel 6 input can be checked from Mission Planner's Radio calibration page
+
+Testing ROI
+-----------
+
+The ROI feature points the vehicle and/or camera to point at a target.  This can be tested by doing the following:
+
+- Ensure the vehicle has GPS lock
+- If using the Mission Planner, go to the Flight Data screen and right-mouse-button-click on a point about 50m ahead of the vehicle (the orange and red lines show the vehicle's current heading), select **Point Camera Here** and input an altitude of -50 (meters). The camera should point forward and then pitch down at about 45 degrees
+
+.. image:: ../../../images/Tarot_BenchTestROI.jpg
+    :target: ../_images/Tarot_BenchTestROI.jpg
+
+Pilot control of the gimbal can be restored by setting up an :ref:`auxiliary function switch <common-auxiliary-functions>` to "Retract Mount" (i.e. RCx_OPTION = 27) and then move the switch to the lower position
+
 Connecting Two Gimbals
 ----------------------
 
@@ -159,3 +115,35 @@ If two Gremsy gimbals are used, each gimbal can be directly connected to one of 
     - :ref:`MNT2_TYPE <MNT2_TYPE>` to "6" for "Gremsy" and reboot the autopilot
     - set the appropriate SERIALx_BAUD, SERIALx_PROTOCOL and SERIALx_OPTIONS parameters as described above
 
+Connecting to the Autopilot (4.2 or earlier)
+============================================
+
+.. image:: ../../../images/gremsy-pixyu-autopilot.png
+    :target: ../_images/gremsy-pixyu-autopilot.png
+    :width: 450px
+
+We recommend connecting the Gimbals's COM2 port to one of the autopilot's Serial/Telemetry ports like Telem2 as shown above.
+
+Connect with a ground station and set the following parameters, if using the first mount:
+
+- :ref:`MNT1_TYPE <MNT1_TYPE>` to "4" for "SToRM32 MavLink" and reboot the autopilot
+- :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection
+- :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 2 for "MAVLink2"
+- :ref:`SR2_EXTRA1 <SR2_EXTRA1>` to 10
+- :ref:`SR2_POSITION <SR2_POSITION>` to 10
+
+The gimbal's maximum angles can be set using these parameters (shown for the first mount):
+
+- :ref:`MNT1_ROLL_MIN <MNT1_ROLL_MIN>` to -30 to allow leaning left up to 30deg
+- :ref:`MNT1_ROLL_MAX <MNT1_ROLL_MAX>` to 30 to allow leaning right up to 30deg
+- :ref:`MNT1_PITCH_MIN <MNT1_PITCH_MIN>` to -90 to allow pointing 90deg down
+- :ref:`MNT1_PITCH_MAX <MNT1_PITCH_MAX>` to 30 to allow pointing 30deg up
+- :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>` to -180 to allow turning around to the left
+- :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to 180 to allow turning around to the right
+
+To control the gimbal's lean angles from a transmitter set the RC controls for roll, pitch, or yaw using ``RCx_OPTION`` 212 (Mount1 Roll), 213 (Mount1 Pitch), 214 (Mount1 Yaw) for the first mount, or 215-217 for the second mount, respectively.
+
+Gremsy's instructions can be found below:
+
+- `How to setup Gremsy gimbal with Pixhawk Cube <https://support.gremsy.com/support/solutions/articles/36000189926-how-to-setup-gremsy-gimbal-with-pixhawk-cube>`__
+- `Control Gremsy Gimbal with Herelink & Cube <https://support.gremsy.com/support/solutions/articles/36000222529-control-gremsy-gimbal-with-herelink-cube-pilot>`__


### PR DESCRIPTION
Now that AP4.3 has gone live we can move the Gremsy setup instructions for 4.3 above the 4.2 instructions.

This has been tested on my local machine and looks OK.