### PR TITLE
Update: remote ID compatible devices

### DIFF
--- a/common/source/docs/common-remoteid.rst
+++ b/common/source/docs/common-remoteid.rst
@@ -28,7 +28,7 @@ OpenDroneID Compatible devices (support included in ArduPlane 4.0 and later)
 
 - `BlueMark DroneBeacon MAVLink (EU, US) <https://dronescout.co/dronebeacon-mavlink-remote-id-transponder/>`__
 - `Wurzbach Electronics <https://wurzbachelectronics.com/esp32-remote-id-development-set>`__
-
+- `mRo RemoteID <https://store.mrobotics.io/product-p/m10049.htm>`__
 
 OpenDroneID
 ===========


### PR DESCRIPTION
added in the mro remoteID that is based on the ESP32-C3