### PR TITLE
benewake: Add TF02 Pro

### DIFF
--- a/common/source/docs/common-benewake-tf02-lidar.rst
+++ b/common/source/docs/common-benewake-tf02-lidar.rst
@@ -4,11 +4,13 @@
 Benewake TF02 / TF03 lidar/ TF-Luna
 ===================================
 
-The `Benewake TF02 lidar <http://en.benewake.com/product/detail/5c345c9de5b3a844c4723299.html>`__ has an indoor range of 22m, an outdoor range of 10m, an update rate of 100hz and weighs only 52g.
+The Benewake TF02 lidar has an indoor range of 22m, an outdoor range of 10m, an update rate of 100Hz and weighs only 52g.
 
 The `TF03 <http://en.benewake.com/product/detail/5c345cc2e5b3a844c472329a.html>`__ has a range of 50m to 180m (depending upon the surface) and weighs 77g.
 
 The `TF-Luna <http://en.benewake.com/product/detail/5e1c1fd04d839408076b6255.html>`__ has a range of 8m indoor, and 3m outdoor and weighs 5g.
+
+The `TF02 Pro <http://en.benewake.com/product/detail/5c345c9de5b3a844c4723299.html>`__ has an indoor range of 40m, an outdoor range of 13.5m, an update rate of 100Hz and weighs only 50g.
 
 More details on both these lidar can be found in the `benewake.com's downloads area <http://en.benewake.com/download>`__
 
@@ -37,7 +39,7 @@ If the SERIAL4 is being used then the following parameters should be set for the
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, =20 (Benewake-Serial) for TF03 if Copter 3.6.12, =27 (Benewake TF03) for TF03 for Copter 4.0 and later, and =20 for TF-Luna. Note: using type = 20 on a TF03 will restrict its maximum range to that of a TF02.
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, =20 (Benewake-Serial) for TF03 if Copter 3.6.12, =27 (Benewake TF03) for TF03 and TF02 Pro for Copter 4.0 and later, and =20 for TF-Luna. Note: using type = 20 on a TF03 will restrict its maximum range to that of a TF02.
 -  :ref:`RNGFND1_MIN_CM <RNGFND1_MIN_CM>` = 30 for TFMini, 10 for TFminiPlus and TF-Luna.
 -  :ref:`RNGFND1_MAX_CM <RNGFND1_MAX_CM>`: for TF02 use **2000** for indoor, **1000** for outdoor.  For TF03 use **3500** for indoor, **12000** for outdoor. For TF-Luna use **800** for indoor, **300** for outdoor. *This is the distance in centimeters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_GNDCLEAR <RNGFND1_GNDCLEAR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*


### PR DESCRIPTION
I would add TF02 Pro.
http://en.benewake.com/product/detail/5c345c9de5b3a844c4723299.html
The TF02 Pro frame does not have SIG.
The TF02 Pro is at device temperature.

![Screenshot from 2022-11-19 20-38-48](https://user-images.githubusercontent.com/646194/202878498-7e008ee6-2289-46b0-930c-6910410d8f53.png)

I have the TF02 EOL.
I removed the TF02 link.