### PR TITLE
Update the list of supported MCUs

### DIFF
--- a/dev/source/docs/porting.rst
+++ b/dev/source/docs/porting.rst
@@ -14,7 +14,7 @@ Consider joining the `ArduPilot Discord Chat <https://ardupilot.org/discord>`__ 
 Step 1 - getting started
 ------------------------
 
-- determine which microcontroller the new flight controllers uses. If it is a MCU we already support (STM32F42x, STM32F40x STM32F41x, STM32F745, STM32F765, STM32F777 or STM32H743 where “x” can be any number), then the port should be relatively straight forward. If it is another MCU, ping us on the `ArduPilot Discord Chat <https://ardupilot.org/discord>`__ for advice on how to proceed.
+- determine which microcontroller the new flight controllers uses. If it is a MCU we already support, for example STM32F405, STM32F427, STM32F745, STM32F765, STM32F777 or STM32H743, then the port should be relatively straight forward. If it is another MCU, ping us on the `ArduPilot Discord Chat <https://ardupilot.org/discord>`__ for advice on how to proceed.
 - determine the crystal frequency (normally 8Mhz or 24Mhz). Refer to the schematic or read the writing on the crystal which is normally a small silver square.
 
 .. note::


### PR DESCRIPTION
Previous list used eg STM32F41x notation, which implied that certain MCUs with less than 1 MB of flash were supported.