### PR TITLE
plane: updating ArmDisarm for 4.2 and higher

### DIFF
--- a/plane/source/docs/arming-your-plane.rst
+++ b/plane/source/docs/arming-your-plane.rst
@@ -79,7 +79,7 @@ three ways:
 
 -  **Rudder Arming**. Hold the rudder stick fully to the right and the
    throttle stick fully down for 2 seconds.
--  **Arming Switch**. An RC channel can be configured as an ARM/DISARM switch by using the RCx_OPTION for that channel set to 41.
+-  **Arming Switch**. An RC channel can be configured as an ARM/DISARM switch by using the RCx_OPTION for that channel set to 153.
 -  **GCS Arming**. Press the arming button on your ground station
 
 .. figure:: ../../../images/armingButtonMissPlan.jpg
@@ -101,7 +101,7 @@ pilots while flying so there are additional requirements prior to disarm:
 
 -  You need to allow rudder disarming by changing **ARMING_RUDDER**
    parameter to 2 (ArmOrDisarm) or use the ARM/DISARM switch function provided by 
-   setting an RC channel's RCx_OPTION to 41.
+   setting an RC channel's RCx_OPTION to 153.
 -  The autopilot needs to make sure that you are not actually
    flying. There is an algorithm for this that uses the **airspeed sensor**
    readings. So you need this source available and giving values lower


### PR DESCRIPTION
I understand that `RCx_OPTION` `ArmDisarm` changed from 41 to 153 in 4.2. If it's desirable to note that older versions use 41, I can amend the PR.