### PR TITLE
Common: fixup robsense swarm link links

### DIFF
--- a/common/source/docs/common-telemetry-robsense-swarmlink.rst
+++ b/common/source/docs/common-telemetry-robsense-swarmlink.rst
@@ -7,7 +7,7 @@ Robsense SwarmLink
   .. image:: ../../../images/telemetry-robsense-swarmlink.png
 	 :target: ../_images/telemetry-robsense-swarmlink.png
 
-`Robsense SwarmLink <http://en.robsense.com/prod_view8.aspx?TypeId=69&Id=177&FId=t3:69:3>`__ telemetry radios allows connecting multiple drones to a single ground station without the need for multiple radios on the ground station side (i.e. it creates a mesh network).  Network monitoring and configuration software is also included.
+`Robsense SwarmLink <https://home.robsense.com/?page_id=862&lang=en>`__ telemetry radios allows connecting multiple drones to a single ground station without the need for multiple radios on the ground station side (i.e. it creates a mesh network).  Network monitoring and configuration software is also included.
 
 Specifications (according to the manufacturer)
 ----------------------------------------------
@@ -24,12 +24,12 @@ Specifications (according to the manufacturer)
 - Size: 83mm x 60mm x 20mm
 - Weight: 65g
 
-More details can be found `here <http://en.robsense.com/prod_view8.aspx?TypeId=69&Id=177&FId=t3:69:3>`__.
+More details can be found `here <https://home.robsense.com/?page_id=862&lang=en#>`__.
 
 EasySwarm
 ---------
 
-Built on top of the SwarmLink hardware, `EasySwarm <http://en.robsense.com/prod_view8.aspx?TypeId=69&Id=177&FId=t3:69:3>`__ is a developer focused ground station and development kit aimed at making swarming easier.  This free and open source software can be found in the `RobSense SwarmLink github repo <https://github.com/RobSenseTech/SwarmLink>`__.
+Built on top of the SwarmLink hardware, `EasySwarm <https://guide.robsense.com/chapter3-1/communication/easyswarm.html>`__ is a developer focused ground station and development kit aimed at making swarming easier.  This free and open source software can be found in the `RobSense SwarmLink github repo <https://github.com/RobSenseTech/SwarmLink>`__.
 
 Features include customised swarming policies, dynamic waypoint planning and real-time tracking of all vehicles.
 


### PR DESCRIPTION
This resolves the broken links on the AP Robsense telemetry page.  It is slightly questionable whether the RobSense stuff works anymore because their [EasySwarm software GitHub page](https://guide.robsense.com/chapter3-1/communication/easyswarm.html) lists Copter-3.3 as the version it supports... still, I guess this is an improvement.

I've tested this locally on my machine and it seems OK.

EDIT: I emailed our contact at Robsense but received a failed-to-deliver message immediately.  I think maybe we should move this page to the archive section.