### PR TITLE
Dev: update copter release notes page

### DIFF
--- a/dev/source/docs/release-procedures.rst
+++ b/dev/source/docs/release-procedures.rst
@@ -73,7 +73,7 @@ Steps 4 to 8 above should be repeated for the ``ArduCopter-beta-heli`` tag to re
 Check the versions are available in Mission Planner
 ---------------------------------------------------
 
-Wait 4hrs to 11hrs for the binaries to be built (check the `Build list <https://firmware.ardupilot.org/Tools/BuildSizes/builds.html>`__ and/or `autotest-output.txt <https://autotest.ardupilot.org/autotest-output.txt>`__ file for status) and then open the Mission Planner's Initial Setup > Install Firmware page and click the "Beta firmwares" link and ensure that the version displayed below each multicopter icon has updated.
+Wait 4hrs to 11hrs for the binaries to be built (check the `Build list <https://firmware.ardupilot.org/Tools/BuildSizes/builds.html>`__, `autotest-output.txt <https://autotest.ardupilot.org/autotest-output.txt>`__  and/or `manifest.json <https://firmware.ardupilot.org/manifest.json>`__ for status) and then open the Mission Planner's Initial Setup > Install Firmware page and click the "Beta firmwares" link and ensure that the version displayed below each multicopter icon has updated.
 
 .. image:: ../images/ReleaseProcedures_MPBetaFirmwares.jpg
     :target: ../_images/ReleaseProcedures_MPBetaFirmwares.jpg

--- a/dev/source/docs/release-procedures.rst
+++ b/dev/source/docs/release-procedures.rst
@@ -34,21 +34,21 @@ Create a new release branch or switch to an existing release branch
 
 Open a Git Bash terminal in the ardupilot repository.
 
-If this release involves a major or minor version increase (i.e. 3.5 to 3.6) create a new branch in your local ardupilot repository:
+If this release involves a major or minor version increase (i.e. 4.3 to 4.4) create a new branch in your local ardupilot repository:
 
-- ``git checkout -b Copter-3.6`` ("Copter-3.6" should be replaced with the correct major and minor version numbers)
+- ``git checkout -b Copter-4.4`` ("Copter-4.4" should be replaced with the correct major and minor version numbers)
 - ``git push`` to create the new directory in the shared repo
-- click the `"New Project" button <https://github.com/ArduPilot/ardupilot/projects>`__ on the GitHub projects page to create the corresponding "Copter 3.x Backports" project.  This is used to track features to be included in future releases
+- click the `"New Project" button <https://github.com/ArduPilot/ardupilot/projects?type=classic>`__ on the GitHub projects page to create the corresponding "Copter 4.x" project.  This is used to track features to be included in future releases
 
 Alternatively if this release is built on an earlier release branch checkout the branch:
 
-- ``git checkout Copter-3.6`` to switch to the existing release branch ("Copter-3.6" should be replaced with the correct major and minor version numbers)
+- ``git checkout Copter-4.3`` to switch to the existing release branch ("Copter-4.3" should be replaced with the correct major and minor version numbers)
 
 Pull in changes from master
 ---------------------------
 
-Check the `ArduPilot Github Projects <https://github.com/ArduPilot/ardupilot/projects>`__ to determine which PRs and commits should be included in this release.
-For example the `Copter 3.5 Backports project <https://github.com/ArduPilot/ardupilot/projects/4>`__ holds the list of PRs and commits that should be included in the next Copter-3.5 release.
+Check the `ArduPilot Github Projects <https://github.com/ArduPilot/ardupilot/projects?type=classic>`__ to determine which PRs and commits should be included in this release.
+For example the `Copter 4.3 project <https://github.com/ArduPilot/ardupilot/projects/25>`__ holds the list of PRs and commits that should be included in the next Copter-4.3 release.
 
 - ``git reset --hard origin/master``, ``git submodule update --recursive`` can be used to reset the release branch to master if all of master should be included (this is normal for at least the first few beta releases)
 
@@ -104,8 +104,8 @@ Releasing a stable version is the same as a beta version except the ``ArduCopter
 
 An additional tag is created including the patch release number:
 
-- ``git tag Copter-3.6.0``
-- ``git push origin Copter-3.6.0``
+- ``git tag Copter-4.3.0``
+- ``git push origin Copter-4.3.0``
 
 Announcements are done in much the same way as beta releases by posting on these sites:
 


### PR DESCRIPTION
This includes two commits:

1. adds the manifest to the copter release procedures
2. updates the links and version numbers

I was sadly unable to test these on my local machine because WSL has suddenly stopped being able to open windows.  I'm sure I'll resolve this in the near-ish future because I can't run SITL now either.  Woe is me.