### PR TITLE
Add supported model number to VectorNav

### DIFF
--- a/common/source/docs/common-external-ahrs.rst
+++ b/common/source/docs/common-external-ahrs.rst
@@ -12,7 +12,7 @@ Supported Systems
 Currently, ArduPilot supports these systems:
 
 - `Parker Lord 3DM® Series <https://www.microstrain.com/inertial-sensors/all-sensors>`_
-- `VectorNav AHRS <https://www.vectornav.com/products>`__
+- `VectorNav VN-300 AHRS <https://www.vectornav.com/products>`__
 
 Setup
 =====


### PR DESCRIPTION
Not all VectorNav units that are on the linked products page are currently supported.  Adding model number of the unit that is supported to prevent confusion.

Other VectorNav units may already work.  But I know that at least one of them doesn't (VN-100) at this time.