### PR TITLE
connect-esc-and-motors: move Y4 to quad section

### DIFF
--- a/copter/source/docs/connect-escs-and-motors.rst
+++ b/copter/source/docs/connect-escs-and-motors.rst
@@ -54,6 +54,10 @@ Quadcopter
     :target: ../_images/motororder-quad-atail-2d.png
     :scale: 35%
 
+.. image:: ../../../images/motororder-Y4a-2d.jpg
+    :target: ../_images/motororder-Y4a-2d.jpg
+    :width: 35%
+
 Tricopter
 ---------
 
@@ -88,13 +92,6 @@ Hexacopter
 .. image:: ../images/motororder-hexa-plus-2d.png
     :target: ../_images/motororder-hexa-plus-2d.png
     :scale: 40%
-
-Y4
---
-
-.. image:: ../../../images/motororder-Y4a-2d.jpg
-    :target: ../_images/motororder-Y4a-2d.jpg
-    :width: 35%
 
 Y6
 --


### PR DESCRIPTION
Moves Y4 up to the quad section. It being down in hex is causing some confusion. 

https://github.com/ArduPilot/ardupilot/issues/22372

https://discuss.ardupilot.org/t/quadcopter-in-tricopter-formation/87121