### PR TITLE
Fix Copter Flight Mode Channel Description

### DIFF
--- a/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
+++ b/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
@@ -80,10 +80,11 @@ The flight mode channel is the input radio channel that ArduPilot
 monitors for mode changes.
 
 [site wiki="copter"]
-On Copter this is always channel 5.
+On Copter this is configurable using the :ref:`FLTMODE_CH <FLTMODE_CH>`
+parameter. 
 [/site]
 [site wiki="plane"]
-On Plane this is configurable using the :ref:`FLTMODE_CH <plane:FLTMODE_CH>`
+On Plane this is configurable using the :ref:`FLTMODE_CH <FLTMODE_CH>`
 parameter. 
 [/site]
 [site wiki="rover"]


### PR DESCRIPTION
Currently, on Copter, the wiki states that the flight mode channel is always channel 5. But this parameter has been added since Jan 27, 2018 on commit 89674482a717bd280c594c408c6feec7d569fac9 of the main firmware repo.