### PR TITLE
Common: remove siyi version note from gimbal landing page

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -23,7 +23,7 @@ gimbals in which ArduPilot controls the stabilisation.
 -  :ref:`Gremsy T3, T7, Pixy, Mio and ZIO <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
 -  :ref:`Servo Gimbals <common-camera-gimbal>` — older-style servo-driven gimbal where ArduPilot provides stabilisation
 -  :ref:`SimpleBGC (aka AlexMos) Gimbal Controller <common-simplebgc-gimbal>` - a popular 2-axis or 3-axis brushess gimbal controller which uses a custom serial interface
--  :ref:`Siyi ZR10 and A8 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera (only supported in AP 4.4 and higher)
+-  :ref:`Siyi ZR10 and A8 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera
 -  :ref:`SToRM32 Gimbal Controller <common-storm32-gimbal>` — an inexpensive 2-axis or 3-axis brushless gimbal controller which responds to MAVLink commands (a richer format than PWM) over a serial interface
 -  :ref:`Tarot 2D Gimbal <common-tarot-gimbal>` — low cost 2-axis brushless gimbal
 


### PR DESCRIPTION
This removes the AP version info from the Siyi line on the cameras and gimbals landing page.  The Siyi page itself already has a note on the required version so I think it is fine to remove it from here to reduce maintenance.

I have not tested this on my local machine but surely it is fine.