### PR TITLE
Common: siyi gimbal param change to control camera

### DIFF
--- a/common/source/docs/common-siyi-zr10-gimbal.rst
+++ b/common/source/docs/common-siyi-zr10-gimbal.rst
@@ -43,6 +43,7 @@ Connect with a ground station and set the following parameters.  The params belo
 - :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>` to -80
 - :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to 80
 - :ref:`MNT1_RC_RATE <MNT1_RC_RATE>` to 90 (deg/s) to control speed of gimbal when using RC targetting
+- :ref:`CAM_TRIGG_TYPE <CAM_TRIGG_TYPE>` to 3 (Mount / Siyi) to allow control of the camera
 - :ref:`RC6_OPTION <RC6_OPTION>` = 213 ("Mount Pitch") to control the gimbal's pitch angle with RC channel 6
 - :ref:`RC7_OPTION <RC7_OPTION>` = 214 ("Mount Yaw") to control the gimbal's yaw angle with RC channel 7
 - :ref:`RC8_OPTION <RC8_OPTION>` = 163 ("Mount Lock") to switch between "lock" and "follow" mode with RC channel 8


### PR DESCRIPTION
This adds a missing parameter setting required to allow autonomous or manual control of the Siyi cameras.

I've tested this on my local machine and it seems fine.