### PR TITLE
Common: Gremsy pages get S1 model added

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -20,7 +20,7 @@ that have their own self-stabilization controllers and the simpler servo-driven
 gimbals in which ArduPilot controls the stabilisation.
 
 -  :ref:`Brushless PWM <common-brushless-pwm-gimbal>` - brushless gimbals that accept PWM or SBUS input for angle control
--  :ref:`Gremsy T3, T7, Pixy, Mio and ZIO <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
+-  :ref:`Gremsy Mio, Pixy, S1, T3, T7 and ZIO <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
 -  :ref:`Servo Gimbals <common-camera-gimbal>` — older-style servo-driven gimbal where ArduPilot provides stabilisation
 -  :ref:`SimpleBGC (aka AlexMos) Gimbal Controller <common-simplebgc-gimbal>` - a popular 2-axis or 3-axis brushess gimbal controller which uses a custom serial interface
 -  :ref:`Siyi ZR10 and A8 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera

--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -1,10 +1,10 @@
 .. _common-gremsy-pixyu-gimbal:
 
-===============================================
-Gremsy T3, T7, Pixy, Mio and ZIO 3-Axis Gimbals
-===============================================
+====================================================
+Gremsy Mio, Pixy, S1, T3, T7, and ZIO 3-Axis Gimbals
+====================================================
 
-Gremsy `T3 <https://gremsy.com/products/gremsy-t3v3>`__, `T7 <https://gremsy.com/products/gremsy-t7>`__, `Pixy WP <https://gremsy.com/products/pixy-wp>`__, `Pixy U <https://gremsy.com/products/pixy-u>`__, `Pixy F <https://gremsy.com/products/pixy-f>`__, `Mio <https://gremsy.com/products/mio>`__  and `ZIO <https://gremsy.com/zio>`__ 3-axis gimbals can communicate with the flight controller using the MAVLink protocol and are compatible with a range of cameras for real-time video or mapping purposes.
+Gremsy `Mio <https://gremsy.com/products/mio>`__, `Pixy F <https://gremsy.com/products/pixy-f>`__, `Pixy U <https://gremsy.com/products/pixy-u>`__, `Pixy WP <https://gremsy.com/products/pixy-wp>`__,  `S1 <https://gremsy.com/products/gremsy-s1v3>`__, `T3 <https://gremsy.com/products/gremsy-t3v3>`__, `T7 <https://gremsy.com/products/gremsy-t7>`__ and `ZIO <https://gremsy.com/zio>`__ 3-axis gimbals can communicate with the flight controller using the MAVLink protocol and are compatible with a range of cameras for real-time video or mapping purposes.
 
 .. image:: ../../../images/gremsy-pixyu-gimbal.png
     :target: https://gremsy.com/products/pixy-u
@@ -50,7 +50,7 @@ Configuring the Gimbal
       :target: ../_images/gremsy-firmware-version-check.png
       :width: 450px
 
-  - If the gimbal firmware is older than 7.7.1 download the latest .hex for `T3 <https://github.com/Gremsy/T3V3-Firmware/releases>`__, `T7 <https://github.com/Gremsy/T7-Firmware/releases>`__, `Pixy W <https://github.com/Gremsy/PixyW-Firmware/releases>`__, `Pixy U <https://github.com/Gremsy/PixyU-Firmware/releases>`__, `Pixy F <https://github.com/Gremsy/PixyF-Firmware/releases>`__, `Mio <https://github.com/Gremsy/Mio-Firmware/releases>`__ or `ZIO <https://github.com/Gremsy/Zio-Firmware/releases>`__
+  - If the gimbal firmware is older than 7.7.1 download the latest .hex for `Mio <https://github.com/Gremsy/Mio-Firmware/releases>`__,  `Pixy F <https://github.com/Gremsy/PixyF-Firmware/releases>`__, `Pixy U <https://github.com/Gremsy/PixyU-Firmware/releases>`__,  `Pixy WP <https://github.com/Gremsy/PixyW-Firmware/releases>`__,  `S1 <https://github.com/Gremsy/S1V3-Firmware/releases>`__, `T3 <https://github.com/Gremsy/T3V3-Firmware/releases>`__, `T7 <https://github.com/Gremsy/T7-Firmware/releases>`__ or `ZIO <https://github.com/Gremsy/Zio-Firmware/releases>`__
   - Select "UPGRADE", "BROWSE" and select the file downloaded above
   - Press the other "UPGRADE" button and the upgrade should complete within 30 seconds
 


### PR DESCRIPTION
Gremsy's S1 (aka S1V3) gimbal also supports MAVLink it seems in their latest release.  A user reported getting it working successfully and my contact at Gremsy as well confirmed that support has been added for MAVlink to this gimbal.

I've tested this on my local machine and it looks OK.