### PR TITLE
Copter: add build video to hexsoon 650 reference page

### DIFF
--- a/copter/source/docs/reference-frames-hexsoon-td650.rst
+++ b/copter/source/docs/reference-frames-hexsoon-td650.rst
@@ -41,8 +41,11 @@ Parameter file: `hexsoon-td650.param <https://github.com/ArduPilot/ardupilot/blo
 
 This parameter file can also be loaded using the Mission Planner's Config/Tuning >> Full Parameter Tree page by selecting "hexsoon-td650" from the drop down on the middle right and then push the "Load Presaved" button.
 
-Flight Demonstration
---------------------
+Videos
+------
+..  youtube:: WSiLnHEjBlI
+    :width: 100%
+
 ..  youtube:: FbzXvi3beDI
     :width: 100%
 


### PR DESCRIPTION
This adds @andyp1per's Hexsoon 650 build video to the corresponding reference vehicle page

I've tested this on my local machine and it seem fine.