### PR TITLE
Rover: link maker boat advanced from reference frames page

### DIFF
--- a/rover/source/docs/reference-frames.rst
+++ b/rover/source/docs/reference-frames.rst
@@ -16,6 +16,7 @@ This section includes details on tested frames to speed up DIY builds of rovers 
     DeSET mapping boat <reference-frames-deset-mapping-boat>
     HobbyKing Hydrotek <reference-frames-hydrotek>
     HobbyKing Hydropro Inception <reference-frames-hydropro-inception>
+    Maker Boat Advanced <https://squirm.tech/an-overview-of-the-maker-boat-advanced/>
     Maker Boat Boogie Board Boat <https://squirm.tech/maker-boat-basic-quick-start/>
     Thunder Tiger Toyota Hilux <reference-frames-tt-toyotahilux>
     Traxxas Stampede 4WD Truck <reference-frame-traxxas-stampede>


### PR DESCRIPTION
This reference frame is actively maintained as can be seen from [this discussion](https://discuss.ardupilot.org/t/maker-boat-advanced-build-info/73585).

I've tested this on my local machine and it seems fine.