### PR TITLE
Common: T265 setup recommends setting serialx_options

### DIFF
--- a/common/source/docs/common-vio-tracking-camera.rst
+++ b/common/source/docs/common-vio-tracking-camera.rst
@@ -50,18 +50,15 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 2 (MAVLink2).  Note this assumes the RPI4 is connected to AutoPilot "Telem2" port.
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 921 (921600 baud)
 - Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to block the RPI4/T265 mavlink messages from reaaching the ground station
+- :ref:`VISO_TYPE <VISO_TYPE>` = 2 (IntelT265)
 
-For ArduPilot-4.1 (and later):
+Next setup the EKF3 to use the ExternalNav for position and velocity:
 
-- :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` = 3 (EKF3)
-- :ref:`EK2_ENABLE <EK2_ENABLE>` = 0 (disabled)
-- :ref:`EK3_ENABLE <EK3_ENABLE>` = 1 (enabled)
 - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 6 (ExternalNav)
 - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 6 (ExternalNav)
 - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro which is safer because of the camera's weakness to high vibrations)
 - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 6 (ExternalNav)
-- :ref:`GPS_TYPE <GPS_TYPE>`  = 0 to disable the GPS
-- :ref:`VISO_TYPE <VISO_TYPE>` = 2 (IntelT265)
+- Optionally set :ref:`GPS_TYPE <GPS_TYPE>`  = 0 to disable the GPS
 
 If you wish to use the camera's heading:
 

--- a/common/source/docs/common-vio-tracking-camera.rst
+++ b/common/source/docs/common-vio-tracking-camera.rst
@@ -51,20 +51,6 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 921 (921600 baud)
 - Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to block the RPI4/T265 mavlink messages from reaaching the ground station
 
-For ArduPilot-4.0 (and earlier):
-
-- :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` = 2 (the default) to use EKF2
-- :ref:`EK2_ENABLE<EK2_ENABLE>` = 1 (the default)
-- :ref:`EK3_ENABLE<EK3_ENABLE>` = 0 (the default)
-- :ref:`EK2_GPS_TYPE<EK2_GPS_TYPE>`  = 3 to disable the EKF’s use of the GPS
-- :ref:`EK2_POSNE_M_NSE<EK2_POSNE_M_NSE>`  = 0.1
-- :ref:`EK2_VELD_M_NSE<EK2_VELD_M_NSE>`  = 0.1
-- :ref:`EK2_VELNE_M_NSE<EK2_VELNE_M_NSE>`  = 0.1
-- :ref:`GPS_TYPE<GPS_TYPE>`  = 0 to disable the GPS
-- :ref:`COMPASS_USE<COMPASS_USE>` = 0,  :ref:`COMPASS_USE2<COMPASS_USE2>`  = 0, :ref:`COMPASS_USE3<COMPASS_USE3>`  = 0 to disable the EKF’s use of the compass and instead rely on the heading from external navigation data
-
-After the parameters are modified, reboot the autopilot.  Connect with the ground station and (if using Mission Planner) right-mouse-button-click on the map, select "Set Home Here", "Set EKF Origin Here" to tell ArduPilot where the vehicle is and it should instantly appear on the map.
-
 For ArduPilot-4.1 (and later):
 
 - :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` = 3 (EKF3)

--- a/common/source/docs/common-vio-tracking-camera.rst
+++ b/common/source/docs/common-vio-tracking-camera.rst
@@ -49,6 +49,7 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 2 (MAVLink2).  Note this assumes the RPI4 is connected to AutoPilot "Telem2" port.
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 921 (921600 baud)
+- Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to block the RPI4/T265 mavlink messages from reaaching the ground station
 
 For ArduPilot-4.0 (and earlier):
 


### PR DESCRIPTION
This comes from a report on my YouTube channel in which a user said their vehicle's telemetry stopped working after they turned on the RPI/T265.

I've also removed some old 4.0 instructions and clarified that the GPS can be left enabled if users wish to have it there.  Leaving it enabled means users may be able to skip setting the home location.

I have tested this on my local machine and it seems ok and no build errors.