### PR TITLE
Update guide-four-channel-plane.rst

### DIFF
--- a/plane/source/docs/guide-four-channel-plane.rst
+++ b/plane/source/docs/guide-four-channel-plane.rst
@@ -72,8 +72,8 @@ and coordinate its turns.
    <tr><td>Roll Plane Left</td><td>Left aileron moves down and right aileron moves up</td><tr>
    <tr><td>Pitch plane up</td><td>Elevator moves down</td></tr>
    <tr><td>Pitch plane down</td><td>Elevator moves up</td></tr>
-   <tr><td>Roll Plane Right</td><td>Rudder moves left</td></tr>
-   <tr><td>Roll Plane Left</td><td>Rudder moves right</td></tr>
+   <tr><td>Yaw Plane Left</td><td>Rudder moves left</td></tr>
+   <tr><td>Yaw Plane Right</td><td>Rudder moves right</td></tr>
    </table>
 
 If the any of the control surfaces do not respond correctly, reverse the 


### PR DESCRIPTION
~ The Rudder movement controls the Yaw of a standard 4 channel plane configuration. It does not make the plane roll.

The correct control configuration of the rudder is as 👇:
 - Yaw Plane Right  |  Rudder moves Right
 - Yaw Plane Left    |  Rudder moves Left