### PR TITLE
Fix for SITL build

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -173,6 +173,12 @@ Build SITL binaries for Windows
 
 You can build 32-bit binaries to be run outside of Cygwin with a small set of companion files. This can be useful when used in conjunction with Mission Planner to run SITL with a stable release build rather than a build from the development branch of ArduPilot. This can be done by compiling using the command below in Cygwin and copying the binary the "sitl" folder typically found at C:\\Users\\user\\Documents\\Mission Planner\\sitl. Mission Planner will download the required files during the first time running SITL. After the initial run, the vehicle-specific binary file can be replaced with the file you built. The custom SITL binaries should be located at /ardupilot/build/sitl.
 
+.. note:: i686-pc-cygwin has been deprecated from cygwin and replaced with x86_64-pc-cygwin. Enter the following commands to create links to the expected toolchain version:
+
+    ::
+
+		 ln -s /usr/bin/x86_64-pc-cygwin-g++.exe /usr/bin/i686-pc-cygwin-g++
+         ln -s /usr/bin/x86_64-pc-cygwin-gcc.exe /usr/bin/i686-pc-cygwin-gcc
 
 ::
 


### PR DESCRIPTION
./waf configure --board=sitl --toolchain i686-pc-cygwin was causing a crash because it couldn't find i686-pc-cygwin. Adding these links allows the build script to complete as written.