### PR TITLE
Dev: update gsoc 2023 project list to remove AI item

### DIFF
--- a/dev/source/docs/gsoc-ideas-list.rst
+++ b/dev/source/docs/gsoc-ideas-list.rst
@@ -8,7 +8,6 @@ This is a list of projects suggested by ArduPilot developers for `GSoC 2023 <htt
 
 - Rover AutoTune
 - Camera and Gimbal enhancements
-- AI & ArduPilot development environment
 - Multicopter Swarm Avoidance
 - Improve custom firmware server including adding branch support and improve dependency handling
 - ROS2 support


### PR DESCRIPTION
I had attempted to remove this in the last PR but missed one line.  I think this project is too much of a moonshot