### PR TITLE
Copter: Revise lat/lng 0, 0 waypoint behavior description

### DIFF
--- a/copter/source/docs/mission-command-list.rst
+++ b/copter/source/docs/mission-command-list.rst
@@ -56,8 +56,7 @@ before it actually reaches the current waypoint
 degrees (0=north, 90 = east). Instead use a
 :ref:`CONDITION_YAW <mission-command-list_condition-yaw>` command.
 
-**Lat, Lon** - the latitude and longitude targets.  If left as zero it
-will hold the current location.
+**Lat, Lon** - the latitude and longitude targets.  If left as zero, current location will be substituted for waypoint location, making it appear as if the waypoint is simply skipped.
 
 **Alt** - the target altitude above home in meters.  If left as zero it
 will hold the current altitude.


### PR DESCRIPTION
Based on current ` ModeAuto::loc_from_cmd()` behavior, a waypoint with location (0, 0) will simply be skipped rather than initiating a loiter.