### PR TITLE
Copter: deadreckoning link to lua script updated

### DIFF
--- a/common/source/docs/common-scripting-applets.rst
+++ b/common/source/docs/common-scripting-applets.rst
@@ -24,9 +24,9 @@ SmartAudio.lua                              Smart Audio control
 VTOL-quicktune.lua                          VTOL-quicktuning applet
 forward_flight_motor_shutdown.lua           Forward flight motor shutdown
 motor_failure_test.lua                      Motor failure testing script
+plane_aerobatics.lua(in Aerobatics subdir)  Autonomous trajectory precise aerobatics
 plane_package_place.lua                     Quadplane payload place script
 plane_ship_landing.lua                      Script to automate moving vehicle landing with a beacon
 runcam_on_arm.lua                           Starts/stops video recording on arm/disarm 
-plane_aerobatics.lua(in Aerobatics subdir)  Autonomous trajectory precise aerobatics
 sport_aerobatics.lua(in Aerobatics subdir)  Autonomous rate based aerobatics
 ==========================================  ===========

--- a/common/source/docs/common-scripting-applets.rst
+++ b/common/source/docs/common-scripting-applets.rst
@@ -22,6 +22,7 @@ RockBlock.lua                               Rockblock modem
 Script_Controller.lua                       Allows selection of multiple scripts and missions on SD Card
 SmartAudio.lua                              Smart Audio control
 VTOL-quicktune.lua                          VTOL-quicktuning applet
+copter-deadreckon-home.lua                  flies towards home on loss of GPS
 forward_flight_motor_shutdown.lua           Forward flight motor shutdown
 motor_failure_test.lua                      Motor failure testing script
 plane_aerobatics.lua(in Aerobatics subdir)  Autonomous trajectory precise aerobatics

--- a/copter/source/docs/deadreckoning-failsafe.rst
+++ b/copter/source/docs/deadreckoning-failsafe.rst
@@ -12,7 +12,7 @@ Copter includes the Dead Reckoning Failsafe that allows a vehicle to return home
 
 .. note::
 
-    Similar functionality is available using the `copter-deadreckon-home.lua <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/examples/copter-deadreckon-home.lua>`__ script (`video1 <https://www.youtube.com/watch?v=KKShYheW4J0>`__, `video2 <https://www.youtube.com/watch?v=esM0EqMH_BE>`__)
+    Similar functionality is available using the `copter-deadreckon-home.lua <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/applets/copter-deadreckon-home.lua>`__ script (`video1 <https://www.youtube.com/watch?v=KKShYheW4J0>`__, `video2 <https://www.youtube.com/watch?v=esM0EqMH_BE>`__)
 
 Setup
 =====


### PR DESCRIPTION
lua script was moved from examples directory to applets directory.

Ideally this should be merged soon after this flight code PR goes in https://github.com/ArduPilot/ardupilot/pull/23233