### PR TITLE
Common: Add Siyi A8 warning

### DIFF
--- a/common/source/docs/common-siyi-zr10-gimbal.rst
+++ b/common/source/docs/common-siyi-zr10-gimbal.rst
@@ -58,6 +58,10 @@ Connect with a ground station and set the following parameters.  The params belo
   - :ref:`RC9_OPTION <RC9_OPTION>` = 168 ("Camera Manual Focus") to adjust focus in and out
   - :ref:`RC9_OPTION <RC9_OPTION>` = 169 ("Camera Auto Focus") to trigger auto focus
 
+.. warning::
+
+    A8 does not support zoom at 4K recording resolution
+
 Configuring the Gimbal
 ----------------------
 


### PR DESCRIPTION
It does not support zoom at 4K resolution.

Here is the [A8 mini User Manual v1.2](https://drive.google.com/drive/folders/19Hs92ClHiRWIjE9xS32Y6GToXNvGveLO)

```
Record Resolution: Switch camera record resolution between HD (720p), Full HD (1080p),
2K, and 4K (under 4K recording resolution, A8 mini camera does not zoom).
```