### PR TITLE
mavproxy: remove Python2 instructions

### DIFF
--- a/mavproxy/source/docs/getting_started/download_and_installation.rst
+++ b/mavproxy/source/docs/getting_started/download_and_installation.rst
@@ -6,7 +6,7 @@ Download and Installation
 
 The following instructions are for user that just want to run MAVProxy. Developers should look at the :ref:`Developer's Guide <mavproxy-development>` for setting up the development environment.
 
-MAVProxy is distributed as a Python package (see `PyPI <https://pypi.org/project/MAVProxy/>`__) and can run under Python 2 or 3.
+MAVProxy is distributed as a Python package (see `PyPI <https://pypi.org/project/MAVProxy/>`__).
 A number of pre-requisite packages are required to run MAVProxy, as detailed in the individual sections below.
 
 .. _mavproxy-downloadinstallwindows:
@@ -34,10 +34,7 @@ within Windows. It generally provides better stability than the native Windows i
 Linux
 =====
 
-MAVProxy runs within Python 2 or 3. If your operating system version is less than 2 years old, it
-is recommended to use the Python 3 environment. Otherwise use Python 2.
-
-For Python 3 on Debian based systems (including Ubuntu, WSL, Raspian):
+For Debian based systems (including Ubuntu, WSL, Raspian):
 
 .. code:: bash
 
@@ -45,15 +42,8 @@ For Python 3 on Debian based systems (including Ubuntu, WSL, Raspian):
     pip3 install PyYAML mavproxy --user
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
-For Python 2 on Debian based systems (including Ubuntu, WSL, Raspian):
 
-.. code:: bash
-
-    sudo apt-get install python-dev python-opencv python-wxgtk4.0 python-pip python-matplotlib python-lxml python-pygame
-    pip install PyYAML mavproxy --user
-    echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
-    
-For Python 3 on Fedora based systems:
+For Fedora based systems:
 
 .. code:: bash
 
@@ -73,29 +63,17 @@ The system will need to be restarted to apply the above change.
 Updating
 --------
 
-To update an existing installation with the current release on Python 3 based systems:
+To update an existing installation with the current release:
 
 .. code:: bash
 
     pip3 install mavproxy pymavlink --user --upgrade
 
-or for Python 2 systems:
-
-.. code:: bash
-
-    pip install mavproxy pymavlink --user --upgrade
-
-To update an existing installation with the current development version (ie, from its master branch) for Python 3 systems:
+To update an existing installation with the current development version (ie, from its master branch):
 
 .. code:: bash
 
     pip3 install mavproxy --user git+https://github.com/ArduPilot/mavproxy.git@master
-
-or for Python 2 systems:
-
-.. code:: bash
-
-    pip install mavproxy --user git+https://github.com/ArduPilot/mavproxy.git@master
 
 .. _mavproxy-downloadinstallmac:
 
@@ -112,16 +90,14 @@ Uninstall python-dateutil (OSX and Windows come bundled with a version that is n
 
 .. code:: bash
 
-    sudo pip uninstall python-dateutil
+    sudo pip3 uninstall python-dateutil
 
 Install MAVProxy and its remaining dependencies from the public PyPi repository:
 
 .. code:: bash
 
-    sudo pip install wxPython
-    sudo pip install gnureadline
-    sudo pip install billiard
-    sudo pip install numpy pyparsing
-    sudo pip install MAVProxy
-
-
+    sudo pip3 install wxPython
+    sudo pip3 install gnureadline
+    sudo pip3 install billiard
+    sudo pip3 install numpy pyparsing
+    sudo pip3 install MAVProxy


### PR DESCRIPTION
we don't want any new installations of Python2!