### PR TITLE
Fix typo on doc landing page

### DIFF
--- a/common/source/docs/common-marvelmind.rst
+++ b/common/source/docs/common-marvelmind.rst
@@ -6,7 +6,7 @@ Marvelmind for Non-GPS navigation
 
 [copywiki destination="copter,rover,blimp"]
 
-This article explains how a `MarvelMind <https://marvelmind.com/>`__ system can be as a short-range substitute for a GPS allowing position control modes like Auto and Guided.
+This article explains how a `MarvelMind <https://marvelmind.com/>`__ system can be a short-range substitute for a GPS allowing position control modes like Auto and Guided.
 See the `user manual <https://marvelmind.com/pics/marvelmind_navigation_system_manual.pdf>`__ for more details on the system.
 
 .. note::


### PR DESCRIPTION
Fix "... system can be **as a** short-range substitute..." to be "... system can be a short-range substitute..."