### PR TITLE
Use python3

### DIFF
--- a/.github/workflows/test-Windows.yml
+++ b/.github/workflows/test-Windows.yml
@@ -27,4 +27,4 @@ jobs:
           ./Sphinxsetup.bat
       - name: Test build
         run: |
-          python ./update.py --parallel 4 --verbose --destdir=./web
+          python3 ./update.py --parallel 4 --verbose --destdir=./web

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check image formats
         run: |
           find ./images/ -exec file {} + | grep RIFF -vzq
-      - name: Check python flake8 formatting
+      - name: Check python3 flake8 formatting
         run : |
           set -eux -o pipefail
           flake8 .

--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -21,12 +21,6 @@ sudo apt-get install -y unzip git imagemagick curl wget make python3
 # Install packages release specific
 if [ ${DISTRIBUTION_CODENAME} = 'bionic' ]; then
   sudo apt-get install -y python3-distutils
-elif [ ${DISTRIBUTION_CODENAME} = 'focal' ]; then
-  sudo apt-get install -y python-is-python3
-else
-    if [ ${DISTRIBUTION_ID} = 'Ubuntu' ]; then
-        sudo apt-get install -y python-is-python3
-    fi
 fi
 
 # For WSL (esp. version 2) make DISPLAY empty to allow pip to run

--- a/antennatracker/make.bat
+++ b/antennatracker/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/ardupilot/make.bat
+++ b/ardupilot/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/blimp/make.bat
+++ b/blimp/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/common/source/docs/common-uavcan-gui.rst
+++ b/common/source/docs/common-uavcan-gui.rst
@@ -8,7 +8,7 @@ DroneCAN_GUI is a tool that allows viewing, configuration and software updates o
 connected to the BUS.
 
 - Windows: Download `DroneCAN_GUI <https://firmware.ardupilot.org/Tools/CAN_GUI/>`_ and install.
-- Linux: python -m pip install dronecan_gui_tool dronecan
+- Linux: python3 -m pip install dronecan_gui_tool dronecan
 
 Before the autopilot can be connected, SLCAN mode must be operational. See :ref:`common-slcan-f4` or :ref:`common-slcan-f7h7` for setup information.
 

--- a/common/source/docs/common-wiki-editing-setup.rst
+++ b/common/source/docs/common-wiki-editing-setup.rst
@@ -100,7 +100,7 @@ The main steps for building the docs are:
    .. code-block:: bash
 
        cd /vagrant
-       python update.py
+       python3 update.py
 
 Setup with Docker
 -----------------
@@ -131,11 +131,11 @@ As shown in the last step of the vagrant instructions above, use update.py to bu
 
 .. code-block:: bash
 
-    python update.py (to build all wikis)
-    python update.py --site copter  (to build just the copter wiki)
-    python update.py --site plane   (to build just the plane wiki)
-    python update.py --site rover   (to build just the rover wiki)
-    python update.py --site dev     (to build just this developer wiki)
+    python3 update.py (to build all wikis)
+    python3 update.py --site copter  (to build just the copter wiki)
+    python3 update.py --site plane   (to build just the plane wiki)
+    python3 update.py --site rover   (to build just the rover wiki)
+    python3 update.py --site dev     (to build just this developer wiki)
 
 The update.py script will copy the common files into each wiki subdirectory and then build each wiki.
 
@@ -209,7 +209,7 @@ Restview can be installed with:
 
 .. code-block:: bat
 	
-	python -m pip install restview
+	python3 -m pip install restview
 		
 The restview executable will be installed in the **Scripts** folder of the Python main folder.
 Restview will start the on-the-fly HTML rendering and open a tab page in your preferred web browser.

--- a/copter/make.bat
+++ b/copter/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/dev/make.bat
+++ b/dev/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/dev/source/docs/apjtools-intro.rst
+++ b/dev/source/docs/apjtools-intro.rst
@@ -31,13 +31,13 @@ How to update the Defaults
 
 ::
 
-    python apj_tool.py --set-file param-defaults.parm arducopter.apj
+    python3 apj_tool.py --set-file param-defaults.parm arducopter.apj
 
 - Check the defaults have been applied correctly with this command
 
 ::
 
-    python apj_tool.py --show arducopter.apj
+    python3 apj_tool.py --show arducopter.apj
 
 - Load the modified .apj file to your vehicle and check the defaults have worked correctly
 
@@ -48,7 +48,7 @@ Additional Info
 
 ::
 
-    python apj_tool.py --help
+    python3 apj_tool.py --help
 
 - The parameters will be the new default values only if the user has not modified them
 - If all parameters are reset to their defaults, they will return to the values specified in the file

--- a/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
+++ b/dev/source/docs/code-overview-adding-a-new-mavlink-message.rst
@@ -87,7 +87,7 @@ so you will need to rebuild pymavlink to include your custom message.
  
  - Remove the currently installed version of pymavlink. ``pip uninstall pymavlink``
  - Install the updated version. CD to ``ardupilot/modules/mavlink/pymavlink``
-   and run ``python setup.py install --user``
+   and run ``python3 setup.py install --user``
  - Mavproxy is now capable of sending or receiving the new message. To ask it
    to print out or send your message you need to implement a module. Modules
    are python plugins that allow you to add functionality to Mavproxy. By default

--- a/mavproxy/make.bat
+++ b/mavproxy/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/plane/make.bat
+++ b/plane/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/planner/make.bat
+++ b/planner/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/planner2/make.bat
+++ b/planner2/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/rover/make.bat
+++ b/rover/make.bat
@@ -55,7 +55,7 @@ goto sphinx_ok
 
 :sphinx_python
 
-set SPHINXBUILD=python -m sphinx.__init__
+set SPHINXBUILD=python3 -m sphinx.__init__
 %SPHINXBUILD% 2> nul
 if errorlevel 9009 (
 	echo.

--- a/update.py
+++ b/update.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """
 
 This script updates and rebuilds wiki sources from Github and from

--- a/update.sh
+++ b/update.sh
@@ -123,7 +123,7 @@ MPARAMS_TIME=$(echo "($END_BUILD_MPARAMS - $END_UPDATES)" | bc)
 echo "[Buildlog] Time to run build_parameters.py: $MPARAMS_TIME seconds"
 
 echo "[Buildlog] Starting to build the wiki at $(date '+%Y-%m-%d-%H-%M-%S')"
-# python update.py --clean --parallel 4 # Build without versioning for parameters. It is better for editing wiki.
+# python3 update.py --clean --parallel 4 # Build without versioning for parameters. It is better for editing wiki.
 python3 update.py --destdir /var/sites/wiki/web --clean --paramversioning --parallel 4 --enablebackups --verbose # Enables parameters versioning and backups, should be used only on the wiki server
 
 


### PR DESCRIPTION
This updates all the docs to use python3. There were a few tutorials which are super old and still use python2, so I didn't update them. 

I also removed the `python-is-python3`. That's a hack package IMO, let's just update the calls to `python3` and deprecate python2. 