### PR TITLE
Common: remove storm32 gimbal video

### DIFF
--- a/common/source/docs/common-storm32-gimbal.rst
+++ b/common/source/docs/common-storm32-gimbal.rst
@@ -83,12 +83,6 @@ Testing the gimbal
 For instructions for testing the gimbal moves correctly please check the
 :ref:`similar section for the SimpleBGC gimbal <common-simplebgc-gimbal_testing_the_gimbal_moves_correctly>`.
 
-The video below shows the STorM32 being tested on Copter3.3. 
-It demonstrates a few features that would not be possible on a 2-axis gimbal like the :ref:`Tarot Gimbal <common-tarot-gimbal>`.
-
-..  youtube:: LAKrGXSFWpM
-    :width: 100%
-
 Resistor issue on some boards
 =============================
 


### PR DESCRIPTION
This removes a very old video I made of the SToRM32 gimbal.  It's not a bad video but its very out of date now especially considering all the recent code and mission command changes.

This has been tested locally.