### PR TITLE
sim: clarify a required setting in RealFlight

### DIFF
--- a/dev/source/docs/sitl-with-realflight.rst
+++ b/dev/source/docs/sitl-with-realflight.rst
@@ -25,7 +25,7 @@ See the last section on this page for setup instructions, if using an OpenTX tra
 Enabling RealFlight Link Feature
 ================================
 
-On RealFlight go to Settings->Physics and enable the FlightAxis
+On RealFlight go to Settings->Physics and enable the FlightAxis and set "Pause Sim When in Background" to No
 option then restart RealFlight. In RealFlight Evolution, press ESC, go to Settings->Physics->Quality and enable the "RealFlight Link" option.
 
 Configure RealFlight


### PR DESCRIPTION
It is necessary to set "Pause Sim When in Background" to "No" for RealFlight to work with Mission Planner. Otherwise, the simulation stops as soon as you switch to MP (to arm, to set parameters or anything else) and MP cannot communicate to FlightAxis.