### PR TITLE
Common: all mount setup pages get link to mount control overview

### DIFF
--- a/common/source/docs/common-brushless-pwm-gimbal.rst
+++ b/common/source/docs/common-brushless-pwm-gimbal.rst
@@ -51,6 +51,8 @@ Connect to the autopilot with a ground station and set the following parameters.
 - :ref:`RC7_OPTION <RC7_OPTION>` = 214 ("Mount Yaw") to control the gimbal's yaw rate with RC channel 7
 - :ref:`RC8_OPTION <RC8_OPTION>` = 163 ("Mount Lock") to switch between "lock" and "follow" mode with RC channel 8
 
+See the "Control with an RC transmitter" section of :ref:`this page <common-mount-targeting>` for more details on parameter changes required to control the gimbal through an RC Transmitter (aka "RC Targeting")
+
 Configuring the Gimbal
 ----------------------
 
@@ -63,3 +65,8 @@ Connect the gimbal to your PC and using its configuration application
     - set yaw angle input to input to channel 11
 
 - If the gimbal supports "lock" and "follow" yaw control it should be configured for "follow".
+
+Control and Testing
+-------------------
+
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands

--- a/common/source/docs/common-camera-gimbal.rst
+++ b/common/source/docs/common-camera-gimbal.rst
@@ -70,6 +70,11 @@ Typical input and output assignments are shown below, but any unused RC input ch
 - :ref:`RC7_OPTION <RC7_OPTION>` = 214 ("Mount Yaw") to control the gimbal's yaw rate with RC channel 7
 - :ref:`RC8_OPTION <RC8_OPTION>` = 163 ("Mount Lock") to switch between "lock" and "follow" mode with RC channel 8
 
+Control and Testing
+===================
+
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
+
 Configuration Using Mission Planner (4.2 or lower)
 ==================================================
 

--- a/common/source/docs/common-djirs2-gimbal.rst
+++ b/common/source/docs/common-djirs2-gimbal.rst
@@ -45,10 +45,12 @@ Connect to the autopilot with a ground station and do the following
 - Download mount-djirs2-driver.lua (`from here <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/drivers>`__) and copy it to the autopilot's SD card in the APM/scripts directory and reboot the autopilot
 - Optionally set DJIR_DEBUG to 1 to display parsing and errors stats at 5sec.  Set to 2 to display gimbal angles
 
-Testing
-=======
+See the "Control with an RC transmitter" section of :ref:`this page <common-mount-targeting>` for details on parameter changes required to control the gimbal through an RC Transmitter (aka "RC Targeting")
 
-See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal
+Control and Testing
+===================
+
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
 
 Videos
 ======

--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -36,7 +36,8 @@ Connect to the autopilot with a ground station and set the following parameters,
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115" for 115200 bps.  "SERIAL2" can be replaced with another serial port (i.e. SERIAL1) depending upon the physical connection
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 2 for "MAVLink2"
 - :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` to 1024 for "Don't forward mavlink to/from"
-- Optionally set :ref:`RC9_OPTION <RC9_OPTION>` to 163 for "Mount Lock" to allow the pilot to switch between "lock" and "follow" modes during "RC Targetting".  Note "RC9" can be replaced with any RC input channel
+
+See the "Control with an RC transmitter" section of :ref:`this page <common-mount-targeting>` for details on parameter changes required to control the gimbal through an RC Transmitter (aka "RC Targeting")
 
 When the autopilot has successfully connected to the gimbal, "Mount: GREMSY PixyU fw:7.7.1.0" (or similar) will be sent to the ground station.  Looking for this message may be useful in determining if the autopilot and gimbal are communicating successfully.
 
@@ -79,30 +80,10 @@ Configuring the Gimbal
 
 - Select the "STIFFNESS" tab and adjust the Tilt, Roll, and Pan gains so that the gimbal holds the camera in position without shaking
 
-Testing Controlling the Gimbal from RC
---------------------------------------
+Control and Testing
+-------------------
 
-- Disconnect the USB cable connecting your PC to the gimbal
-- Powerup the vehicle and gimbal
-- Move the transmitter's channel 6 tuning knob to its minimum position, the camera should point straight down
-- Move the ch6 knob to maximum and the gimbal should point upwards
-
-.. note::
-
-   The RC's channel 6 input can be checked from Mission Planner's Radio calibration page
-
-Testing ROI
------------
-
-The ROI feature points the vehicle and/or camera to point at a target.  This can be tested by doing the following:
-
-- Ensure the vehicle has GPS lock
-- If using the Mission Planner, go to the Flight Data screen and right-mouse-button-click on a point about 50m ahead of the vehicle (the orange and red lines show the vehicle's current heading), select **Point Camera Here** and input an altitude of -50 (meters). The camera should point forward and then pitch down at about 45 degrees
-
-.. image:: ../../../images/Tarot_BenchTestROI.jpg
-    :target: ../_images/Tarot_BenchTestROI.jpg
-
-Pilot control of the gimbal can be restored by setting up an :ref:`auxiliary function switch <common-auxiliary-functions>` to "Retract Mount" (i.e. RCx_OPTION = 27) and then move the switch to the lower position
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
 
 Connecting Two Gimbals
 ----------------------

--- a/common/source/docs/common-mount-targeting.rst
+++ b/common/source/docs/common-mount-targeting.rst
@@ -43,6 +43,7 @@ While the gimbal is in "RC Targeting" mode (see above for how to change modes), 
 - set :ref:`RC6_OPTION <RC6_OPTION>` = 212 ("Mount1 Roll") to control the gimbal's roll angle with RC channel 6
 - set :ref:`RC7_OPTION <RC7_OPTION>` = 213 ("Mount1 Pitch") to control the gimbal's pitch angle with RC channel 7
 - set :ref:`RC8_OPTION <RC8_OPTION>` = 214 ("Mount1 Yaw") to control the gimbal's yaw angle with RC channel 8
+- ensure the RCx_TRIM parameter for each RC input channel used is half way between RCx_MIN and RCx_MAX
 
 By default the RC input specifies the **angle** but this can be changed to **rate** control by setting :ref:`MNT1_RC_RATE <MNT1_RC_RATE>` to the desired rotation rate in deg/sec.
 

--- a/common/source/docs/common-simplebgc-gimbal.rst
+++ b/common/source/docs/common-simplebgc-gimbal.rst
@@ -39,12 +39,12 @@ The gimbal's maximum lean angles can be set using these parameters:
 
 - :ref:`MNT1_ROLL_MIN <MNT1_ROLL_MIN>`, :ref:`MNT1_ROLL_MAX <MNT1_ROLL_MAX>` to -30 and 30 to limit the roll angle to 30 degrees in each direction
 - :ref:`MNT1_PITCH_MIN <MNT1_PITCH_MIN>`, :ref:`MNT1_PITCH_MAX <MNT1_PITCH_MAX>` to -90 and 0 to limit the gimbal to point between straight down (-90 degrees) and straight forward (0 degrees)
+- For 3-axis gimbals with 360 degrees of yaw set :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>`, :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to -180 and 180 respectively
 
-To control the gimbal's pitch angles from a transmitter set an RC channel's ``RCx_OPTION`` to 213.
+Control and Testing
+===================
 
-For a 3-axis gimbal with 360 degrees of yaw set:
-
-- :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>`, :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to -180 and 180 to get a full 360 degrees of yaw range
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
 
 Configuration when using MAVLink Protocol
 =========================================

--- a/common/source/docs/common-siyi-zr10-gimbal.rst
+++ b/common/source/docs/common-siyi-zr10-gimbal.rst
@@ -70,3 +70,8 @@ Configuring the Gimbal
 
 .. image:: ../../../images/siyi-gimbal-firmversion.png
     :target: ../_images/siyi-gimbal-firmversion.png
+
+Control and Testing
+-------------------
+
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands

--- a/common/source/docs/common-storm32-gimbal.rst
+++ b/common/source/docs/common-storm32-gimbal.rst
@@ -77,11 +77,10 @@ To use the serial protocol use all the same settings as above except:
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 8 (SToRM32 Gimbal Serial).  If another serial port is connected to the gimbal replace "2" with the serial port number
 -  :ref:`MNT1_TYPE <MNT1_TYPE>` = 5 (SToRM32 Serial)
 
-Testing the gimbal
-==================
+Control and Testing
+===================
 
-For instructions for testing the gimbal moves correctly please check the
-:ref:`similar section for the SimpleBGC gimbal <common-simplebgc-gimbal_testing_the_gimbal_moves_correctly>`.
+See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
 
 Resistor issue on some boards
 =============================


### PR DESCRIPTION
This adds links to each camera gimbal/mount page linking to the control overview page

I've also added a note regarding setting the RCx_TRIM value which came up as an issue on [this discussion](https://discuss.ardupilot.org/t/ip-cameras-rtsp-mavlink-support/99893/15).

This has been tested locally and looks ok.