### PR TITLE
Add style for enums and prefer enum classes

### DIFF
--- a/dev/source/docs/style-guide.rst
+++ b/dev/source/docs/style-guide.rst
@@ -356,6 +356,31 @@ underscores.
 
     class ap_compass { };
 
+Enums
+---------------
+
+Prefer enum classes over raw enums. Enums should be PascalCase, and be singular.
+All entries should have trailing commas, even the last one.
+
+**Right:**
+
+::
+
+    enum class CompassType {
+        FOO,
+        BAR,
+    };
+
+**Wrong:**
+
+::
+
+    enum compass_types {
+        FOO,
+        BAR
+    };
+
+
 Functions and variables
 -----------------------
 


### PR DESCRIPTION
Recommend enum classes since they are commonly used. Provide a style recommendation for them. 
https://github.com/ArduPilot/ardupilot/pull/23877
https://github.com/ArduPilot/ardupilot/pull/23830
https://github.com/ArduPilot/ardupilot/pull/23768/files#diff-ed061f26ab421c524f35bb9112b56bc1322892589f95b77e9497345eb48eafbe
https://github.com/ArduPilot/ardupilot/pull/23119/files#diff-a98f7c976f44f4a82c8c4882b638ca053d70a95f603861216630e20243689dd2


I did not cover the aspect of using `#DEFINE` to enable/disable enums, and to be sure to pin all the numbers so they don't change value when you change your build options. Seems too advanced for the style guide.
