### PR TITLE
Common: Siyi ZR10 yaw angle min/max fix

### DIFF
--- a/common/source/docs/common-siyi-zr10-gimbal.rst
+++ b/common/source/docs/common-siyi-zr10-gimbal.rst
@@ -44,8 +44,8 @@ Connect with a ground station and set the following parameters.  The params belo
 - :ref:`MNT1_TYPE <MNT1_TYPE>` to "8" ("Siyi") and reboot the autopilot
 - :ref:`MNT1_PITCH_MIN <MNT1_PITCH_MIN>` to -90
 - :ref:`MNT1_PITCH_MAX <MNT1_PITCH_MAX>` to 25
-- :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>` to -80
-- :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to 80
+- :ref:`MNT1_YAW_MIN <MNT1_YAW_MIN>` to -135
+- :ref:`MNT1_YAW_MAX <MNT1_YAW_MAX>` to 135
 - :ref:`MNT1_RC_RATE <MNT1_RC_RATE>` to 90 (deg/s) to control speed of gimbal when using RC targetting
 - :ref:`RC6_OPTION <RC6_OPTION>` = 213 ("Mount Pitch") to control the gimbal's pitch angle with RC channel 6
 - :ref:`RC7_OPTION <RC7_OPTION>` = 214 ("Mount Yaw") to control the gimbal's yaw angle with RC channel 7


### PR DESCRIPTION
Fix siyi setup instructions to specify yaw min/max to +-135 deg which matches the datasheet.

![image](https://github.com/ArduPilot/ardupilot_wiki/assets/1498098/3ea909a6-a371-4ee5-a8c7-28fa74df2ad7)

This has been tested local and seems ok.