### PR TITLE
cube overview - I2C2 port might be wrong

### DIFF
--- a/common/source/docs/common-thecubeorange-overview.rst
+++ b/common/source/docs/common-thecubeorange-overview.rst
@@ -162,12 +162,12 @@ The Cube connector pin assignments
    </tr>
    <tr>
    <td>4 (blk)</td>
-   <td>SCL I2C1</td>
+   <td>SCL I2C2</td>
    <td>+3.3V</td>
    </tr>
    <tr>
    <td>5 (blk)</td>
-   <td>SDA I2C1</td>
+   <td>SDA I2C2</td>
    <td>+3.3V</td>
    </tr>
    <tr>
@@ -218,12 +218,12 @@ The Cube connector pin assignments
    </tr>
    <tr>
    <td>4 (blk)</td>
-   <td>SCL I2C2</td>
+   <td>SCL I2C1</td>
    <td>+3.3V</td>
    </tr>
    <tr>
    <td>5 (blk)</td>
-   <td>SDA I2C2</td>
+   <td>SDA I2C1</td>
    <td>+3.3V</td>
    </tr>
    <tr>


### PR DESCRIPTION
Looking at the schematics, it might be that the I2C port numbers for GPS1 and GPS2 are reversed https://github.com/proficnc/The-Cube/blob/master/CB_REV_C_Altium/PCB%203D%20Print%20from%20Above.PDF

It is possible the schematic is wrong, but this does align with the cube docs I am working off: https://docs.cubepilot.org/user-guides/autopilot/the-cube-module-overview