### PR TITLE
Update building-setup-mac.rst removing tap ardupilot/homebrew-px4

### DIFF
--- a/dev/source/docs/building-setup-mac.rst
+++ b/dev/source/docs/building-setup-mac.rst
@@ -31,7 +31,6 @@ Setup steps
 
    ::
 
-       brew tap ardupilot/homebrew-px4
        brew update
        brew install genromfs
        brew install gcc-arm-none-eabi


### PR DESCRIPTION
brew tap ardupilot/homebrew-px4 is out of date. homebrew-cask and homebrew-core now seem to have the correct versions of gcc and other relevant tools.