### PR TITLE
Update gitignore with files downloaded during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,15 @@
 /antennatracker/source/docs/logmessages.rst
 /blimp/source/docs/logmessages.rst
 
+# Binary features files
+/copter/source/docs/binary-features.rst
+/plane/source/docs/binary-features.rst
+/rover/source/docs/binary-features.rst
+/antennatracker/source/docs/binary-features.rst
+/blimp/source/docs/binary-features.rst
+features.json.gz
+build_options.py
+
 # Javascript files
 /antennatracker/source/_static/useralerts.js
 /copter/source/_static/useralerts.js
@@ -91,6 +100,7 @@
 # Website
 /frontend/blog_posts.json
 /frontend/news_posts.json
+/frontend/source/_static/common_theme_override.css
 
 # Mac file
 .DS_Store


### PR DESCRIPTION
I followed the instructions for [Setup in Windows](https://ardupilot.org/dev/docs/common-wiki-editing-setup.html#setup-in-windows) to build the wiki and noticed some files were created that seem unversioned on purpose.

I'm least certain about `build_options.py`. But as I understand it, it's also relevant to specific board configuration so it's in the same section.

_(Contribution on behalf of @FlyfocusUAV)_