### PR TITLE
Common: viewpro gets image and video download instructions

### DIFF
--- a/common/source/docs/common-viewpro-gimbal.rst
+++ b/common/source/docs/common-viewpro-gimbal.rst
@@ -55,3 +55,13 @@ Testing
 =======
 
 See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal
+
+Downloading Images and Videos
+=============================
+
+If the gimbal is connected using Ethernet, images and videos stored on the SD card may be downloaded manually using the built-in webserver.  Using your favourite browser open http://192.168.2.119:8554/download (assuming the gimbal is using the default IP address).
+
+`wget <https://www.gnu.org/software/wget/>`__ can also be used to download all images and videos with a single command
+
+- On Windows, ``wget.exe -r -l 10 --convert-links http://192.168.2.119:8554/download/``
+- On Linux/Ubuntu ``wget -r -l 10 --convert-links http://192.168.2.119:8554/download/``


### PR DESCRIPTION
This adds a little section to the bottom of the ViewPro page with instructions on how images and videos can be downloaded from the gimbal over ethernet.  Eventually I'd like to add this info for all our cameras but so far this is the only one that I have confirmed can do it.

I have tested this on my local machine and it looks OK.