### PR TITLE
Common: Flir vue page gets warning

### DIFF
--- a/common/source/docs/common-flir-vue-pro.rst
+++ b/common/source/docs/common-flir-vue-pro.rst
@@ -40,9 +40,11 @@ Set the following parameters on the autopilot (assuming Telem2/Serial2 is used):
 
 To allow triggering the taking of pictures during a mission or from a transmitter's auxiliary switch connect the "P3" 3-pin servo connector to the one of the autopilot's servo outputs.  In this example AUX OUT 1 (aka SERVO9) is used.  Then set the following parameters (Assuming the Camera1 instance):
 
-- :ref:`SERVO9_FUNCTION <SERVO9_FUNCTION>` = 10 (Camera Trigger)
+
+- :ref:`CAM1_TYPE<CAM1_TYPE>` = 1 (Servo)
 - :ref:`CAM1_SERVO_ON<CAM1_SERVO_ON>` = 1900
-- `CH8_OPT`` or :ref:`RC8_OPTION <RC8_OPTION>` = 9 (Camera Trigger) to enable triggering from transmitter switch 8
+- :ref:`SERVO9_FUNCTION <SERVO9_FUNCTION>` = 10 (Camera Trigger)
+- :ref:`RC8_OPTION <RC8_OPTION>` = 9 (Camera Trigger) to enable triggering from transmitter switch 8
 
 Configure the Phone
 -------------------

--- a/common/source/docs/common-flir-vue-pro.rst
+++ b/common/source/docs/common-flir-vue-pro.rst
@@ -6,6 +6,10 @@ FLIR Vue Pro
 
 The `FLIR Vue Pro <https://www.flir.com/products/vue-pro/>`__ infrared camera supports MAVLink which allows the camera to add position and attitude information to each image stored on its internal SD card
 
+.. warning::
+
+    The Flir Vue Pro MAVLink interface appears to be broken in the latest firmware from FLIR (ver 3.3.2) meaning pictures taken will not include EXIF data of the vehicle's position and attitude
+
 .. image:: ../../../images/flir-vue-pro.png
     :width: 400px
 


### PR DESCRIPTION
This PR adds a warning to the Flir Vue Pro camera setup page.  I've also adding a missing setting and removed a very old setting (the "CH8_OPT" part).

I've recently re-tested the setup and found that the MAVLink interface has somehow been broken and I strongly suspect it is due to some change on the FLIR firmware side.  [There is a discussion here](https://discuss.ardupilot.org/t/flir-vue-pro-gets-no-mavlink-info/96072) where other users are also apparently struggling.

I've tested this locally and it looks OK.