### PR TITLE
Dev: Add link to newer SITL serial info

### DIFF
--- a/dev/source/docs/sitl-serial-mapping.rst
+++ b/dev/source/docs/sitl-serial-mapping.rst
@@ -6,7 +6,7 @@
 Archived: SITL Serial Mapping
 =============================
 
-.. warning:: This topic is archived.
+.. warning:: This topic is archived. The information has been moved to :ref:`learning-ardupilot-uarts-and-the-console`.
 
 This document attempts to supply information about the virtual serial ports present in ArduPilot's SITL.
 


### PR DESCRIPTION
There are still links floating out there to the old page. Redirect to the newer info and the consolidated page.