### PR TITLE
modules: graph: remove whitespace to fix code blocks

### DIFF
--- a/mavproxy/source/docs/modules/graph.rst
+++ b/mavproxy/source/docs/modules/graph.rst
@@ -44,8 +44,8 @@ To set the timespan along the horizontal axis (in seconds):
 .. code:: bash
 
     graph timespan 20
- 
- To set the tickresolution along the horizontal axis (1/<number of ticks>):
+
+To set the tickresolution along the horizontal axis (1/<number of ticks>):
 
 .. code:: bash
 


### PR DESCRIPTION
There was whitespace causing the `tickresolution` line to be included in the code block above it.