### PR TITLE
dev: fix rosdep in ros 2 page

### DIFF
--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -44,7 +44,7 @@ Now update all dependencies:
     cd ~/ros2_ws
     sudo apt update
     rosdep update
-    rosdep install --rosdistro ${ROS_DISTRO} --from-paths src
+    rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i
 
 And finally, build your workspace:
 


### PR DESCRIPTION
![Screenshot from 2023-09-12 15-13-36](https://github.com/ArduPilot/ardupilot_wiki/assets/62964137/54b9bf99-b369-4d8f-94fa-80110145a0ad)

The rosdep command tried to install a binary package for `ardupilot_sitl` instead of using the package in the worskpace source directory.
Adding the flag `-i`, makes it so that rosdep doesn't try to install binaries for packages that are already in the workspace. It is present in the other pages for `ROS2`, but I missed it on this one.

It fixes the issue:
![Screenshot from 2023-09-12 15-17-29](https://github.com/ArduPilot/ardupilot_wiki/assets/62964137/fd212226-63aa-4a09-9a4e-c73a6bfad80d)

