### PR TITLE
Update ac_throttlemid.rst to take into account lower hover throttles and the max hover throttle hard limit in the code.

### DIFF
--- a/copter/source/docs/ac_throttlemid.rst
+++ b/copter/source/docs/ac_throttlemid.rst
@@ -7,7 +7,7 @@ Setting Hover Throttle
 Copter includes automatic learning of Hover Throttle (previously known as "mid throttle")
 The :ref:`MOT_THST_HOVER <MOT_THST_HOVER>` value will slowly move towards the average motor output whenever the vehicle is holding a steady hover in non-manual flight modes (i.e. all modes except Stabilize and Acro).
 
-If you wish to manually set the :ref:`MOT_THST_HOVER <MOT_THST_HOVER>` value, it is best to download a dataflash log and set the value to what is seen in the CTUN.ThO field.  The value should be between 0.2 and 0.8.
+If you wish to manually set the :ref:`MOT_THST_HOVER <MOT_THST_HOVER>` value, it is best to download a dataflash log and set the value to what is seen in the CTUN.ThO field. The value is usually between 0.2 and 0.6, but may be lower if the copter has a very high power-to-weight ratio.
 
 If for some reason you wish to disable learning, you can set the :ref:`MOT_HOVER_LEARN <MOT_HOVER_LEARN>` parameter to 0.
 


### PR DESCRIPTION
Very high-powered copters have a hover throttle lower than 0.2, so I've updated it to say "usually" instead of stating it as a requirement, which may make users think something is wrong if their hover throttle is that low.

I've also changed the max of 0.8 to 0.6 since the code limits the maximum hover throttle to 0.6875