### PR TITLE
Common: link Xacti page from cameras-and-gimbals landing page

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -27,6 +27,7 @@ gimbals in which ArduPilot controls the stabilisation.
 -  :ref:`Siyi ZR10, ZR30 and A8 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera
 -  :ref:`SToRM32 Gimbal Controller <common-storm32-gimbal>` — an inexpensive 2-axis or 3-axis brushless gimbal controller which responds to MAVLink commands (a richer format than PWM) over a serial interface
 -  :ref:`ViewPro gimbals <common-viewpro-gimbal>`
+-  :ref:`Xacti gimbals <common-xacti-gimbal>`
 
 Mount control is covered on the :ref:`common-mount-targeting` page.
 
@@ -100,6 +101,7 @@ Detail topics
     Siyi ZR10, ZR30 and A8 <common-siyi-zr10-gimbal>
     SToRM32 Gimbal Controller <common-storm32-gimbal>
     ViewPro gimbals <common-viewpro-gimbal>
+    Xacti gimbals <common-xacti-gimbal>
     FLIR Vue Pro Thermal Camera <common-flir-vue-pro>
     Airpixel Entire Geotagger <common-geotagging-airpixel-entire>
     Seagull IR Camera Trigger <common-camera-trigger-seagull-ir>

--- a/common/source/docs/common-xacti-gimbal.rst
+++ b/common/source/docs/common-xacti-gimbal.rst
@@ -6,9 +6,16 @@
 Xacti Gimbals
 =============
 
-The `Xacti Camera Gimbals <https://xacti-co.com/service/drone_camera/>`__ are 3-axis camera gimbals which communicate with ArduPilot using the DroneCAN protocol.
+The `Xacti Camera Gimbals <https://xacti-co.com/service/drone_camera/>`__ are relatively lightweight 3-axis camera gimbals which communicate with ArduPilot using the DroneCAN protocol.  Real time video output is available simulataneously through HDMI and USB.  Pictures taken include the vehicle's location (lat, lon, alt) stored using EXIF.
 
 .. image:: ../../../images/xacti-gimbal.png
+
+The four supported models are:
+
+- CX-GB100 : 20MP RGB
+- CX-GB200 : 12MP RGB + 640x512 pixel IR
+- CX-GB300 : Multispectral NDVI
+- CX-GB400 : 12MP RGB with 2.5x optical zoom
 
 .. note::
 
@@ -63,6 +70,17 @@ Control and Testing
 -------------------
 
 See :ref:`Gimbal / Mount Controls <common-mount-targeting>` for details on how to control the gimbal using RC, GCS or Auto mode mission commands
+
+Firmware Updates
+----------------
+
+Firmware updates are available from Xacti directly and normally include a "firmware.bin" file and an empty "UPDATE.txt" file.  To update the camera:
+
+- Power down the gimbal and remove its SD card
+- Copy the "firmware.bin" and "UPDATE.txt" files to the SD card
+- Power up the gimbal and wait for at least 10 seconds
+- Optionally power down the gimbal, remove the SD card and check that the "firmware.bin" and/or "UPDATE.txt" files have been deleted.  If either was deleted then the firmware update was successful
+- Power up the gimbal and it should operate normally
 
 Videos
 ------


### PR DESCRIPTION
This PR makes three changes:

1. Add a link to the Xacti page from the cameras-and-gimbals landing page.  I know this may be slightly controversial because we normally leave new features in the "Upcoming Features" area until we start beta testing the next version but I think that it would be good to have more visibility on this series of cameras.  I think these cameras could be quite popular because although slightly expensive they are high quality and very small.  I'm sure it will take time for the number of users to ramp up and I would like to get that process started as quickly as possible.
2. Add note on which models are supported
3. Add firmware update process instructions

I've tested this locally and it looks OK.