### PR TITLE
apmcopter-libraries: Remove AP_Buffer

### DIFF
--- a/dev/source/docs/apmcopter-programming-libraries.rst
+++ b/dev/source/docs/apmcopter-programming-libraries.rst
@@ -60,5 +60,4 @@ libraries and their function.
    camera mount control library, camera shutter control libraries
 -  `AP_Mission <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Mission>`__
    - stores/retrieves mission commands from eeprom
--  `AP_Buffer <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Buffer>`__ -
-   a simple FIFO buffer for use with inertial navigation
+


### PR DESCRIPTION
This is a PR for removing AP_Buffer description and links, as it's no longer exist!