### PR TITLE
Add missing sitl setup and packages up to

### DIFF
--- a/dev/source/docs/ros2-gazebo.rst
+++ b/dev/source/docs/ros2-gazebo.rst
@@ -39,7 +39,7 @@ Build:
 .. code-block:: bash
 
     cd ~/ros2_ws
-    colcon build --cmake-args -DBUILD_TESTING=ON
+    colcon build --packages-up-to ardupilot_gz_bringup --cmake-args -DBUILD_TESTING=ON 
 
 If you'd like to test your installation, run:
 

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -8,6 +8,9 @@ Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed
 
 .. code-block:: bash
 
+    source /opt/ros/humble/setup.bash
+    cd ~/ros2_ws/
+    colcon build --packages-up-to ardupilot_sitl
     source ~/ros2_ws/install/setup.bash
     ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
 

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -4,7 +4,7 @@
 ROS 2 with SITL
 ===============
 
-Once ROS2 is correctly :ref:`installed <ros2>`, source your workspace and launch Ardupilot SITL with ROS 2! 
+Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch Ardupilot SITL with ROS 2! 
 
 .. code-block:: bash
 

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -4,7 +4,7 @@
 ROS 2 with SITL
 ===============
 
-Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch Ardupilot SITL with ROS 2! 
+Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch Ardupilot SITL with ROS 2!
 
 .. code-block:: bash
 
@@ -14,13 +14,25 @@ Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed
     source ~/ros2_ws/install/setup.bash
     ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
 
-If the ROS 2 topics aren't being published, set the ardupilot parameter DDS_ENABLE to 1 manually and reboot the launch
+If the ROS 2 topics aren't being published, set the ardupilot parameter DDS_ENABLE to 1 manually and reboot the launch.
 
 .. code-block:: bash
-    
+
     export PATH=$PATH:~/ros2_ws/src/ardupilot/Tools/autotest
     sim_vehicle.py -w -v ArduPlane --console -DG --enable-dds
 
     param set DDS_ENABLE 1
 
 For more information refer to `ardupilot/Tools/ros2/README.md <https://github.com/ArduPilot/ardupilot/tree/master/Tools/ros2#readme>`__. There you can find examples of launches using serial connection instead of udp, as well as a step-by-step breakdown of what the launch files are doing.
+
+Once everything is running, you can now interract with ArduPilot through the ROS 2 CLI.
+
+.. code-block:: bash
+
+    source ~/ros2_ws/install/setup.bash
+    # See the node appear in the ROS graph
+    ros2 node list
+    # See which topics are exposed by the node
+    ros2 node info /ardupilot_dds
+    # Echo a topic published from ArduPilot
+    ros2 topic echo /ap/geopose/filtered

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -9,7 +9,7 @@ ROS 2
 
 ArduPilot capabilities can be extended with `ROS <http://www.ros.org/>`__ (aka Robot Operating System).
 
-`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been superseded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and Ardupilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__
+`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been superseded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and Ardupilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__.
 
 
 Prerequisites
@@ -18,13 +18,15 @@ Prerequisites
 - Learn on to use ArduPilot first by following the relevant wiki for `Rover <https://ardupilot.org/rover/index.html>`__, `Copter <https://ardupilot.org/copter/index.html>`__ or `Plane <https://ardupilot.org/plane/index.html>`__. In particular, make sure the vehicle works well in Manual and Autonomous modes like Guided and Auto before trying to use ROS.
 - Learn how to use ROS 2 by reading the `beginner tutorials <https://docs.ros.org/en/humble/Tutorials.html>`__.  In the case of a problem with ROS, it is best to ask on ROS community forums first (or google your error).
 
-    We are keen to improve ArduPilot's support of ROS 2 so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__ with a title 
+    We are keen to improve ArduPilot's support of ROS 2 so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__. A maintainer can add the `ROS` tag. 
 
-First, make sure that you have successfully installed `ROS humble <https://docs.ros.org/en/humble/Installation.html>`__ and create a `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__. This page assumes that your workspace is named `ros2_ws`
+First, make sure that you have successfully installed `ROS humble <https://docs.ros.org/en/humble/Installation.html>`__ and create a `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__. This page assumes that your workspace is named `ros2_ws`.
 
 Before anything else, make sure that you have `sourced your ROS 2 environment <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`__ and check if it is `configured correctly <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#check-environment-variables>`__.
 
-Finally, follow the `Installing Build Dependencies <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS#installing-build-dependencies>`__ section of `AP_DDS`'s README
+Follow the `Installing Build Dependencies <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS#installing-build-dependencies>`__ section of `AP_DDS`'s README.
+
+Finally, ensure you have `set up your ArduPilot build environment <https://ardupilot.org/dev/docs/building-the-code.html#setting-up-the-build-environment>`__.
 
 Installation (Ubuntu)
 =====================

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -18,7 +18,7 @@ Prerequisites
 - Learn on to use ArduPilot first by following the relevant wiki for `Rover <https://ardupilot.org/rover/index.html>`__, `Copter <https://ardupilot.org/copter/index.html>`__ or `Plane <https://ardupilot.org/plane/index.html>`__. In particular, make sure the vehicle works well in Manual and Autonomous modes like Guided and Auto before trying to use ROS.
 - Learn how to use ROS 2 by reading the `beginner tutorials <https://docs.ros.org/en/humble/Tutorials.html>`__.  In the case of a problem with ROS, it is best to ask on ROS community forums first (or google your error).
 
-    We are keen to improve ArduPilot's support of ROS 2 so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__. A maintainer can add the `ROS` tag. 
+    We are keen to improve ArduPilot's support of ROS 2 so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__. A maintainer can add the `ROS` tag.
 
 First, make sure that you have successfully installed `ROS humble <https://docs.ros.org/en/humble/Installation.html>`__ and create a `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__. This page assumes that your workspace is named `ros2_ws`.
 
@@ -137,17 +137,17 @@ Build the container:
 Start the container in interactive mode:
 
 .. code-block:: bash
-    
+
     docker run -it --name ardupilot-dds ardupilot/ardupilot-dev-ros
 
 Connect another bash process to the running container:
 
 .. code-block:: bash
-    
+
     docker container exec -it ardupilot-dds /bin/bash
 
 The remaining steps are the same as for Ubuntu. You may need to install MAVProxy if it is not available on the container.
 
 .. code-block:: bash
-    
+
     pip install -U MAVProxy

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -9,7 +9,7 @@ ROS 2
 
 ArduPilot capabilities can be extended with `ROS <http://www.ros.org/>`__ (aka Robot Operating System).
 
-`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been succeded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and Ardupilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__
+`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been superseded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and Ardupilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__
 
 
 Prerequisites
@@ -20,7 +20,7 @@ Prerequisites
 
     We are keen to improve ArduPilot's support of ROS 2 so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__ with a title 
 
-First, make sure that you have succesfully installed `ROS humble <https://docs.ros.org/en/humble/Installation.html>`__ and create a `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__. This page assumes that your workspace is named `ros2_ws`
+First, make sure that you have successfully installed `ROS humble <https://docs.ros.org/en/humble/Installation.html>`__ and create a `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__. This page assumes that your workspace is named `ros2_ws`
 
 Before anything else, make sure that you have `sourced your ROS 2 environment <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`__ and check if it is `configured correctly <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#check-environment-variables>`__.
 
@@ -44,14 +44,15 @@ Now update all dependencies:
     cd ~/ros2_ws
     sudo apt update
     rosdep update
-    rosdep install --rosdistro ${ROS_DISTRO} --from-paths src -i
+    source /opt/ros/humble/setup.bash
+    rosdep install --from-paths src --ignore-src
 
 And finally, build your workspace:
 
 .. code-block:: bash
 
     cd ~/ros2_ws
-    colcon build --cmake-args -DBUILD_TESTING=ON
+    colcon build --packages-up-to ardupilot_dds_tests --cmake-args -DBUILD_TESTING=ON
 
 If you'd like to test your installation, run:
 


### PR DESCRIPTION
This improves instructions to make sure users don't miss steps for SITL.

It also improves the build workflow by only building what's needed, instead of everything, which is good when someone's ROS workspace is huge. 

This work was sponsored by AeroVironment. 