### PR TITLE
Recommend Sensor Connect for configuration

### DIFF
--- a/common/source/docs/common-external-ahrs.rst
+++ b/common/source/docs/common-external-ahrs.rst
@@ -24,7 +24,8 @@ VectorNav300 or MicroStrain
 
     - :ref:`EAHRS_TYPE<EAHRS_TYPE>` = 1 (VectorNAV) or 2 (MicroStrain)
 
-This will replace ArduPilot’s internally generated INS/AHRS subsystems with the external system
+This will replace ArduPilot’s internally generated INS/AHRS subsystems with the external system.
+The MicroStrain system must be configured via `Sensor Connect <https://www.microstrain.com/software/sensorconnect>`__ before use.
 
 VN-300 Specific setup
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
ArduPilot software does not currently configure the MicroStrain External AHRS, yet the Wiki never told users that. Adding a link to Sensor Connect is a good way to let users know they should go configure. 

![image](https://github.com/ArduPilot/ardupilot_wiki/assets/25047695/606c284c-107f-460c-b1da-a4d39b188654)
