### PR TITLE
Common: Septentrio page details dual antenna setup

### DIFF
--- a/common/source/docs/common-gps-septentrio.rst
+++ b/common/source/docs/common-gps-septentrio.rst
@@ -18,25 +18,42 @@ Setup instructions
 
 To setup this using GPS1 input (serial3) configure these parameters:
 
-- GPS_INJECT_TO,0
-- GPS_RATE_MS,100
-- GPS_TYPE,10
-- :ref:`SERIAL3_BAUD<SERIAL3_BAUD>`,115
-- :ref:`SERIAL3_PROTOCOL<SERIAL3_PROTOCOL>`,5
+- :ref:`GPS_INJECT_TO<GPS_INJECT_TO>` = 0 (send to first GPS)
+- :ref:`GPS_RATE_MS<GPS_RATE_MS>` = 100
+- :ref:`GPS_TYPE<GPS_TYPE>` = 10 (SBF)
+- :ref:`SERIAL3_BAUD<SERIAL3_BAUD>` = 115
+- :ref:`SERIAL3_PROTOCOL<SERIAL3_PROTOCOL>` = 5 (GPS)
 
 To setup this using GPS2 input (serial4) configure these parameters:
 
-- GPS_INJECT_TO,1
-- GPS_RATE_MS2,100
-- GPS_TYPE2,10
-- :ref:`SERIAL4_BAUD<SERIAL4_BAUD>`,115
-- :ref:`SERIAL4_PROTOCOL<SERIAL4_PROTOCOL>`,5
+- :ref:`GPS_INJECT_TO<GPS_INJECT_TO>` = 1 (send to 2nd GPS)
+- :ref:`GPS_RATE_MS2<GPS_RATE_MS2>` = 100
+- :ref:`GPS_TYPE2<GPS_TYPE2>` = 10 (SBF)
+- :ref:`SERIAL4_BAUD<SERIAL4_BAUD>` = 115
+- :ref:`SERIAL4_PROTOCOL<SERIAL4_PROTOCOL>` = 5 (GPS)
 
 If you want to inject RTCM corrections to both GPS1 and GPS2 then use:
-- GPS_INJECT_TO,127
+
+- :ref:`GPS_INJECT_TO<GPS_INJECT_TO>` = 127 (send to all)
 
 Note:
 Baud rate is auto-negotiated by the ArduPilot firmware, and might get set to something different than the 115200 baud.
+
+GPS-for-Yaw
+===========
+
+:ref:`GPS-for-yaw<common-gps-for-yaw>` is possible using two separate GPSs or, in ArduPilot 4.5 (or higher), a single unit with two antennas may also be used.
+
+If a single unit with two antennas is used please set the following parameters:
+
+- :ref:`GPS_TYPE <GPS_TYPE>` = 26 (SBF-DualAntenna)
+- :ref:`GPS_MB1_TYPE <GPS_MB1_TYPE>` = 1 (RelativeToCustomBase)
+- :ref:`GPS_MB1_OFS_X <GPS_MB1_OFS_X>`, :ref:`GPS_MB1_OFS_Y <GPS_MB1_OFS_Y>` and :ref:`GPS_MB1_OFS_Z <GPS_MB1_OFS_Z>` to match the offset of the main antenna from the second in meters.  For example if the second antenna is 50cm to the right of main antenna set :ref:`GPS_MB1_OFS_Y <GPS_MB1_OFS_Y>` = -0.5.
+- :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 2 (GPS)
+
+See the :ref:`<antenna_offsets>` section for a diagram illustrating the directions of these offsets.
+
+Note that the yaw calculation requires the GPS have an RTK fixed lock and the yaw calculation is only correct while the vehicle is upright so it should not be used on vehicle that spend significant time at extreme lean angles (e.g tail sitters).
 
 Video including setup instructions
 ==================================


### PR DESCRIPTION
PR https://github.com/ArduPilot/ardupilot/pull/25601 adds support for GPS-for-yaw when using a single Septentrio GPS with two antennas.  This is new for 4.5.

This has been tested locally and looks OK to me.