### PR TITLE
Correct on-board flash size 128MB for aocoda-h743dual

### DIFF
--- a/common/source/docs/common-aocoda-h743dual.rst
+++ b/common/source/docs/common-aocoda-h743dual.rst
@@ -17,7 +17,7 @@ Specifications
 -  **Processor**
 
    -  STM32H743VIH6 (480MHz)
-   -  128KByte Flash for datalogging
+   -  128MByte Flash for datalogging
 
 
 -  **Sensors**


### PR DESCRIPTION
Correct on-board flash size 128MB for aocoda-h743dual