### PR TITLE
flight-modes.rst: remove mention of terrain following for Cruise

### DIFF
--- a/plane/source/docs/flight-modes.rst
+++ b/plane/source/docs/flight-modes.rst
@@ -34,7 +34,7 @@ of functionality available.
    <tr><td>MANUAL</td><td>-</td><td>-</td><td>-</td><td></td><td>Y</td><td>Manual control surface movement, passthrough</td></tr>
    <tr><td>FBWA</td><td>s</td><td>s</td><td>-</td><td></td><td>Y</td><td>Roll and pitch follow stick input, up to set limits</td></tr>
    <tr><td>FBWB</td><td>s</td><td>A</td><td>SPD</td><td>Y</td><td>Y</td><td>like FBWA, but with automatic height and speed control</td></tr>
-   <tr><td>CRUISE</td><td>A</td><td>A</td><td>SPD</td><td>Y</td><td>Y</td><td>like FBWB, but with ground course tracking and terrain following</td></tr>
+   <tr><td>CRUISE</td><td>A</td><td>A</td><td>SPD</td><td>Y</td><td>Y</td><td>like FBWB, but with ground course tracking</td></tr>
    <tr><td>STABILIZE</td><td>+</td><td>+</td><td>-</td><td></td><td>Y</td><td>Wing-leveling on stick release</td></tr>
    <tr><td>AUTOTUNE</td><td>s</td><td>s</td><td>-</td><td></td><td>Y</td><td>like FBWA, but learns attitude tuning while flying</td></tr>
    <tr><td>TRAINING</td><td>+</td><td>+</td><td>-</td><td></td><td>Y</td><td>Manual control up to roll and pitch limits</td></tr>


### PR DESCRIPTION
This suggests that Cruise does terrain following out of the box, and that FBWB cannot do terrain following. Both of which are wrong.