### PR TITLE
Fix connected with git config --global url."https://"

### DIFF
--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -30,7 +30,7 @@ Clone ArduPilot repository
 
     ::
 
-         git config --global url."https://" 
+         git config --global url."https://".insteadOf git://
 
     to use https protocols instead of the default git:// prefix.
 


### PR DESCRIPTION
Valid command is `git config --global url."https://".insteadOf git://` not `git config --global url."https://"`