### PR TITLE
Improve ROS2 docs

### DIFF
--- a/dev/source/docs/ros2-cartographer-slam.rst
+++ b/dev/source/docs/ros2-cartographer-slam.rst
@@ -4,7 +4,7 @@
 Cartographer SLAM with ROS 2 in SITL
 ====================================
 
-This page shows how to setup ROS 2 with Ardupilot SITL and run Google Cartographer as a SLAM source. 
+This page shows how to setup ROS 2 with ArduPilot SITL and run Google Cartographer as a SLAM source. 
 
 Installation
 ============
@@ -53,7 +53,7 @@ In another terminal, run:
 Configure ArduPilot
 ===================
 
-If you'd like to get the information from Cartographer to go into Ardupilot's extended kalman filter, you will need to change some parameters, you can do that through any GCS, including mavproxy:
+If you'd like to get the information from Cartographer to go into ArduPilot's extended kalman filter, you will need to change some parameters, you can do that through any GCS, including mavproxy:
 
 -  :ref:`AHRS_EKF_TYPE <copter:AHRS_EKF_TYPE>` = 3 to use EKF3
 -  :ref:`EK2_ENABLE <copter:EK2_ENABLE>` = 0 to disable EKF2

--- a/dev/source/docs/ros2-cartographer-slam.rst
+++ b/dev/source/docs/ros2-cartographer-slam.rst
@@ -50,13 +50,6 @@ In another terminal, run:
     source ~/ros2_ws/install/setup.sh
     ros2 launch ardupilot_ros cartographer.launch.py
 
-To test and fly around, you can launch a `mavproxy <https://ardupilot.org/dev/docs/copter-sitl-mavproxy-tutorial.html>`__ instance in yet another terminal:
-
-.. code-block:: bash
-    
-    mavproxy.py --console --map --aircraft test --master=:14550
-
-
 Configure ArduPilot
 ===================
 

--- a/dev/source/docs/ros2-gazebo.rst
+++ b/dev/source/docs/ros2-gazebo.rst
@@ -4,19 +4,19 @@
 ROS 2 with Gazebo
 =================
 
-Once ROS2 is correctly :ref:`installed <ros2>` and running :ref:`sitl <ros2-sitl>`, we can integrate Ardupilot with Gazebo. 
+Once ROS2 is correctly :ref:`installed <ros2>` and running :ref:`SITL <ros2-sitl>`, we can integrate ArduPilot with Gazebo. 
 
-First, `install Gazebo Garden <https://gazebosim.org/docs/garden/install>`.
+First, `install Gazebo Garden <https://gazebosim.org/docs/garden/install>`__.
 
 Next, set up all the necessary ROS 2 packages in the workspace.
 
-We will clone the required repositories using `vcstool <https://github.com/dirk-thomas/vcstool>` and a `ros2.repos` files:
+We will clone the required repositories using `vcstool <https://github.com/dirk-thomas/vcstool>`__ and a `ros2.repos` files:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws/src
+    cd ~/ros2_ws
     wget https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos
-    vcs import --recursive < ros2_gz.repos
+    vcs import --recursive src < ros2_gz.repos
 
 Set the gazebo version
 
@@ -74,7 +74,7 @@ Examples available
 
     ros2 launch ardupilot_gz_bringup iris_maze.launch.py
 
-Here is a demo video of Ardupilot working with ROS 2 and Gazebo:
+Here is a demo video of ArduPilot working with ROS 2 and Gazebo:
 
 ..  youtube:: HZKXrSAE-ac
     :width: 100%

--- a/dev/source/docs/ros2-gazebo.rst
+++ b/dev/source/docs/ros2-gazebo.rst
@@ -32,14 +32,14 @@ Update ROS dependencies:
     source /opt/ros/humble/setup.bash
     sudo apt update
     rosdep update
-    rosdep install --rosdistro $ROS_DISTRO --from-paths src -i -r -y
+    rosdep install --from-paths src --ignore-src -r
 
 Build:
 
 .. code-block:: bash
 
     cd ~/ros2_ws
-    colcon build --packages-up-to ardupilot_gz_bringup --cmake-args -DBUILD_TESTING=ON 
+    colcon build --packages-up-to ardupilot_gz_bringup
 
 If you'd like to test your installation, run:
 
@@ -78,3 +78,9 @@ Here is a demo video of Ardupilot working with ROS 2 and Gazebo:
 
 ..  youtube:: HZKXrSAE-ac
     :width: 100%
+
+
+Next up
+=======
+
+Run Cartographer SLAM in :ref:`Cartographer SLAM with ROS 2 in SITL <ros2-cartographer-slam>`

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -25,7 +25,10 @@ If the ROS 2 topics aren't being published, set the ardupilot parameter DDS_ENAB
 
 For more information refer to `ardupilot/Tools/ros2/README.md <https://github.com/ArduPilot/ardupilot/tree/master/Tools/ros2#readme>`__. There you can find examples of launches using serial connection instead of udp, as well as a step-by-step breakdown of what the launch files are doing.
 
-Once everything is running, you can now interract with ArduPilot through the ROS 2 CLI.
+ROS 2 CLI
+=========
+
+Once everything is running, you can now interact with ArduPilot through the ROS 2 CLI.
 
 .. code-block:: bash
 
@@ -36,3 +39,18 @@ Once everything is running, you can now interract with ArduPilot through the ROS
     ros2 node info /ardupilot_dds
     # Echo a topic published from ArduPilot
     ros2 topic echo /ap/geopose/filtered
+
+MAVProxy
+========
+
+To test and fly around, you can launch a `mavproxy <https://ardupilot.org/dev/docs/copter-sitl-mavproxy-tutorial.html>`__ instance in yet another terminal:
+
+.. code-block:: bash
+    
+    mavproxy.py --console --map --aircraft test --master=:14550
+
+
+Next up
+=======
+
+Add Gazebo in :ref:`ROS 2 with Gazebo <ros2-gazebo>`

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -4,7 +4,7 @@
 ROS 2 with SITL
 ===============
 
-Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch Ardupilot SITL with ROS 2!
+Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch ArduPilot SITL with ROS 2!
 
 .. code-block:: bash
 

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -58,7 +58,7 @@ And finally, build your workspace:
 .. code-block:: bash
 
     cd ~/ros2_ws
-    colcon build --packages-up-to ardupilot_dds_tests --cmake-args -DBUILD_TESTING=ON
+    colcon build --packages-up-to ardupilot_dds_tests
 
 If you'd like to test your installation, run:
 

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -9,7 +9,7 @@ ROS 2
 
 ArduPilot capabilities can be extended with `ROS <http://www.ros.org/>`__ (aka Robot Operating System).
 
-`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been superseded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and Ardupilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__.
+`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications. ROS has been superseded by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__, and ArduPilot now natively supports it through its library `AP_DDS <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_DDS>`__.
 
 
 Prerequisites


### PR DESCRIPTION
* Consistent rosdep instructions
* Add next steps to make order clearer
* Put MavProxy in the SITL tutorial
* Remove specifyinig rosdistro in rosdep call, use the environment variable instead
* Rely on colcon enabling testing by default
* Fix invalid link rendering
* Fix incorrect capitilization of tools