### PR TITLE
update some gps-for-yaw and Septentrio information

### DIFF
--- a/common/source/docs/common-gps-for-yaw.rst
+++ b/common/source/docs/common-gps-for-yaw.rst
@@ -4,8 +4,10 @@
 GPS for Yaw (aka Moving Baseline)
 =================================
 
-New RTK GPS modules, such as a pair of Ublox F9's or devices based on the Unicore UM-982, can be used to estimate yaw, in addition to providing position information. This removes the need for a compass which may suffer from magnetic interference from the ground or the vehicle's motors and ESCs.  This works even if the
-GPSs do not have an RTK fix (RTCM data from a fixed RTK station or NTRIP server).
+New RTK GPS modules, such as a pair of Ublox F9's, devices based on the Unicore UM-982 or some dual-antenna devices can be used to estimate yaw,
+in addition to providing position information.
+This removes the need for a compass which may suffer from magnetic interference from the ground or the vehicle's motors and ESCs.
+This works even if the GPSs do not have an RTK fix (RTCM data from a fixed RTK station or NTRIP server).
 
 GPSes from ArduPilot Partners that are known to work are shown on the :ref:`common-positioning-landing-page`
 
@@ -20,7 +22,7 @@ Hardware Setup
 GPS Yaw estimation relies on the detection of signal delays from each satellite as they reach two separated antennas. The GPS system may consist of dual or a single module, but two antennas are required in each case.
 
 - The antennas must be separated by at least 30cm on the vehicle.
-- For dual unit systems, the 1st GPS and 2nd GPS should be connected to a serial/telem ports on the
+- For dual unit systems, the 1st GPS and 2nd GPS should be connected to the serial/telem ports on the
   autopilot or via DroneCAN.  The following parameter instructions assume Serial3 and Serial4 are used for serial connecting GPSes but any serial port(s) should work as long as the first port using protocol 5 is connected to one of the GPS.
 - Dual unit Serial GPS modules must be connected to ArduPilot via their (not the autopilots's) UART1 connectors, DroneCAN modules via CAN , or interconnected per their manufacturer instructions.
 

--- a/common/source/docs/common-gps-septentrio.rst
+++ b/common/source/docs/common-gps-septentrio.rst
@@ -4,7 +4,7 @@
 Septentrio AsteRx UAS GPS Family
 ================================
 
-The Septentrio `AsteRx-m2 UAS <http://www.septentrio.com/products/gnss-receivers/rover-base-receivers/oem-receiver-boards/asterx-m2-uas/>`__ RTK GPS and other AsteRX-m RTK GPS are relatively expensive but also highly accurate RTK GPS.
+The Septentrio `AsteRx-m2 UAS <http://www.septentrio.com/products/gnss-receivers/rover-base-receivers/oem-receiver-boards/asterx-m2-uas/>`__ RTK GPS and other AsteRX-m RTK GPS are relatively expensive but also highly accurate RTK GPS receivers.
 
 .. image:: ../../../images/gps-septrino.png
 	:target: ../_images/gps-septrino.png
@@ -32,6 +32,9 @@ To setup this using GPS2 input (serial4) configure these parameters:
 - :ref:`SERIAL4_BAUD<SERIAL4_BAUD>` = 115
 - :ref:`SERIAL4_PROTOCOL<SERIAL4_PROTOCOL>` = 5 (GPS)
 
+The Septentrio driver currently does not use `GPS_RATE_MS` and `GPS_RATE_MS2`.
+It is still important to set them to the expected value of 100 (10Hz) as they are used as weights when combining GPS results.
+
 If you want to inject RTCM corrections to both GPS1 and GPS2 then use:
 
 - :ref:`GPS_INJECT_TO<GPS_INJECT_TO>` = 127 (send to all)
@@ -53,9 +56,10 @@ If a single unit with two antennas is used please set the following parameters:
 
 See the :ref:`Antenna Offsets<antenna-offsets>` section for a diagram illustrating the directions of these offsets.
 
-Note that the yaw calculation requires the GPS have an RTK fixed lock and the yaw calculation is only correct while the vehicle is upright so it should not be used on vehicle that spend significant time at extreme lean angles (e.g tail sitters).
+Note that the yaw calculation is only correct while the vehicle is upright,
+so it should not be used on vehicle that spend significant time at extreme lean angles (e.g tail sitters).
 
-Video including setup instructions
-==================================
+RTK setup with Mission Planner and Septentrio AsteRx-m rover
+============================================================
 ..  youtube:: HWJnG3tu9iM
     :width: 100%

--- a/common/source/docs/common-positioning-landing-page.rst
+++ b/common/source/docs/common-positioning-landing-page.rst
@@ -72,7 +72,7 @@ These GPS can incorporate real time kinematic data, either internally generated 
     LOCOSYS HAWK R1 RTK GNSS / R2 RTK GNSS + Compass<common-gps-locosys>
     Qiotek DroneCAN RTK-F9P GPS <https://www.qio-tek.com/index.php/product/qiotek-zed-f9p-rtk-and-compass-dronecan-module>
     Swift Navigation's Piksi Multi RTK GPS Receiver <common-piksi-multi-rtk-receiver>
-    Septentrio AsteRx-mUAS RTK GPS <common-gps-septentrio>
+    Septentrio AsteRx-m UAS RTK GPS <common-gps-septentrio>
     Synerx MDU-2000 RTK + LTE GPS <common-synerex-mdu-2000>
     Trimble BD930 RTK GNSS <common-gps-trimble-bd930>
     Trimble PX-1 RTX GNSS+INS <common-gps-trimble-px1>


### PR DESCRIPTION
This fixes an incorrect statement in the Septentrio documentation about the requirement of an RTK fix for dual-antenna heading (tested and RTK fix is not required). This also adds some information about the `GPS_RATE_MS` and `GPS_RATE_MS2` parameters which currently aren't used by the SBF driver, but are still required for correct position calculation. Some typos and unclear documentation were also fixed.