### PR TITLE
Update warning for centimeters on fly-by-wire-low-altitude-limit.rst

### DIFF
--- a/plane/source/docs/fly-by-wire-low-altitude-limit.rst
+++ b/plane/source/docs/fly-by-wire-low-altitude-limit.rst
@@ -14,8 +14,6 @@ it is reached you will regain altitude control.
 
 .. note:: the minimum MSL altitude target will be the higher of: this altitude, or the current altitude target above terrain in FBWB or CRUISE modes if :ref:`common-terrain-following` is enabled, or the :ref:`FENCE_ALT_MIN<FENCE_ALT_MIN>` above HOME if that fence (See :ref:`common-geofencing-landing-page`) is enabled.
 
-.. warning:: this parameter is in centimeters, not meters!
-
 Use for R/C training
 ====================
 


### PR DESCRIPTION
Fix warning that is no longer correct since parameter rework in 4.5.0 CRUISE_ALT_FLOOR is now in meters.