### PR TITLE
Common: ModalAI VOXL page gets links to optflow+rangefinder transition applet

### DIFF
--- a/common/source/docs/common-modalai-voxl.rst
+++ b/common/source/docs/common-modalai-voxl.rst
@@ -56,6 +56,7 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 - Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to disable the camera's odometry messages from being sent to the GCS
 - :ref:`VISO_TYPE <VISO_TYPE>` = 3 (VOXL)
 - Set :ref:`VISO_POS_X <VISO_POS_X>`, :ref:`VISO_POS_Y <VISO_POS_Y>`, :ref:`VISO_POS_Z <VISO_POS_Z>` to the camera's position on the drone relative to the center-of-gravity.  See :ref:`sensor position offset compensation <common-sensor-offset-compensation>` for more details
+- Optionally increase :ref:`VISO_QUAL_MIN <VISO_QUAL_MIN>` to 10 (or higher) to only consume estimates from the camera when the quality is 10% (or higher)
 
 If only the VOXL camera will be used for position estimation and heading (e.g. No GPS):
 
@@ -85,6 +86,8 @@ For indoor/outdoor transitions (e.g. VOXL camera indoors, GPS+Compass outdoors):
 After the parameters are modified, reboot the autopilot.
 
 More details on :ref:`GPS/Non-GPS Transitions can be found here <common-non-gps-to-gps>`
+
+To use an optical flow and rangefinder for backup in case the VOXL fails, a Lua applet for `ExternalNav/Optical flow transitions is here <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/ahrs-source-extnav-optflow.lua>`__
 
 Videos
 ------

--- a/dev/source/docs/adding_simulated_devices.rst
+++ b/dev/source/docs/adding_simulated_devices.rst
@@ -184,10 +184,6 @@ You can test two virtual wheel encoders like this:
 
 ::
 
-    param set AHRS_EKF_TYPE 3
-    param set EK2_ENABLE 0
-    param set EK3_ENABLE 1
-    param fetch
     param set EK3_SRC1_POSXY 0
     param set EK3_SRC1_VELXY 7
     param set EK3_SRC1_VELZ 0
@@ -208,10 +204,6 @@ You can test a virtual range beacons by setting the following parameters
 
 ::
 
-    param set AHRS_EKF_TYPE 3
-    param set EK2_ENABLE 0
-    param set EK3_ENABLE 1
-    param fetch
     param set EK3_GPS_TYPE 3
     param set GPS_TYPE 0
     param set BCN_TYPE 10
@@ -287,10 +279,6 @@ Enable EKF3, disable GPS and set Serial5 protocol to mavlink so as to accept vis
 
 ::
 
-    param set AHRS_EKF_TYPE 3
-    param set EK2_ENABLE 0
-    param set EK3_ENABLE 1
-    param fetch
     param set EK3_SRC1_POSXY 6
     param set EK3_SRC1_POSZ 6
     param set EK3_SRC1_VELXY 6


### PR DESCRIPTION
This updates the ModalAI wiki page to include changes in PR https://github.com/ArduPilot/ardupilot/pull/26277 which is included in Copter-4.5.0-beta3.  The changes include:

- explanation of the VISO_QUAL_MIN parameter
- link to a new Lua applet that automatically switches to optical flow + rangefinder if the ModalAI fails

I've also included a bit of a drive-by change to the developer wiki to remove some references to EKF2.  EKF3 has been the default for quite some time now so I don't think we need to mention EKF2 anymore.

I've tested these changes locally and they look OK to me.