### PR TITLE
Common: modalai gets optional SR2_EXTRA3 setting

### DIFF
--- a/common/source/docs/common-modalai-voxl.rst
+++ b/common/source/docs/common-modalai-voxl.rst
@@ -54,6 +54,7 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 2 (MAVLink2).  Note this assumes the camera is connected to the autopilot's "Telem2" port.
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 921 (921600 baud)
 - Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to disable the camera's odometry messages from being sent to the GCS
+- Optionally set :ref:`SR2_EXTRA3 <SR2_EXTRA3>` = 0 to disable sending the SYSTEM_TIME message to the camera which has been known to cause the camera to lose its position estimate (e.g. quality falls to -1).  Note this assumes the camera is connected to the autopilot's second mavlink port (e.g. Telem2)
 - :ref:`VISO_TYPE <VISO_TYPE>` = 3 (VOXL)
 - Set :ref:`VISO_POS_X <VISO_POS_X>`, :ref:`VISO_POS_Y <VISO_POS_Y>`, :ref:`VISO_POS_Z <VISO_POS_Z>` to the camera's position on the drone relative to the center-of-gravity.  See :ref:`sensor position offset compensation <common-sensor-offset-compensation>` for more details
 - Optionally increase :ref:`VISO_QUAL_MIN <VISO_QUAL_MIN>` to 10 (or higher) to only consume estimates from the camera when the quality is 10% (or higher)

--- a/common/source/docs/common-modalai-voxl.rst
+++ b/common/source/docs/common-modalai-voxl.rst
@@ -54,7 +54,7 @@ Connect to the autopilot with a ground station (i.e. Mission Planner) and check 
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 2 (MAVLink2).  Note this assumes the camera is connected to the autopilot's "Telem2" port.
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 921 (921600 baud)
 - Optionally set :ref:`SERIAL2_OPTIONS <SERIAL2_OPTIONS>` = 1024 (Don't forward mavlink to/from) to disable the camera's odometry messages from being sent to the GCS
-- Optionally set :ref:`SR2_EXTRA3 <SR2_EXTRA3>` = 0 to disable sending the SYSTEM_TIME message to the camera which has been known to cause the camera to lose its position estimate (e.g. quality falls to -1).  Note this assumes the camera is connected to the autopilot's second mavlink port (e.g. Telem2)
+- Optionally set :ref:`SR2_EXTRA3 <SR2_EXTRA3>` = 0 to disable sending the SYSTEM_TIME message to the camera which has been known to cause the camera to lose its position estimate (e.g. quality falls to -1).  Note this assumes the camera is connected to the autopilot's second mavlink port (e.g. usually Telem2)
 - :ref:`VISO_TYPE <VISO_TYPE>` = 3 (VOXL)
 - Set :ref:`VISO_POS_X <VISO_POS_X>`, :ref:`VISO_POS_Y <VISO_POS_Y>`, :ref:`VISO_POS_Z <VISO_POS_Z>` to the camera's position on the drone relative to the center-of-gravity.  See :ref:`sensor position offset compensation <common-sensor-offset-compensation>` for more details
 - Optionally increase :ref:`VISO_QUAL_MIN <VISO_QUAL_MIN>` to 10 (or higher) to only consume estimates from the camera when the quality is 10% (or higher)


### PR DESCRIPTION
This adds a workaround to an obscure issue with the ModalAI camera's processing of the [SYSTEM_TIME message](https://mavlink.io/en/messages/common.html#SYSTEM_TIME).

It seems that the camera loses its position estimate after about a minute if sent a stream of SYSTEM_TIME messages where the "time_unix_usec" field is zero but the "time_boot_ms" field is non-zero.  The easiest workaround for now is to ensure that the SRx_EXTRA3 parameter is set to zero so the message is not sent to the camera at all.

I've also reported this to ModalAI and hopefully they can figure out the cause.

I've tested this locally and it looks OK.