### PR TITLE
Microstrain7 data rates

### DIFF
--- a/common/source/docs/common-external-ahrs.rst
+++ b/common/source/docs/common-external-ahrs.rst
@@ -27,6 +27,7 @@ VectorNav300 or MicroStrain
 
 This will replace ArduPilot’s internally generated INS/AHRS subsystems with the external system.
 The MicroStrain system must be configured via `Sensor Connect <https://www.microstrain.com/software/sensorconnect>`__ before use.
+See the below section on data rates.
 
 VN-300 Specific setup
 ~~~~~~~~~~~~~~~~~~~~~
@@ -49,3 +50,59 @@ VectorNav100
 This will replace ArduPilot's internally generated INS/AHRS subsystems with the external system.
 
 In addition, instead of replacing ArduPilot's INS/AHRS systems, it is possible to use an external AHRS system's sensors (IMU,GPS, Compass, and Barometer) as additional sensors for use with ArduPilot's INS/AHRS systems. Simply do not change the :ref:`AHRS_EKF_TYPE<AHRS_EKF_TYPE>` from "3" (EKF3), but setup the others parameters as discussed above.
+
+
+MicroStrain7
+------------
+
+The 3DM-GQ7 supports up to 230k baud on the 3.3V TTL serial interface.
+The RS-232 interface supports higher baud rates, but most autopilots do not come with RS-232 interfaces.
+
+To use the 3DM-GQ7 with 230k baud in ArduPilot, set the following data rates in SensorConnect.
+
+* IMU
+
+  * Enable the Time Field at 50Hz
+
+  * Scaled Ambient Pressure: 50Hz
+
+  * Magnetometer Vector: 50Hz
+
+  * Accelerometer Vector: 50Hz
+
+  * Gyroscope Vector: 50Hz
+
+  * Attitude (Quaternion): 50Hz
+
+* GNSS Receiver 1 and 2
+
+  * Enable the Time Field at 2Hz
+
+  * UTC Time: 2Hz
+
+  * GPS Fix Information: 2Hz
+
+  * Position (LLH): 2Hz
+
+  * DOP Data: 2Hz
+
+  * Velocity (NED): 2Hz
+
+* Estimation Filter
+
+  * Position (LLH): 50Hz
+
+  * Filter Status: 50Hz
+
+  * Velocity (NED): 50Hz
+
+  * Attitude (Quaternion): 50Hz
+
+  * Position Uncertainty (LLH): 50Hz
+
+  * Velocity Uncertainty (NED): 50Hz
+
+This rates work well for platforms that run the EKF at 50Hz, such as Plane, Sub, Blimp.
+MicroStrain hardware and firmware for higher baud rates than 230k is in development.
+With higher baud rates, MicroStrain7 should be suitable for Copter and QuadPlane.
+


### PR DESCRIPTION
Here's the wiki to accompany the release of GQ7 support; this lets users know how to configure the data rates.
I tested these on a 3DM-QG7 with what's merged to `master`.

In a future release of ArduPilot, these may be configured automatically by the driver.

Here's the duty usage on the serial line. 4.19mS at minimum between packet groups, with 230k baud rate.
![image](https://github.com/ArduPilot/ardupilot_wiki/assets/25047695/b301a5cb-c52a-4570-a8ed-f888a7d22c24)

