### PR TITLE
Common: Document CUAV PW-LINK IP Address for MAVProxy usage

### DIFF
--- a/common/source/docs/common-cuav-pwlink.rst
+++ b/common/source/docs/common-cuav-pwlink.rst
@@ -17,3 +17,14 @@ Connecting to the Ground Station
 ================================
 
 Open WIFI connection dialog on PC or Android Phone and select the ``CUAVWLINKxxxx`` SSID and connect using the password ``cuavwlink``. Once connected use the UDP connection with port = 14550 (which is default) to connect using Mission Planner. QGC should auto-detect and connect.
+The PW-LINK default IP address is ``192.168.4.1``.
+
+
+MAVProxy
+--------
+
+The following command can be used to connect a MAVProxy ground station to the vehicle.
+
+.. code-block:: bash
+  
+    mavproxy.py --master :14550


### PR DESCRIPTION
Document the address and mavproxy command for the CUAV PW-LINK.

In theory, this should work, but it fails to connect. Perhaps something else is up.