### PR TITLE
Common: Neopixel rewording and add NTF_LED_LEN explanation

### DIFF
--- a/common/source/docs/common-serial-led-neopixel.rst
+++ b/common/source/docs/common-serial-led-neopixel.rst
@@ -9,7 +9,7 @@ A "NeoPixel" style (WS2812B compatible) RGB LED can be attached to any PWM outpu
 
 If used for notification purposes, be sure to set :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` "Neopixel" bit(8).
 
-.. note:: a few "NeoPixel" LED types have a different data order for the red and green data instead of the normal green/red/blue orde. If you are not displaying the desired colors, try setting the ref:`NTF_LED_TYPES<NTF_LED_TYPES>` parameter to ``NeoPixelRGB`` tpe instead.
+.. note:: a few "NeoPixel" LED types have a different data order for the red and green data instead of the normal green/red/blue orde. If you are not displaying the desired colors, try setting the :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` parameter to ``NeoPixelRGB`` tpe instead.
 
 .. warning:: Most WS2812 style LED and strings will operate correctly when connected to the autopilot. However, if you get intermittent or non-operation, you may need to implement one of the configurations below. This is due to the fact that the autopilot outputs swing to 3.3V but the worst case input signal high spec for the LED is 4.3V at a 5V supply. So at extremes of tolerance/manufacturing spec, you can get a combination which will not work correctly. In that case the easiest solution is to lower the LED supply as shown below.
 

--- a/common/source/docs/common-serial-led-neopixel.rst
+++ b/common/source/docs/common-serial-led-neopixel.rst
@@ -5,9 +5,13 @@ NeoPixel
 
 .. image:: ../../../images/neopixel-string.jpeg
 
-A "NeoPixel" style (WS2812B compatible) RGB LED can be attached to any PWM output by setting its SERVOx_FUNCTION to one of the ``NeoPixelx`` output functions and setting :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` parameter to ``NeoPixel``. Multiple ``NeoPixelx`` output functions are provided for connecting multiple strings (up to 4).
+Up to four strings of "NeoPixel" style (WS2812B compatible) RGB LEDs can be used to display the same LED patterns as other RGB LEDs including those commonly installed on GPS/compass units.  Each string can have multiple LEDs with the maximum number dependent upon the autopilot's CPU speed.  On a high speed autopilot with an H7 processor, up to 44 individual LEDs per string are known to work.
 
-If used for notification purposes, be sure to set :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` "Neopixel" bit(8).
+Attach each LED to a separate PWM output and set the following parameters
+
+- Set :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` to include ``NeoPixel`` (bit 8)
+- Set :ref:`NTF_LED_LEN<NTF_LED_LEN>` to the number of LEDs connected to a servo output (up to 4)
+- Set SERVOx_FUNCTION to ``NeoPixel1``, ``NeoPixel2``, ``NeoPixel3`` or ``NeoPixel4`` where "x" corresponds to the PWM output channel that the LED is connected to
 
 .. note:: a few "NeoPixel" LED types have a different data order for the red and green data instead of the normal green/red/blue orde. If you are not displaying the desired colors, try setting the :ref:`NTF_LED_TYPES<NTF_LED_TYPES>` parameter to ``NeoPixelRGB`` tpe instead.
 


### PR DESCRIPTION
This includes two changes:

1. fix a broken link for a parameter
2. mention the NTF_LED_LEN parameter must be set if multiple NeoPixel LEDs are attached
3. re-organise the wording so that the parameter changes appear in a list instead of all in a single paragraph.  I think this makes it easier to read

I've tested this locally and it looks OK to me.

Maybe @andyp1per should review this because I think he knows more about these LEDs than I do.  I've actually never used them before today.