### PR TITLE
ADS-B: Removed dead link to uav-store.de

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -25,7 +25,6 @@ The sensors can be purchased directly from `uAvionix <https://uavionix.com/produ
    -  USA: `Unmanned Systems Source <https://www.unmannedsystemssource.com/shop/atc-devices/pingrx-ads-b-receiver/>`__
    -       `R Cubed Engineering <http://www.rcubedengineering.com/ecommerce/>`__
    -  U.K.: `Unmanned Tech <http://www.unmannedtech.co.uk/>`__
-   -  Germany: `UAV Store <http://www.uav-store.de/ads-b-receivers/>`__
 
 Connecting to the autopilot
 ===========================


### PR DESCRIPTION
ADS-B: Removed dead link to uav-store.de. Domain has been killed.