### PR TITLE
ADS-B Extlinks: Fixed links and removed dead link uav-store.de

### DIFF
--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -22,8 +22,8 @@ Required Hardware
 
 The sensors can be purchased directly from `uAvionix <https://uavionix.com/products/>`__ or `Sagetech <https://sagetech.com/>`__ or from the following distributors:
 
-   -  USA: `Unmanned Systems Source <https://www.unmannedsystemssource.com/shop/atc-devices/pingrx-ads-b-receiver/>`__
-   -       `R Cubed Engineering <http://www.rcubedengineering.com/ecommerce/>`__
+   -  USA: `Unmanned Systems Source <https://www.unmannedsystemssource.com/product-category/atc-devices/>`__
+   -       `R Cubed Engineering <http://www.rcubedengineering.com/>`__
    -  U.K.: `Unmanned Tech <http://www.unmannedtech.co.uk/>`__
    -  Germany: `UAV Store <http://www.uav-store.de/ads-b-receivers/>`__
 

--- a/common/source/docs/common-ads-b-receiver.rst
+++ b/common/source/docs/common-ads-b-receiver.rst
@@ -25,7 +25,7 @@ The sensors can be purchased directly from `uAvionix <https://uavionix.com/produ
    -  USA: `Unmanned Systems Source <https://www.unmannedsystemssource.com/product-category/atc-devices/>`__
    -       `R Cubed Engineering <http://www.rcubedengineering.com/>`__
    -  U.K.: `Unmanned Tech <http://www.unmannedtech.co.uk/>`__
-   -  Germany: `UAV Store <http://www.uav-store.de/ads-b-receivers/>`__
+
 
 Connecting to the autopilot
 ===========================


### PR DESCRIPTION
ADS-B Extlinks: Fixed links and removed dead link uav-store.de. 

Small fixes to other stores and removed dead uav-store.de. Domain killed.