### PR TITLE
Common: RTF page update

### DIFF
--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -66,7 +66,6 @@ VTOL/QuadPlanes from Partners
 Rovers from Partners
 ====================
 
-* `AION ROBOTICS - R1 UGV <https://www.aionrobotics.com/r1>`__
 * `AION ROBOTICS - R6 UGV <https://www.aionrobotics.com/r6>`__
 * `AION ROBOTICS - M6 UGV <https://www.aionrobotics.com/m6-commercial-ugv>`__
 * `TT Robotix - Rhino 6x6 <http://www.ttrobotix.com/products/detail/906.html>`__

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -73,6 +73,11 @@ Rovers from Partners
 * `TT Robotix - Rhino 6x6 <http://www.ttrobotix.com/products/detail/906.html>`__
 * `TT Robotix - Base 1 Rover <http://www.ttrobotix.com/products/detail/907.html>`__
 
+Boats from Partners
+===================
+
+* `BlueRobotics BlueBoat <https://bluerobotics.com/store/boat/blueboat/blueboat/>`__
+
 Subs from Partners
 ==================
 

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -20,7 +20,6 @@ Copters from Partners
 * `Hitec - SUI Endurance <https://hitecnology.com/drones/sui-endurance-multipurpose-professional-multirotor>`__
 * `Holybro - S500 V2 Kit <https://shop.holybro.com/s500-v2-kitmotor2216-880kv-propeller1045_p1153.html>`__
 * `Holybro - X500 Kit <https://shop.holybro.com/x500-kit_p1180.html>`__
-* `SkyRocket - Journey <http://sky-viper.com/journey/>`__
 * `TT Robotix - X-1300 EagleEyes Quadcopter <http://www.ttrobotix.com/products/detail/923.html>`__
 * `TT Robotix - H2-X6 Phoenix H6 Multirotor <http://www.ttrobotix.com/products/detail/926.html>`__
 * `TT Robotix - X-450 Scout Quadcopter <http://www.ttrobotix.com/products/detail/928.html>`__
@@ -90,6 +89,7 @@ Vehicles from Non-Partners
 * `Aton <https://traxxas.com/products/models/heli/Aton-Plus>`__ and `Aton-Plus from traxxas <https://traxxas.com/products/models/heli/Aton-Plus>`__ (firmware loaded using an SD Card)
 * DRONEE  Easy to Use Mapping Plane Drone `DRONEE PLANE <https://dronee.aero/pages/droneeplane>`__
 * `MotoDoro Farm Mapper (Plane) <https://motodoro.com/blog/detail/00005-farm-mapper-vtol.html>`__
+* `SkyRocket - Journey <http://sky-viper.com/journey/>`__
 * `UAV Mapper from TuffWing <http://www.tuffwing.com/products/drone_mapper.html>`__
 * 3DR Solo from `Amazon <https://www.amazon.com/3DR-Solo-Quadcopter-No-Gimbal/dp/B00ZPM7BOG>`__
 * `LP Mini Orca HVTOL Drone <https://lpbond.com/productos/miniorca.html>`__

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -55,6 +55,7 @@ VTOL/QuadPlanes from Partners
 * `Event38 - E455 <https://event38.com/fixed-wing/e455-vtol-drone/>`__
 * `FlyDragonDroneTech - FDG30 <https://www.droneassemble.com/product/vtol-uav-6-hours-endurance-with-1kg-payload-for-survey-serveillance/>`__
 * `FlyDragonDroneTech - FDG50F <https://www.droneassemble.com/product/hybrid-vtol-uav-7-hours-endurance-with-10kgs-payload/>`__
+* :ref:`Holybro Swan-K1 <common-Swan-K1>`
 * :ref:`MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>`
 * `MakeFLyEasy - Freeman 2300 <https://www.aliexpress.com/item/10000223137957.html?spm=a2g0o.store_home.productList_1076398524.pic_3>`__
 * `MakeFLyEasy - Freeman 2100 <https://www.aliexpress.com/item/10000223137957.html?spm=a2g0o.store_home.productList_1076398524.pic_2>`__
@@ -62,7 +63,6 @@ VTOL/QuadPlanes from Partners
 * `SpektreWorks - Cobalt 55 E-VTOL <https://www.spektreworks.com/cobalt>`__
 * `SpektreWorks - Cobalt 55 G-VTOL <https://www.spektreworks.com/cobalt>`__
 * `SpektreWorks - Cobalt 110 G-VTOL <https://www.spektreworks.com/cobalt>`__  
-*  :ref:`Swan-K1 <common-Swan-K1>`
 
 Rovers from Partners
 ====================


### PR DESCRIPTION
This updates our [RTF page](https://ardupilot.org/rover/docs/common-rtf.html) with the following changes:

- SkyRocket Journey moved to Non-partner vehicles area
- BlueRobitcs BlueBoat is added
- Swan-K1 gets "Holybro" at the beginning to clarify the company
- Removed AION R1 which is no longer available

This has been tested locally and looks OK to me.

FYI @rishabsingh3003 