### PR TITLE
Common: optical flow updates

### DIFF
--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -150,20 +150,6 @@ and leave all other options checked.
 .. image:: ../../../images/OptFlow_ArmingChecks.png
     :target: ../_images/OptFlow_ArmingChecks.png
 
-Because optical flow requires good sonar/range finder data when the
-optical flow is enabled, an additional pre-arm check is enforced.
-
-[site wiki="plane,copter"]
-**While the vehicle is disarmed you should lift the vehicle straight up
-to at least 50cm but no higher than 2m** (if the rangefinder sees a
-distance of over 2m you will need to restart the autopilot).
-
-The error message when arming fails this check is "PreArm: check range
-finder"
-
-This check can be disabled by unchecking the "Parameter/Sonar" arming
-check.
-
 First Flight
 ============
 

--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -14,8 +14,72 @@ With the sensor connected to the autopilot, connect to the autopilot with the Mi
 .. image:: ../../../images/PX4Flow_CheckForData_MP.png
     :target: ../_images/PX4Flow_CheckForData_MP.png
 
-Calibrating the sensor
-======================
+Inflight Calibration
+====================
+
+..  youtube:: Crx97v1bwWo
+    :width: 100%
+
+If the vehicle has a GPS, the inflight calibration procedures is the easiest way to get a good calibration:
+
+- Set :ref:`RCx_OPTION <RC8_OPTION>` = 158 (Optflow Calibration) to allow starting the calibration from an :ref:`auxiliary switch <common-auxiliary-functions>`
+- Setup the EKF3 to use GPS (the default)
+
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+- Fly the vehicle in Loiter mode to at least 10m (higher is better but stay within the limits of the rangefinder)
+- Pull the auxiliary switch high to start the calibration
+- Use the roll and pitch sticks to rock the vehicle back and forth in both roll and pitch
+- Check the GCS "Messages" tab for output like below confirming the calibration is complete
+
+::
+
+   FlowCal: Started
+   FlowCal: x:0% y:0%
+   FlowCal: x:66% y:6%
+   FlowCal: x:100% y:74%
+   FlowCal: samples collected
+   FlowCal: scalarx:0.976 fit: 0.10   <-- lower "fit" values are better
+   FlowCal: scalary:0.858 fit: 0.04
+   FlowCal: FLOW_FXSCALER=30.00000, FLOW_FYSCALER=171.0000
+
+- Land the vehicle and setup the EKF3 to use OpticalFlow
+
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 (None)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 0 (None)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+- Fly the vehicle again to check performance
+
+An alternative method which avoids the need to land and change EKF3 parameters between calibration and testing is to setup :ref:`GPS/Non-GPS transitions <common-non-gps-to-gps>` so the pilot can manually change between GPS and Optical Flow inflight.  The full parameter list is below assuming the pilot will engage the calibration using RC input 8 (a 2-position switch) and switch between GPS and Optical flow using RC input 9 (a 3-position switch)
+
+  - :ref:`RC8_OPTION <RC8_OPTION>` = 158 (Optflow Calibration)
+  - :ref:`RC9_OPTION <RC9_OPTION>` = 90 (EKF Pos Source) low is GPS, middle is OpticalFlow, high is unused
+  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
+  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
+  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC2_POSXY <EK3_SRC1_POSXY>` = 0 (None)
+  - :ref:`EK3_SRC2_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
+  - :ref:`EK3_SRC2_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
+  - :ref:`EK3_SRC2_VELZ <EK3_SRC1_VELZ>` = 0 (None)
+  - :ref:`EK3_SRC2_YAW <EK3_SRC1_YAW>` = 1 (Compass)
+  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
+
+Log based Calibration
+=====================
+
+To calibrate the sensor using Log file data please follow these steps:
+
 #. Connect to your autopilot and ensure that logging while disarmed is enabled by setting :ref:`LOG_DISARMED <copter:LOG_DISARMED>` to 1
 [site wiki="rover"]
 #. Ensure the :ref:`FLOW_HGT_OVR <rover:FLOW_HGT_OVR>` parameter is set to the height of the sensor above ground
@@ -153,73 +217,4 @@ Example Video (Copter-3.4)
 ..  youtube:: Bzgey8iR69Q
     :width: 100%
 
----------------------------------
-
-
-Inflight Calibration
-====================
-
-Copter-4.2.0 includes an inflight calibration procedure:
-
-- Set :ref:`RCx_OPTION <RC8_OPTION>` = 158 (Optflow Calibration) to allow starting the calibration from an :ref:`auxiliary switch <common-auxiliary-functions>`
-- Setup the EKF3 to use GPS (the default)
-
-  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
-  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
-  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
-  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
-  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
-  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
-
-- Fly the vehicle in Loiter mode to at least 10m (higher is better but stay within the limits of the rangefinder)
-- Pull the auxiliary switch high to start the calibration
-- Use the roll and pitch sticks to rock the vehicle back and forth in both roll and pitch
-- Check the GCS "Messages" tab for output like below confirming the calibration is complete
-
-::
-
-   FlowCal: Started
-   FlowCal: x:0% y:0%
-   FlowCal: x:66% y:6%
-   FlowCal: x:100% y:74%
-   FlowCal: samples collected
-   FlowCal: scalarx:0.976 fit: 0.10   <-- lower "fit" values are better
-   FlowCal: scalary:0.858 fit: 0.04
-   FlowCal: FLOW_FXSCALER=30.00000, FLOW_FYSCALER=171.0000
-
-- Land the vehicle and setup the EKF3 to use OpticalFlow
-
-  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 (None)
-  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
-  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
-  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 0 (None)
-  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
-  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
-
-- Fly the vehicle again to check performance
-
-An alternative method which avoids the need to land and change EKF3 parameters between calibration and testing is to setup :ref:`GPS/Non-GPS transitions <common-non-gps-to-gps>` so the pilot can manually change between GPS and Optical Flow inflight.  The full parameter list is below assuming the pilot will engage the calibration using RC input 8 (a 2-position switch) and switch between GPS and Optical flow using RC input 9 (a 3-position switch)
-
-  - :ref:`RC8_OPTION <RC8_OPTION>` = 158 (Optflow Calibration)
-  - :ref:`RC9_OPTION <RC9_OPTION>` = 90 (EKF Pos Source) low is GPS, middle is OpticalFlow, high is unused
-  - :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (GPS)
-  - :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
-  - :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 3 (GPS)
-  - :ref:`EK3_SRC1_VELZ <EK3_SRC1_VELZ>` = 3 (GPS)
-  - :ref:`EK3_SRC1_YAW <EK3_SRC1_YAW>` = 1 (Compass)
-  - :ref:`EK3_SRC2_POSXY <EK3_SRC1_POSXY>` = 0 (None)
-  - :ref:`EK3_SRC2_VELXY <EK3_SRC1_VELXY>` = 5 (Optical Flow)
-  - :ref:`EK3_SRC2_POSZ <EK3_SRC1_POSZ>` = 1 (Baro)
-  - :ref:`EK3_SRC2_VELZ <EK3_SRC1_VELZ>` = 0 (None)
-  - :ref:`EK3_SRC2_YAW <EK3_SRC1_YAW>` = 1 (Compass)
-  - :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 (Disable FuseAllVelocities)
-
-
-
-.. note::
-
-   To use the inflight calibration EKF3 must be enabled.  This is the default for ArduPilot 4.1 and higher
-
-..  youtube:: Crx97v1bwWo
-    :width: 100%
 [/site]

--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -103,7 +103,7 @@ check.
 First Flight
 ============
 
-#. For EKF2, set :ref:`EK2_GPS_TYPE <EK2_GPS_TYPE>` = 0; for EKF3, set :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 0 (we don't want the optical flow being used by the EKF at this stage) 
+#. Set :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 0 (we don't want the optical flow being used by the EKF at this stage) 
 #. Perform a short test flight hovering in STABILIZE or AltHold for copter, or QSTABILIZE or QHOVER for QuadPlane, at small lean angles at heights ranging from 50cm to 3m with 
 #. Download the flash log and plot the following in mission planner
 #. EKF5.meaRng should correlate with the change in vehicle height
@@ -118,7 +118,7 @@ Second Flight
    You will need at least 15m of clear space around the vehicle to do this flight safely.
    If the optical flow velocity estimates are bad, you will have little warning and the copter may lean to its maximum lean angle very quickly.
 
-#. For EKF2, set :ref:`EK2_GPS_TYPE <EK2_GPS_TYPE>` = 3; for EKF3, set :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 and :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 to make the EKF ignore GPS and use the flow sensor
+#. Set :ref:`EK3_SRC1_VELXY <EK3_SRC1_VELXY>` = 5 and :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 0 to make the EKF ignore GPS and use the flow sensor
 #. Ensure you have a loiter and hover mode available on you transmitter.
 #. Set "EKF Origin" on Ground Control Station map. In Mission Planner, right click, select "Set Home here", and choose to set "set EKF origin here".
 #. Take-off in loiter and bring the Copter/QuadPlane to about 1m height
@@ -134,21 +134,6 @@ Second Flight
 Setup for Normal Operation
 ==========================
 
-For EKF2:
----------
-
-#. Verify that :ref:`EK2_ENABLE <EK2_ENABLE>` = 1, enabling EKF2
-#. Set :ref:`EK2_FLOW_DELAY <EK2_FLOW_DELAY>` depending on your optical flow sensor
-#. To only use the optical flow sensor and not use the GPS, set :ref:`EK2_GPS_TYPE <EK2_GPS_TYPE>` = 3; to use the GPS with the optical flow sensor, set this to 0.
-
-For EKF3:
----------
-.. note::
-
-   EKF3 is enabled and used by default in ArduPilot firmware 4.1 and higher
-
-#. Verify that :ref:`EK3_ENABLE <EK3_ENABLE>` = 1, enabling EKF3
-#. Set :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` = 3 to use EKF3
 #. Set :ref:`EK3_SRC_OPTIONS <EK3_SRC_OPTIONS>` = 0 to disable FuseAllVelocities
 #. Set :ref:`EK3_FLOW_DELAY <EK3_FLOW_DELAY>` depending on your optical flow sensor
 #. Set :ref:`EK3_SRC1_POSXY <EK3_SRC1_POSXY>` = 3 (Primary horizontal position from GPS, set this to 0 to only use the optical flow sensor)


### PR DESCRIPTION
This makes a few changes to the optical setup page:

1. remove old references to the EKF2.  4.2 and higher used the EKF3 so the vast majority of users will be on EKF3 now and so we simply things by removing EKF2
2. Inflight calibration is moved to the stop.  This has been available since 4.1 and is the easiest and best way to get an accurate calibration
3. removed out-of-date pre-arm check information.  We no longer have the 2m rangefinder check.

I've tested this locally and it looks OK to me.