### PR TITLE
Common: update EKF source switching to include POSZ explanation

### DIFF
--- a/common/source/docs/common-ekf-sources.rst
+++ b/common/source/docs/common-ekf-sources.rst
@@ -12,7 +12,17 @@ The EKF position and velocity sources used for its internal updates can be set u
 - :ref:`EK3_SRC1_VELZ<EK3_SRC1_VELZ>`: Velocity Vertical Source
 - :ref:`EK3_SRC1_YAW<EK3_SRC1_YAW>`: Yaw Source
 
-The options for these are generally self-explanatory. However, the :ref:`EK3_SRC1_YAW<EK3_SRC1_YAW>`  source options need a bit more explanation:
+The options for these are generally self-explanatory however a couple of items are explained in more detail below
+
+The :ref:`EK3_SRC1_POSZ<EK3_SRC1_POSZ>` source options are:
+
+- Option 1: Baro is the default and works well for most vehicles and situations.  If a GPS is also present the EKF may be configured to slowly correct the altitude to match the GPS by setting :ref:`EK3_OGN_HGT_MASK <EK3_OGN_HGT_MASK>` to 5 (e.g. 1:Correct when using Baro height + 4:Apply corrections to local position).
+- Option 2: RangeFinder should almost never be used.  This is only appropriate for indoor use where the floor is flat with no ground clutter (e.g. no chairs, boxes, etc).  Please note that :ref:`Surface Tracking <copter:terrain-following-manual-modes>` and :ref:`Terrain Following <terrain-following>` do not require the EKF to use the rangefinder at all
+- Option 3: GPS is only recommended if the vehicle will fly long duration flights where the air pressure may change significantly **and** the vehicle has a high quality GPS (e.g. UBlox F9P dual band).  In case of GPS failure the EKF will fallback to using the barometer (if present)
+- Option 4: Beacon may be useful when beacons are used in place of a GPS
+- Option 6: ExternalNav may be used when a companion device provides a position estimate
+
+The :ref:`EK3_SRC1_YAW<EK3_SRC1_YAW>` source options are:
 
 - Option 1: Compass is the normal default.
 - Option 2: GPS is used with GPS that can supply yaw (see :ref:`common-gps-for-yaw`)
@@ -23,7 +33,11 @@ The options for these are generally self-explanatory. However, the :ref:`EK3_SRC
 Source Switching
 ================
 
-Three set of EKF position and velocity source parameters are provided which can be selected via an :ref:`RC switch RCx_OPTION <common-auxiliary-functions>` set to "90". Otherwise, the _SRC1 set is used.
+Three sets of EKF position and velocity source parameters are provided and by default the 1st set is used (e.g. the _SRC1 set).
+
+The active set can be selected via an :ref:`RC auxiliary switch <common-auxiliary-functions>` (e.g. set ``RCx_OPTION`` to "90" / "EKF Position Source").
+
+Ground stations or companion computers may set the source by sending a `MAV_CMD_SET_EKF_SOURCE_SET  <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_SET_EKF_SOURCE_SET>`__ mavlink command but no GCSs are currently known to implement this.
 
 This feature is especially helpful when using :ref:`common-non-gps-to-gps`.
 

--- a/common/source/docs/common-understanding-altitude.rst
+++ b/common/source/docs/common-understanding-altitude.rst
@@ -61,7 +61,7 @@ If the vehicle is moved over a ground object 1m tall. The Estimated ALT will rem
 
 If the RF's measurements change too rapidly (>2m for 3 reports), or the RF moves out of range, then they will be ignored and current altitude from the Estimated ALT set as new Target ALT. This prevents rapid climbs/descents with fast moving RF data. It also means that tracking requiring large,rapid changes, such as quickly approaching a tall object, will result in a possible impact. See :ref:`Object Avoidance <common-object-avoidance-landing-page>` in those cases.
 
-This is called ``Surface Tracking`` in ArduPilot.
+This is called :ref:`Surface Tracking <copter:terrain-following-manual-modes>` in ArduPilot.
 
 Optionally (normally recommended only for indoor use), the RF can be used as an additional sensor source for the EKF for altitude estimation. This is normally only used when the only altitude sensor available is a RF, since they have very limited range and more subject to environmental impacts to accuracy.
 

--- a/copter/source/docs/additional-information.rst
+++ b/copter/source/docs/additional-information.rst
@@ -9,6 +9,7 @@ Additional Information and Topics of Interest
     :maxdepth: 1
 
     Upcoming Features <common-master-features>
+    Reference Frames <reference-frames>
     Ready to Fly/Use Vehicles <common-rtf>
     Antenna Tracking <common-antenna-tracking>
     Simulation <common-simulation>

--- a/copter/source/docs/terrain-following-manual-modes.rst
+++ b/copter/source/docs/terrain-following-manual-modes.rst
@@ -24,9 +24,9 @@ Setup and Configuration
 
 .. warning::
 
-    Do not set the :ref:`EK2_ALT_SOURCE <EK2_ALT_SOURCE>` or ``EK3_ALT_SOURCE`` parameters.  These parameters should be left at "0" (barometer).
+    Do not set the :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` to Rangefinder.  This parameter should be left at the default.
 
-    Do not set the :ref:`EK2_RNG_USE_HGT <EK2_RNG_USE_HGT>`  or :ref:`EK3_RNG_USE_HGT <EK3_RNG_USE_HGT>` parameters.  These parameters should be left at "-1".
+    Do not set :ref:`EK3_RNG_USE_HGT <EK3_RNG_USE_HGT>` parameter.  This parameter should be left at "-1".
 
 How does it work?
 -----------------

--- a/copter/source/docs/terrain-following.rst
+++ b/copter/source/docs/terrain-following.rst
@@ -28,9 +28,9 @@ Setting up a Mission to use Terrain data
 
 .. warning::
 
-    Do not set the :ref:`EK2_ALT_SOURCE <EK2_ALT_SOURCE>` or ``EK3_ALT_SOURCE`` parameters.  These parameters should be left at "0" (barometer).
+    Do not set the :ref:`EK3_SRC1_POSZ <EK3_SRC1_POSZ>` to Rangefinder.  This parameter should be left at the default.
 
-    Do not set the :ref:`EK2_RNG_USE_HGT <EK2_RNG_USE_HGT>`  or :ref:`EK3_RNG_USE_HGT <EK3_RNG_USE_HGT>` parameters.  These parameters should be left at "-1".
+    Do not set :ref:`EK3_RNG_USE_HGT <EK3_RNG_USE_HGT>` parameter.  This parameter should be left at "-1".
 
 Sources of Terrain Data
 =======================


### PR DESCRIPTION
This makes a few changes to our EKF source switching page in response to [this support thread](https://discuss.ardupilot.org/t/arkflow-and-z-drop/115549) in which a user ended up changing the EKF_SRC1_POSZ to RangeFinder which is pretty much never a good idea.

I've also included a couple of drive-by changes:

- updated a warning on the Surface Tracking and Terrain Following pages to remove the old EKF2 info and clarify the EKF3 source set parameter involved
- added a link to Surface Tracking from the "Understanding altitudes" page
- added a link to reference frames from the "Additional Info" page to make Copter match Rover

I've tested these locally and they look OK to me.