### PR TITLE
Common: hereflow gets brd-boot-delay setting

### DIFF
--- a/common/source/docs/common-hereflow.rst
+++ b/common/source/docs/common-hereflow.rst
@@ -32,6 +32,7 @@ Connection to Autopilot
 - Set :ref:`FLOW_TYPE <FLOW_TYPE>` = 6 (DroneCAN)
 - Set :ref:`CAN_P1_DRIVER <CAN_P1_DRIVER>` = 1 to enable DroneCAN
 - Set :ref:`CAN_D1_PROTOCOL <CAN_D1_PROTOCOL>` = 1 (DroneCAN)
+- Optionally set :ref:`BRD_BOOT_DELAY <BRD_BOOT_DELAY>` = 3000 (3 seconds) to slow the autopilot's startup which allows the flow sensor to boot up first and avoid initialisation issues
 
 To use the onboard lidar (not recommended):
 


### PR DESCRIPTION
We discovered soon after the 4.5.0 release that some users found the HereFlow sensor was not working with some autopilots and the workaround was to slow the board's boot up time.  This PR adds this advice to the HereFlow wiki page even though it will soon be resolved for at least some boards.

This has been tested locally and looks OK to me.