### PR TITLE
Copter: improve GUID_OPTIONS parameter explanation

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -143,5 +143,6 @@ tuning options for the vehicle.
     Vibration Damping <common-vibration-damping>
 [/site]
 [site wiki="copter"]
+    Weathervaning <weathervaning>
     Windspeed Estimation and Baro Compensation <airspeed-estimation>
 [/site]

--- a/common/source/docs/common-oa-dijkstras.rst
+++ b/common/source/docs/common-oa-dijkstras.rst
@@ -7,7 +7,7 @@ Object Avoidance with Dijkstra's
 ..  youtube:: GAmNaDTzy3Q
     :width: 100%
 
-Copter and Rover 4.0 (and higher) support `Dijkstra's <https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm>`__ for path planning around fences and stay-out zones.  This well known algorithm internally builds up a list of "safe areas" calculated from the fence and stay-out zones and then finds the shortest path to the destination.
+Copter and Rover support `Dijkstra's <https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm>`__ for path planning around fences and stay-out zones in Auto, Guided and RTL modes.  This well known algorithm internally builds up a list of "safe areas" calculated from the fence and stay-out zones and then finds the shortest path to the destination.
 
 .. image:: ../../../images/oa-dijkstras.png
 
@@ -25,6 +25,9 @@ Configuration
 -  :ref:`OA_TYPE <OA_TYPE>` = 2 (Dijkstra).  You may need to refresh parameters after changing this to see the parameters below.
 -  :ref:`OA_MARGIN_MAX <OA_MARGIN_MAX>`: the distance (in meters) that the vehicle should stay away from the fences and stay-out zones
 -  :ref:`OA_OPTIONS<OA_OPTIONS>` bit 2 (+4 to the value) can be set to use S-Curves around fence corners in the planned path to speed up turns. Note that using S-Curves, instead of the normal "approach,stop, turn, proceed" method of path planning around sharp fence corners, could still result in a fence breach.To avoid this :ref:`WPNAV_RADIUS<WPNAV_RADIUS>` should be set smaller than :ref:`FENCE_MARGIN<FENCE_MARGIN>`. Also waypoints should also be placed at least 10m from fence boundaries.
+[site wiki="copter"]
+- For use in :ref:`Guided mode <ac2_guidedmode>`, set :ref:`GUID_OPTIONS<GUID_OPTIONS>` bit 6 (e.g. 64)
+[/site]
 
 Videos
 ------

--- a/copter/source/docs/ac2_guidedmode.rst
+++ b/copter/source/docs/ac2_guidedmode.rst
@@ -16,9 +16,9 @@ Overview
 
 Guided mode is not a traditional flight mode that would be assigned to a
 mode switch like other flight modes. The guided mode capability is
-enabled using a ground station application (such as Mission Planner) and
-telemetry radio (such as a :ref:`SiK Telemetry Radio <common-sik-telemetry-radio>`). 
-This capability allows you to
+enabled using a ground station application (such as Mission Planner) and a
+:ref:`telemetry radio <common-telemetry-landingpage>`. 
+This capability allows the pilot to
 interactively command the copter to travel to a target location by
 clicking on a point on the Mission Planner Flight Data map. Once the
 location is reached, the copter will hover at that location, waiting for
@@ -43,8 +43,7 @@ Instructions
    over wireless telemetry between your copter and your laptop.
 -  On your laptop, using the software that came with the telemetry
    module, make sure that it's working and that you have a GPS lock.
--  Take off in :ref:`Stabilize Mode <stabilize-mode>` and once
-   at a reasonable altitude, switch to Loiter.
+-  Take off in :ref:`Loiter Mode <loiter-mode>` and climb to a safe altitude
 -  In the Mission Planner Flight Data screen map, try right-clicking on
    a nearby spot and select "Fly to Here".
 -  You will be asked for a guided mode altitude. Enter an above home
@@ -78,12 +77,28 @@ Bit 	Meaning
 ===    ==========
 0 	   Allow Arming from Transmitter
 2 	   Ignore pilot yaw input
-3 	   SetAttitudeTarget_ThrustAsThrust 
+3 	   SetAttitudeTarget interprets Thrust As Thrust
+4      Do not stabilize PositionXY
+5      Do not stabilize VelocityXY
+6      Waypoint navigation used for position targets
+7      Allow weathervaning
 ===    ==========
 
-Bit 3 makes interpretation of SET_ATTITUDE_TARGET MAVLink command's ``thrust`` field as pure thrust from 0 to 1 , instead of a climb rate. See `Commands in Guided Mode <https://ardupilot.org/dev/docs/copter-commands-in-guided-mode.html>`__
+Bit 0 (e.g. "1") allowing arming in Guided mode from the RC transmitter
 
-The :ref:GUID_TIMEOUT<GUID_TIMEOUT> parameter holds the timeout (in seconds) when the vehicle is being controlled using attitude, velocity and/or acceleration commands. If no commands are received from the companion computer for this many seconds, the vehicle will slow to a stop (if velocity and/or acceleration commands were being provided) or hold a level hover (if attitude commands were provided). The default setting is 3 seconds.
+Bit 2 (e.g. "4") disables the pilot's ability to change the vehicle's heading using the RC transmitter
+
+Bit 3 (e.g. "8") changes the interpretation of the `SET_ATTITUDE_TARGET MAVLink <https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET>`__ command's ``thrust`` field to be pure thrust expressed as a value between 0 and 1, instead of a climb rate. See :ref:`Copter Commands in Guided Mode <copter-commands-in-guided-mode>` for more details
+
+Bit 4 (e.g. "16") disables the position controller's XY axis position error correction.  This may be useful if an external controller is providing high speed targets which already include position error correction
+
+Bit 5 (e.g. "32") is the same as above but affects the position controller's velocity error correction
+
+Bit 6 (e.g. "64") enables S-Curve path planning (the same as is used in :ref:`Auto mode <auto-mode>`) to reach the position target.  This may result a smoother acceleration and deceleration but the position target cannot be updated quickly.  This also allows :ref:`object avoidance path planning <common-object-avoidance-landing-page>` (e.g. :ref:`Bendy Ruler <common-oa-bendyruler>` and :ref:`Dijkstras<common-oa-dijkstras>`) to be used in Guided mode
+
+Bit 7 (e.g. "128") enables :ref:`weathervaning <weathervaning>`
+
+The :ref:`GUID_TIMEOUT<GUID_TIMEOUT>` parameter holds the timeout (in seconds) when the vehicle is being controlled using attitude, velocity and/or acceleration commands. If no commands are received from the companion computer for this many seconds, the vehicle will slow to a stop (if velocity and/or acceleration commands were being provided) or hold a level hover (if attitude commands were provided). The default setting is 3 seconds.
 
 .. _guided_nogps:
 


### PR DESCRIPTION
This PR improves the Copter Guided mode GUID_OPTIONS parameter explanation.

This is in response to [this Copter 4.5 support issue](https://discuss.ardupilot.org/t/drone-not-avoiding-obstacles/116293) in which the user was attempting to get BendyRuler working in Guided mode.  It turns out that one of the GUID_OPTIONS bits needs to be set for this to work.

Some other changes are also included:

- Guide mode links changed to the telemetry landing page instead of the SiK radio.
- Guided mode link fixed for GUID_TIMEOUT
- Dijkstra's loses mention of ver 4.0
- Dijkstra's mentions the GUID_OPTIONS parameter setting (for Copter)
- Weathervaning is added to the Advanced Configuration landing page.  It's only in the Flight Features at the moment but the Advanced Configuration page is where we should have a full list of advanced-but-not-commonly-used features

This has been tested locally and looks good to me.