### PR TITLE
Common: gremsy gets new ZIO warning

### DIFF
--- a/common/source/docs/common-gremsy-pixyu-gimbal.rst
+++ b/common/source/docs/common-gremsy-pixyu-gimbal.rst
@@ -19,6 +19,8 @@ Gremsy `Mio <https://gremsy.com/products/mio>`__, `Pixy F <https://gremsy.com/pr
 
    PixyWE gimbals are not supported.
 
+   ZIO gimbals cannot be used as a secondary mount (e.g. "Connecting Two Gimbals" below does not work with the ZIO)
+
 Where to Buy
 ============
 


### PR DESCRIPTION
It seems like the ZIO cannot be used as a 2nd gimbal at least according to testing on [this 4.5 support thread](https://discuss.ardupilot.org/t/gremsy-zio-does-not-work-if-set-to-mount-2/116127).

I've informed Gremsy as well.