### PR TITLE
dev: source: docs: companion-computers: update BlueOS landing page

### DIFF
--- a/dev/source/docs/companion-computers.rst
+++ b/dev/source/docs/companion-computers.rst
@@ -40,7 +40,7 @@ tools/suites are listed below.
     :maxdepth: 1
 
     APSync <apsync-intro>
-    BlueOS <https://blueos.cloud/docs/blueos/1.1/overview/>
+    BlueOS <https://blueos.cloud/>
     DroneKit <droneapi-tutorial>
     FlytOS <flytos>
     Maverick <https://goodrobots.github.io/maverick/#/>


### PR DESCRIPTION
Original link was specified before the base landing page existed, and is also now outdated from to the latest stable version.