### PR TITLE
Remove comment about Google-maps timezone.

### DIFF
--- a/dev/source/docs/ardupilot-discord-server.rst
+++ b/dev/source/docs/ardupilot-discord-server.rst
@@ -27,7 +27,7 @@ Time of the meeting is: 2300 UTC each Monday.
 A second development call is held at a time more convenient for the European community.
 This meeting is held each Wednesday at 0700 UTC.
 
-A calendar with the meetings can be found at https://calendar.google.com/calendar/embed?src=rgdbom27tb1vlo62kjjnmt8va4%40group.calendar.google.com which will show the correct time for your timezone.
+A calendar with the meetings can be found at https://calendar.google.com/calendar/embed?src=rgdbom27tb1vlo62kjjnmt8va4%40group.calendar.google.com . Depending on the browser, times may be displayed in local time, or GMT and is so noted if in GMT
 
 Prefer Typing?
 --------------


### PR DESCRIPTION
When the timezone known by Google-maps, its shows in localtime. When the timezone is not known by Google-maps, it shows in GMT, and displays a small notice at the bottom. At first I thought it was Brave and Tor that weren't sending the timezone for privacy/tracking concerns, but even Chrome support is inconsistent.

Working Browsers:
Debian 12, Firefox 115.5.0esr (64-bit)
Android 13: Chrome 121.0.6167.143
Android 13, Firefox 122.0.1

Fallback to GMT(displayed at the bottom of page):
Debian 12, Chome Version 119.0.6045.159 (Official Build) (64-bit) Android 13, Brave 1.62.156 based on Chromium 121.0.6167.139 Android 13, TorBrowser 115.2.1-release(13.0.9)