### PR TITLE
Common: Torqeedo parameters lose links

### DIFF
--- a/common/source/docs/common-torqeedo.rst
+++ b/common/source/docs/common-torqeedo.rst
@@ -67,14 +67,14 @@ Configuration
 
 Please set the following parameters
 
-- :ref:`TRQD_TYPE <TRQD_TYPE>` = 1 (Tiller) if the autopilot will be connected to the tiller connector or 2 (Motor) if connected to the motor connector
+- ``TRQD_TYPE`` = 1 (Tiller) if the autopilot will be connected to the tiller connector or 2 (Motor) if connected to the motor connector
 - :ref:`SERIAL1_PROTOCOL <SERIAL1_PROTOCOL>` = 39 (Torqeedo) if the Torqeedo is connected to serial port 1.  If another serial port is used please set the appropriate SERIALx_PROTOCOL parameter
 - :ref:`SERIAL1_BAUD <SERIAL1_BAUD>` = 19 (19200 bps) if using serial port 1.  If another serial port is used please set the appropriate SERIALx_BAUD parameter instead
 
 If a serial port with flow control pins (clear-to-send and ready-to-send) is used no further parameter settings are required.  If serial port without flow-control is used then please set
 
-- :ref:`TRQD_ONOFF_PIN <TRQD_ONOFF_PIN>` = 54 (AUX5) and connect the autopilot's AUX5 pin to the interface's board's MOSFET
-- :ref:`TRQD_DE_PIN <TRQD_DE_PIN>` = 55 (AUX6) and connect the autopilot's AUX6 pin to the RS485<->TTL converter's DE and RE pins
+- ``TRQD_ONOFF_PIN`` = 54 (AUX5) and connect the autopilot's AUX5 pin to the interface's board's MOSFET
+- ``TRQD_DE_PIN`` = 55 (AUX6) and connect the autopilot's AUX6 pin to the RS485<->TTL converter's DE and RE pins
 
 Battery voltage and current information are taken from the Torqeedo battery or motor by setting this parameter
 
@@ -99,7 +99,7 @@ The "TRSE" log message (only available when using the "Tiller" connection) inclu
 
 The "TRMP" log message (only available when using the "Motor" connection) includes the motor RPM, power (in Watts), voltage, current and temperature.
 
-This above log information can also be sent as text to the ground station by setting :ref:`TRQD_OPTIONS <TRQD_OPTIONS>` = 3
+This above log information can also be sent as text to the ground station by setting ``TRQD_OPTIONS`` = 3
 
 Introduction Videos
 -------------------


### PR DESCRIPTION
PR https://github.com/ArduPilot/ardupilot/pull/26494 changed the Torqeedo parameters so they no longer start with TRQD and instead start with TRQ1 and TRQ2.

This removes the parameter links which I think will stop working once the wiki is updated.