### PR TITLE
Common: minor fix to trimble page formatting

### DIFF
--- a/common/source/docs/common-gps-trimble-px1.rst
+++ b/common/source/docs/common-gps-trimble-px1.rst
@@ -21,6 +21,7 @@ The following instructions assume the PX-1 is your first GPS. If you have config
 - :ref:`SERIAL3_PROTOCOL <SERIAL3_PROTOCOL>` = 5 (to use GPS)
 
 The following parameters are not yet supported by GSOF:
+
 - :ref:`GPS1_RATE_MS<GPS1_RATE_MS>`
 - :ref:`GPS_AUTO_CONFIG<GPS_AUTO_CONFIG>`
 - :ref:`GPS_SAVE_CFG<GPS_SAVE_CFG>`


### PR DESCRIPTION
the parameter changes were all appearing on one line so this fixes this.

This has been tested locally and looks OK.