### PR TITLE
Dev: ROS: Split into ROS 1 and ROS 2 docs

### DIFF
--- a/dev/source/docs/ros.rst
+++ b/dev/source/docs/ros.rst
@@ -1,29 +1,46 @@
 .. _ros:
 
-========
-ROS/ROS2
-========
+=============
+ROS 1 / ROS 2
+=============
 
 .. image:: ../images/logos/rosorg_logo.png
     :target: ../_images/logos/rosorg_logo.png
 
 ArduPilot capabilities can be extended with `ROS <http://www.ros.org/>`__ (aka Robot Operating System).
 
-`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications.  In the future, we expect ROS will be replaced by `ROS2 <http://design.ros2.org/articles/why_ros2.html>`__
+`ROS <http://www.ros.org/>`__ provides libraries, tools, hardware abstraction, device drivers, visualizers, message-passing, package management, and more to help software developers create robot applications.
+ROS1 is being replaced by `ROS 2 <http://design.ros2.org/articles/why_ros2.html>`__
 
 
 .. image:: ../images/logos/ros2_logo.jpg
     :target: ../_images/logos/ros2_logo.jpg
 
-`MAVROS <http://wiki.ros.org/mavros>`__ is a ROS package that can convert between ROS topics and `MAVLink messages <https://github.com/ArduPilot/mavlink>`__ allowing ArduPilot vehicles to communicate with ROS.  The `MAVROS code can be found here <https://github.com/mavlink/mavros/tree/master/mavros>`__.
+The tutorials below are split between ROS 1 and ROS 2.
+If you aren't sure which version to use, the ArduPilot development team recommends ROS 2 because ROS 1 is end-of-life in 2025.
 
-These pages will show you how to:
+Prerequisites
+=============
+
+Before using ArduPilot with ROS, you should first be familiar with both ArduPilot and ROS before trying to integrate them together.
+
+- Learn how to use ArduPilot first by following the relevant wiki for `Rover <https://ardupilot.org/rover/index.html>`__, `Copter <https://ardupilot.org/copter/index.html>`__ or `Plane <https://ardupilot.org/plane/index.html>`__. In particular, make sure the vehicle works well in Manual and Autonomous modes like Guided and Auto before trying to use ROS.
+- Learn how to use ROS by reading the `ROS 1 tutorials <http://wiki.ros.org/ROS/Tutorials>`__ or the `ROS 2 tutorials <https://docs.ros.org/en/humble/Tutorials.html#>`__.  In the case of a problem with ROS, it is best to ask on ROS community forums or `Robotics Stack Exchange <https://robotics.stackexchange.com/>`__ first (or google your error). You will find many other tutorials about ROS like `Emlid <https://docs.emlid.com/navio2/ros>`__.
+
+MAVROS
+======
+
+`MAVROS <http://wiki.ros.org/mavros>`__ is a ROS package that can convert between ROS topics and `MAVLink messages <https://github.com/ArduPilot/mavlink>`__ allowing ArduPilot vehicles to communicate with ROS.
+The `MAVROS code can be found here <https://github.com/mavlink/mavros/tree/master/mavros>`__.
+Starting in ArduPilot 4.5, ArduPilot supports a direct DDS interface compatible with ROS 2, which removes the need to use MAVROS for certain applications.
+
+ROS 1
+=====
 
 .. toctree::
     :maxdepth: 1
 
         Install ROS and MAVROS <ros-install>
-        Install ROS2 <ros2>
         Connecting to ArduPilot from ROS <ros-connecting>
         Hector SLAM for non-GPS navigation <ros-slam>
         Google Cartographer SLAM for non-GPS navigation <ros-cartographer-slam>
@@ -33,24 +50,32 @@ These pages will show you how to:
         Clock/Time syncronisation <ros-timesync>
         Send data from AP to ROS/mavros <ros-data-from-ap>
         ROS with SITL <ros-sitl>
-        ROS 2 with SITL <ros2-sitl>
         ROS with SITL in Gazebo <ros-gazebo>
-        ROS 2 with SITL in Gazebo <ros2-gazebo>
-        ROS 2 over Ethernet <ros2-over-ethernet>
-        Cartographer SLAM with ROS 2 in SITL <ros2-cartographer-slam>
         ROS with distance sensors <ros-distance-sensors>
         ROS with Aruco Boards detection <ros-aruco-detection>
         ROS with Apriltag Boards detection <ros-apriltag-detection>
 
-Prerequisites
-=============
+ROS 2
+=====
 
-- Learn on to use ArduPilot first by following the relevant wiki for `Rover <https://ardupilot.org/rover/index.html>`__, `Copter <https://ardupilot.org/copter/index.html>`__ or `Plane <https://ardupilot.org/plane/index.html>`__. In particular, make sure the vehicle works well in Manual and Autonomous modes like Guided and Auto before trying to use ROS.
-- Learn how to use ROS by reading the `beginner tutorials <http://wiki.ros.org/ROS/Tutorials>`__.  In the case of a problem with ROS, it is best to ask on ROS community forums first (or google your error). You will find many other tutorials about ROS like `Emlid <https://docs.emlid.com/navio2/ros>`__.
+.. toctree::
+    :maxdepth: 1
 
-    Here is ArduPilot Rover performing path planning around objects using ROS navigation.
+        Install ROS 2 <ros2>
+        ROS 2 with SITL <ros2-sitl>
+        ROS 2 with SITL in Gazebo <ros2-gazebo>
+        ROS 2 over Ethernet <ros2-over-ethernet>
+        Cartographer SLAM with ROS 2 in SITL <ros2-cartographer-slam>
+
+
+Conclusion
+==========
+
+ROS is capable of extending autopilot capabilities with a wider ecosystem of technologies that can run on more powerful computers.
+
+Here is ArduPilot Rover performing path planning around objects using ROS navigation.
 
 ..  youtube:: tqVH4lWk51Y
     :width: 100%
 
-    We are keen to improve ArduPilot's support of ROS so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__ with a title that includes "ROS" and we will attempt to resolve them as quickly as possible.
+We are keen to improve ArduPilot's support of ROS so if you find issues (such as commands that do not seem to be supported), please report them in the `ArduPilot issues list <https://github.com/ArduPilot/ardupilot/issues>`__ with a title that includes "ROS" and we will attempt to resolve them as quickly as possible.

--- a/dev/source/docs/ros2-over-ethernet.rst
+++ b/dev/source/docs/ros2-over-ethernet.rst
@@ -10,7 +10,7 @@ Ensure you have ROS 2 :ref:`installed <ros2>` and have run :ref:`SITL <ros2-sitl
 
 Additionally, make sure you understand the :ref:`basics of networking in ArduPilot. <common-network>`
 
-==========
+
 Motivation
 ==========
 
@@ -22,7 +22,6 @@ Compared to connecting an autopilot over serial, ethernet has the following adva
 * Ethernet is easier to debug with tools such as ``tcpdump`` or ``Wireshark``
 * Ethernet uses standard cabling, so it's more difficult to mix up TX and RX
 
-==================
 Physical Equipment
 ==================
 
@@ -31,7 +30,6 @@ The following equipment is required to complete this tutorial:
 * A computer that can run the MicroROS Agent and the ROS 2 CLI
 * An autopilot with ethernet support
 
-=============================================
 Necessary parameters for static configuration
 =============================================
 
@@ -79,7 +77,6 @@ Then, you would configure all of the below parameters.
 
 Modify the addresses to suit your needs; the rest can remain the same.
 
-=====
 Steps
 =====
 

--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -148,7 +148,7 @@ Table of Contents
     MAVLink Interface <docs/mavlink-commands>
     CAN and DroneCAN/UAVCAN <docs/can-bus>
     Companion Computers <docs/companion-computers>
-    ROS/ROS2 <docs/ros>
+    ROS1/ROS2 <docs/ros>
     Lua Scripts <docs/common-lua-scripts>
     Porting to a new Flight Controller <docs/porting>
     OEM Customization <docs/common-oem-customizations>


### PR DESCRIPTION
Before and After:

![image](https://github.com/ArduPilot/ardupilot_wiki/assets/25047695/a81f31ee-cf11-4bc0-88e0-416c11de486e)

I want to also recommend using ROS 2. Note the ethernet changes were because it wasn't representing in the TOC correctly. Incorrect headings were used.
