### PR TITLE
Dev: update VSCode launch.json gdb args

### DIFF
--- a/dev/source/docs/debugging-with-gdb-using-vscode.rst
+++ b/dev/source/docs/debugging-with-gdb-using-vscode.rst
@@ -129,6 +129,13 @@ Example launch.json File
                         "text": "-enable-pretty-printing",
                         "ignoreFailures": true
                     }
+                ],
+                "postRemoteConnectCommands": [
+                    {
+                        "description": "Set breakpoint at AP_HAL::panic",
+                        "text": "-break-insert AP_HAL::panic",
+                        "ignoreFailures": false
+                    }
                 ]
             },
             {
@@ -146,7 +153,21 @@ Example launch.json File
                 ],
                 "miDebuggerPath": "/usr/bin/gdb",
                 "MIMode": "gdb",
-                "launchCompleteCommand": "exec-run"
+                "launchCompleteCommand": "exec-run",
+                "setupCommands": [
+                    {
+                        "description": "Enable pretty-printing for gdb",
+                        "text": "-enable-pretty-printing",
+                        "ignoreFailures": true
+                    }
+                ],
+                "postRemoteConnectCommands": [
+                    {
+                        "description": "Set breakpoint at AP_HAL::panic",
+                        "text": "-break-insert AP_HAL::panic",
+                        "ignoreFailures": false
+                    }
+                ]
             },
 
         // Autotest Debugging Profile


### PR DESCRIPTION
This automatically adds a breakpoint at AP_HAL::panic() when debugging

I normally debug ArduPilot through vscode like this without the extra step of using `sim_vehicle.py`. Recently, I had a panic in SITL that I can't reproduce and couldn't debug at the time because I hadn't enabled this breakpoint in my setup. I came up with this addition for my personal `launch.json` and figured it would be useful for others.

I tested by triggering a panic with the appropriate mav command, and this does indeed cause gdb to break there now.