### PR TITLE
Changes for RPLidar A2M12

### DIFF
--- a/common/source/docs/common-rplidar-a2.rst
+++ b/common/source/docs/common-rplidar-a2.rst
@@ -66,6 +66,8 @@ Example setup below shown for first proximity sensor:
 - :ref:`PRX1_TYPE <PRX1_TYPE>` = "5"
 - :ref:`PRX1_ORIENT <PRX1_ORIENT>` = "0" if mounted on the top of the vehicle, "1" if mounted upside-down on the bottom of the vehicle.
 
+.. note:: Only on RPLidar A2M12 :ref:`SERIAL1_BAUD <SERIAL1_BAUD>` should be set to "256". 
+
 It may be necessary to turn off flow control if using Telem1 (aka Serial1) or Telem2 (aka Serial2)
 
 - :ref:`BRD_SER1_RTSCTS <BRD_SER1_RTSCTS>` =  "0" if using Serial1


### PR DESCRIPTION
I was trying to set RPLidar A2M12 to Copter for obstacle avoidance but it was never working and shoving "PRX1: No Data" on HUD on Mission Planner. After reading datasheet only A2M12 model got different baud rate from rest of A2 Lidars. 
![Screenshot from 2024-05-20 12-00-32](https://github.com/ArduPilot/ardupilot_wiki/assets/74731238/87791b34-f0d1-4a7f-a50e-dea940796c9c)

As you can see its working at 256000 bps. after changing SERIAL1_BAUD parameter to "256" everything works fine.