### PR TITLE
Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue 26812

### DIFF
--- a/common/source/docs/common-aocoda-h743dual.rst
+++ b/common/source/docs/common-aocoda-h743dual.rst
@@ -126,10 +126,10 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
  - PWM2 51
  - PWM3 52
  - PWM4 53
- - PWM5 54
- - PWM6 55
- - PWM7 56
- - PWM8 57
+ - PWM5 57
+ - PWM6 56
+ - PWM7 55
+ - PWM8 54
  - PWM9 58
  - PWM10 59
  - PWM11 60


### PR DESCRIPTION
[26812 Aocoda-RC H743Dual motor 5-8 mis-labeled issue](https://github.com/ArduPilot/ardupilot_wiki/issues/5759)