### PR TITLE
Common: fix rplidar links

### DIFF
--- a/common/source/docs/common-rplidar-a2.rst
+++ b/common/source/docs/common-rplidar-a2.rst
@@ -4,7 +4,7 @@
 RPLidar C1, A2 and S1 360 degree lidar
 ======================================
 
-The `RPLidar A2 <https://www.slamtec.ai/home/rplidar_a2/>`__ ,`RPLidar A2 <https://www.slamtec.ai/home/rplidar_a2/>`__, or RPlidar S1 can be used for object avoidance in ArduPilot.  This page describes how to connect them directly to your autopilot.
+The `RPLidar C1 <https://www.slamtec.ai/product/slamtec-rplidar-c1/>`__, `RPLidar A2 <https://www.slamtec.ai/product/slamtec-rplidar-a2/>`__, or RPlidar S1 can be used for object avoidance in ArduPilot.  This page describes how to connect them directly to your autopilot.
 See separate wiki pages on object avoidance for Copter and Rover for more details on how to setup the avoidance feature.
 
    .. image:: ../../../images/rplidar-a2.jpg


### PR DESCRIPTION
This fixes the links on the RPLidar page.  when I look at them at least using firefox the 2nd one is broken.  This seems to fix it.
