### PR TITLE
Revert "Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue 26812"

### DIFF
--- a/common/source/docs/common-aocoda-h743dual.rst
+++ b/common/source/docs/common-aocoda-h743dual.rst
@@ -128,10 +128,10 @@ The numbering of the GPIOs for PIN variables in ArduPilot is:
  - PWM2 51
  - PWM3 52
  - PWM4 53
- - PWM5 57
- - PWM6 56
- - PWM7 55
- - PWM8 54
+ - PWM5 54
+ - PWM6 55
+ - PWM7 56
+ - PWM8 57
  - PWM9 58
  - PWM10 59
  - PWM11 60


### PR DESCRIPTION
Reverts ArduPilot/ardupilot_wiki#6010
my mistake for merging this...I already had a 4.6 wiki pending PR which fixes another error on the page #5896 which wont be merged until 4.6 beta when the code is released