### PR TITLE
Common: simplify camera servo and camera relay setup instructions

### DIFF
--- a/common/source/docs/common-3d-mapping.rst
+++ b/common/source/docs/common-3d-mapping.rst
@@ -24,13 +24,7 @@ Equipment you will need
 `Plane <https://ardupilot.org/plane/index.html>`_ or
 :ref:`Multicopter <copter:home>`
 
-A digital still camera:
-
-`Canon cameras capable of CHDK <http://chdk.wikia.com/wiki/For_Developers>`__ including the S100,
-S110, Elph 110 HS and SX230HS
-
-Other camera types including Canon ELPH 520 HS (not CHDK capable) with
-some method of triggering the camera shutter
+A digital still camera  with some method of triggering the camera shutter
 
 GoPro cameras are not recommended because of their fish-eye lenses
 
@@ -60,8 +54,8 @@ overlap in pictures from adjacent tracks.
 
 The camera shutter needs to be triggered throughout the mission (i.e
 every 2 to 5 seconds or at regular distance intervals).  Many cameras
-include a feature to take pictures at regular time intervals.  `Canon cameras loaded with CHDK can run a script <http://chdk.wikia.com/wiki/User_Written_Scripts>`__ that does
-this.  Alternatively :ref:`Copter/Plane/Rover can trigger a Canon CHDK camera at timed or distance based intervals <common-chdk-camera-control-tutorial>`.
+include a feature to take pictures at regular time intervals. If not, then a
+camera shutter release method must be implemented via a relay control, see :ref:`common-camera-shutter-with-servo` for example.
 
 A mission to accomplish this would include some or all of these
 commands:
@@ -75,7 +69,7 @@ column.  Adding "1" to the "Delay" columns will cause the copter to
 momentarily stop at each waypoint.
 
 **DO_DIGICAM_CONTROL** will cause the camera shutter to be pushed once
-immediately if the autopilot has been connected using CHDK or a
+immediately if the autopilot has been connected using a
 servo.  This command takes no arguments and like other "do" commands it
 executes immediately after the preceding waypoint command begins.
 

--- a/common/source/docs/common-apm-to-chdk-camera-link-tutorial.rst
+++ b/common/source/docs/common-apm-to-chdk-camera-link-tutorial.rst
@@ -1,5 +1,7 @@
 .. _common-apm-to-chdk-camera-link-tutorial:
 
+**ARCHIVED: page considered obsolete**
+
 ====================================
 Camera Shutter Triggering using CHDK
 ====================================

--- a/common/source/docs/common-archived-topics.rst
+++ b/common/source/docs/common-archived-topics.rst
@@ -28,6 +28,8 @@ value to users with old hardware.
     Erle-Brain2 Wiring Quick Start <common-erle-brain2-wiring-quick-start>
     PXFmini Wiring Quick Start <common-pxfmini-wiring-quick-start>
     Web Apps <common-web-apps>
+    Camera Triggering using CHDK <common-apm-to-chdk-camera-link-tutorial>
+    Camera Triggering using CHDK Tutorial <common-chdk-camera-control-tutorial>
 
 [/site]
 [site wiki="copter,plane,rover"]

--- a/common/source/docs/common-camera-shutter-with-servo.rst
+++ b/common/source/docs/common-camera-shutter-with-servo.rst
@@ -30,19 +30,19 @@ Configure the autopilot by setting these parameters:
 Relay control connection and configuration
 ==========================================
 
-Connect one of the autopilot's GPIO pins to the camera or the camera control cable that accepts high/low voltage input.  As mentioned on the :ref:`relay wiki page<common-relay>` normally the autopilot's servo/motor outputs can be used but in additional some autopilots have dedicated pins purely for use as relays/GPIOs.
+Connect one of the autopilot's GPIO pins to the camera or the camera control cable that accepts high/low voltage input.  As mentioned on the :ref:`relay wiki page<common-relay>` the autopilot's servo/motor outputs can normally be used but, in addition, some autopilots have dedicated pins purely for use as relays/GPIOs.
 
 Configure the autopilot by setting these parameters:
 
-- If using 4.5 (or earlier) only the 1st relay can be used so set `RELAY_PIN` to the GPIO pin used
+- If using 4.5 (or earlier) only the 1st relay can be used so set ``RELAY_PIN`` to the GPIO pin used
 - If using 4.6 (or higher) any relay can be used.  Below are settings if the first relay is used.
 
   - Set :ref:`RELAY1_FUNCTION<RELAY1_FUNCTION>` = 4 (Camera) 
   - Set :ref:`RELAY1_PIN<RELAY1_PIN>` to the GPIO pin used
 
-- Set `SERVOx_FUNCTION` = -1 (GPIO) where "x" is the servo output channel used.  This is not required in the rare case where the autopilot's dedicated GPIO pins are useds
+- Set ``SERVOx_FUNCTION`` = -1 (GPIO) where "x" is the servo output channel used.  This is not required in the rare case where an autopilot's dedicated GPIO pins are used.
 - Set :ref:`CAM1_DURATION<CAM1_DURATION>` to the time (in seconds) that the relay is held high
-- Set :ref:`CAM1_RELAY_ON<CAM1_RELAY_ON>` = 0 to swap the relay voltage.  E.g. high by default, low to trigger the camera shutter
+- Set :ref:`CAM1_RELAY_ON<CAM1_RELAY_ON>` = 0 to swap the relay voltage.  E.g. GPIO output would now be normally high by default, and then low to trigger the camera shutter
 
 .. _common-camera-shutter-with-servo_enhanced_camera_trigger_logging:
 

--- a/common/source/docs/common-camera-shutter-with-servo.rst
+++ b/common/source/docs/common-camera-shutter-with-servo.rst
@@ -4,113 +4,61 @@
 Camera Shutter Configuration
 ============================
 
-ArduPilot allows you to configure a particular port (servo or relay) as
-the camera trigger, which will then be activated when :ref:`camera commands are specified in missions <common-camera-control-and-auto-missions-in-mission-planner>`.
+ArduPilot allows you to configure a :ref:`servo output<common-servo>` or :ref:`relay<common-relay>` to control a camera trigger from :ref:`an RC transmitter, a ground station or during a mission <common-camera-controls>`.
 
-This article explains what settings you need to configure for both servos and relays. For a typical relay based trigger, see this DIY article using a Pixhawk as an example autopilot: :ref:`common-pixhawk-camera-trigger-setup`.
+This article explains in general what connections and settings are required but in most cases the autopilot's servo output or relay voltage will be converted into a format understood by the particular camera used and the setup details will depend upon what hardware is used (infrared, cable, etc).  These two pages may provide more details
 
-.. note::
+- :ref:`DIY article for a Pixhawk using a relay based trigger<common-pixhawk-camera-trigger-setup>`
 
-   The servo or relay port signal must be converted into a format
-   (infrared, cable or whatever) understood by your particular camera. The
-   configuration settings will depend on the hardware that is used to
-   perform this conversion. Some useful hardware configurations and
-   settings are linked from the section 
-   :ref:`Setting values for different cameras <common-camera-shutter-with-servo_setting_values_for_different_cameras>`. 
+Servo control connection and configuration
+==========================================
 
-Shutter configuration with Pixhawk or IOMCU Equipped Autopilots
-===============================================================
+Connect one of the autopilot's PWM output (aka servo outputs) to the camera or the camera control cable that accepts PWM input.
+As mentioned on the :ref:`servos wiki page <common-servo>` there are some autopilot specific limitations on which PWM outputs may be used:
 
-.. note:: on autopilots not using an IOMCU (most that do, label outputs as MAIN/AUX), ANY output can be used for a relay or servo. See :ref:`common-gpios` for how to designate an output as a GPIO for relay use.
+- For autopilots with IOMCU (e.g. label outputs as MAIN OUT and AUX OUT), it is easiest to use AUX OUT 1 to 6.
+- For autopilots without an IOMCU any output may be used
 
-Pixhawk has 6 AUX Ports (AUX1-AUX6, referred to as SERVO9-SERVO14 in *Mission
-Planner*) that can be configured as :ref:`servos <common-servo>`,
-:ref:`relays <common-relay>`, or 
-:ref:`digital inputs or outputs <common-pixhawk-overview_pixhawk_digital_outputs_and_inputs_virtual_pins_50-55>`.
-The image and configuration below is for the Pixhawk with SERVO10 (labeled RC10/AUX2 on this autopilot) connected to camera control hardware and configured as either a servo or relay.
+Configure the autopilot by setting these parameters:
 
-.. figure:: ../../../images/Pixhawkdetailview.jpg
-   :target: ../_images/Pixhawkdetailview.jpg
+- Set `SERVOx_FUNCTION` = 10 (CameraTrigger) where "x" is the PWM output connected to the camera
+- Set :ref:`CAM1_TYPE<CAM1_TYPE>` = 1 (Servo) and reboot the autopilot
+- Set :ref:`CAM1_SERVO_ON<CAM1_SERVO_ON>` to the pwm value to output to trigger taking a picture (e.g. 1300)
+- Set :ref:`CAM1_SERVO_OFF<CAM1_SERVO_OFF>` to the pwm value to output when *not* taking a picture (e.g. 1100)
+- Set :ref:`CAM1_DURATION<CAM1_DURATION>` to the time (in seconds) that the pwm value should remain high (e.g 0.1)
 
-   Pixhawk Detail View highlighting AUXPorts
+Relay control connection and configuration
+==========================================
 
+Connect one of the autopilot's GPIO pins to the camera or the camera control cable that accepts high/low voltage input.  As mentioned on the :ref:`relay wiki page<common-relay>` normally the autopilot's servo/motor outputs can be used but in additional some autopilots have dedicated pins purely for use as relays/GPIOs.
 
-.. tip::
+Configure the autopilot by setting these parameters:
 
-   You can monitor and log *exactly* when the camera was triggered. For more information see the :ref:`Enhanced camera trigger logging <common-camera-shutter-with-servo_enhanced_camera_trigger_logging>` section below.
+- If using 4.5 (or earlier) only the 1st relay can be used so set `RELAY_PIN` to the GPIO pin used
+- If using 4.6 (or higher) any relay can be used.  Below are settings if the first relay is used.
 
-The actual output used for the shutter is set and configured in the SETUP/Optional Hardware/Camera Gimbal screen:
+  - Set :ref:`RELAY1_FUNCTION<RELAY1_FUNCTION>` = 4 (Camera) 
+  - Set :ref:`RELAY1_PIN<RELAY1_PIN>` to the GPIO pin used
 
-   .. figure:: ../../../images/missionplannercameragimbalscreen.jpg
-      :target: ../_images/missionplannercameragimbalscreen.jpg
-
-      Mission Planner: Camera Gimbal Configuration Screen
-
--  The **Shutter** drop-down list is used to set the connected output for camera
-   trigger. Here we have selected SERVO10, which corresponds to AUX2
-   on the Pixhawk.
--  The **Duration** setting specifies how long the servo/relay
-   will be held in the **Pushed** state when the shutter is activated, in
-   tenths of a second. Above the value is 10, so the pushed state is
-   held for one second. **Not Pushed** when the shutter is not active.
--  **For Servos only (settings ignored for relay outputs):**
-
-   -  The Shutter *Pushed* and *Not Pushed* settings are the PWM signal
-      values that will be sent when the servo is in those states.
-   -  The *Servo Limits* setting specifies the range of PWM signal
-      values within which the servo will not bind.
-      
-.. note:: Mission Planners screen is not up-to-date in that the request to "Please set the Ch7 Option to Camera Trigger" is out of date, and the "transistor" selection in the *Shutter* drop-down list does nothing.
-
-- To set which RC Channel will control the manual shutter release, configure its ``RCx_OPTION`` in the CONFIG/Full Parameter List or CONFIG/User Params to "Camera Trigger".
+- Set `SERVOx_FUNCTION` = -1 (GPIO) where "x" is the servo output channel used.  This is not required in the rare case where the autopilot's dedicated GPIO pins are useds
+- Set :ref:`CAM1_DURATION<CAM1_DURATION>` to the time (in seconds) that the relay is held high
+- Set :ref:`CAM1_RELAY_ON<CAM1_RELAY_ON>` = 0 to swap the relay voltage.  E.g. high by default, low to trigger the camera shutter
 
 .. _common-camera-shutter-with-servo_enhanced_camera_trigger_logging:
 
-Enhanced camera trigger logging
+Camera shutter feedback logging
 ===============================
 
-ArduPilot logs TRIG messages when it *triggers* the camera.  You can additionally set up ArduPilot to log CAM messages when the camera has actually fired, by connecting a :ref:`digital input pin <common-pixhawk-overview_pixhawk_digital_outputs_and_inputs_virtual_pins_50-55>` on the autopilot to the camera's hot shoe (consider using `Seagulls SYNC2 Shoe Horn Adapter <https://www.seagulluav.com/product/seagull-sync2/>`__).  This more accurately logs the exact time that pictures are recorded.
+ArduPilot logs TRIG messages when it *triggers* the camera.  If the camera provides a GPIO output (e.g. camera flash hotshoe) then this can be used to also log CAM messages at the exact moment that pictures are taken.
 
-You will need to configure one of the AUX pins as a digital GPIO
-output/input, and connect it to the camera flash hotshoe (a universal
-camera hot shoe is required). The pin should be held for at least 2
-milliseconds for reliable trigger detection.
+Connect the camera's GPIO output  to one of the autopilot's :ref:`GPIO pins <common-gpios>` (e.g. AUX OUT).  As mentioned above there are restrictions on which pins may be used.
 
-The main steps are (example for Camera1 instance):
+Set the following parameters:
+ 
+- Set `SERVOx_FUNCTION` = -1 (GPIO) where "x" is the servo output channel used.  This is not required in the rare case where the autopilot's dedicated GPIO pins are useds
+- Set :ref:`CAM1_FEEDBAK_PIN<CAM1_FEEDBAK_PIN>` to the pin number connected to the hotshoe
+- Set :ref:`CAM1_FEEDBAK_POL<CAM1_FEEDBAK_POL>` = 0 if the hotshoe voltage goes low when a picture is taken or 1 if the voltage goes high
 
-#. Open *Mission Planner* and then click on **CONFIG/TUNING/Full
-   Parameters List**
-#. Set at least two of the output pins as digital GPIO output/inputs as described in 
-   :ref:`GPIOs <common-gpios>`.
-#. Set :ref:`CAM1_FEEDBAK_PIN<CAM1_FEEDBAK_PIN>` to the pin number connected to the hotshoe.
-#. Set :ref:`CAM1_FEEDBAK_POL<CAM1_FEEDBAK_POL>` to indicate whether the feedback pin (hotshoe voltage) goes high or low when the picture is taken.
+See :ref:`digital input pin <common-pixhawk-overview_pixhawk_digital_outputs_and_inputs_virtual_pins_50-55>` for more details.
 
-.. _common-camera-shutter-with-servo_setting_values_for_different_cameras:
-
-Setting values for different cameras
-====================================
-
-The actual values needed for servo/relay settings depends on what
-hardware is used to send the shutter signal to the camera. The following
-topics describe the hardware setup and configuration settings for a
-number of specific cameras/camera types:
-
--  :ref:`Camera Triggering using Stratosnapper <common-camera-trigger-stratosnapperv2>` -
-   shows how to connect to a camera with an IR interface. The
-   Stratosnapper can also be used to connect to cameras using other
-   cables and protocols
--  :ref:`Camera Shutter with Relay and CHDK on APM <common-apm-to-chdk-camera-link-tutorial>` - shows how to set
-   up a relay port to send a signal to a Canon camera running CHDK (on
-   APM2.x)
-
-If these aren't suitable for your hardware configuration, we recommend
-you check your hardware manual for information about servo/relay inputs
-that are accepted.
-
-.. note::
-
-   The :ref:`CHDK Camera Control Tutorial <common-chdk-camera-control-tutorial>` is not a good
-   example of integrating with the camera shutter, because it does not use
-   the standard shutter configuration explained in this article. This is
-   however a good example of how you can access other features of a Canon
-   camera using CHDK (for example, the zoom).
+Consider using the `Seagulls SYNC2 Shoe Horn Adapter <https://www.seagulluav.com/product/seagull-sync2/>`__

--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -49,8 +49,6 @@ Shutter Controllers
 -------------------
 
 -  :ref:`Servo or Relay controlled camera shutter <common-camera-shutter-with-servo>` (servo, relay).
--  :ref:`Camera Triggering using CHDK <common-apm-to-chdk-camera-link-tutorial>`
--  :ref:`Camera Triggering using CHDK Tutorial <common-chdk-camera-control-tutorial>` (non-standard integration)
 -  :ref:`Seagull IR Camera Trigger <common-camera-trigger-seagull-ir>`
 -  :ref:`Seagull MAP2 Camera Trigger <common-camera-trigger-seagull-map2>`
 -  :ref:`Seagull MAP-X2 Camera Trigger and Logger <common-camera-trigger-seagull-mapx2>`
@@ -114,8 +112,6 @@ more scenic photos. ArduPilot will stabilize the gimbal to whatever position you
     StratosnapperV2 Camera Trigger <common-camera-trigger-stratosnapperv2>
     Camera Trigger Directly from AUX Ports <common-pixhawk-camera-trigger-setup>
     Camera Triggering Configuration <common-camera-shutter-with-servo>
-    Camera Triggering using CHDK <common-apm-to-chdk-camera-link-tutorial>
-    Camera Triggering using CHDK Tutorial <common-chdk-camera-control-tutorial>
     RunCam Camera Control <common-camera-runcam>
     Gimbal / Mount Controls <common-mount-targeting>
     Camera Controls <common-camera-controls>

--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -54,6 +54,7 @@ Shutter Controllers
 -  :ref:`Seagull MAP-X2 Camera Trigger and Logger <common-camera-trigger-seagull-mapx2>`
 -  :ref:`Seagull REC Camera Trigger <common-camera-trigger-seagull-rec>`
 -  :ref:`StratosnapperV2 Camera Trigger <common-camera-trigger-stratosnapperv2>`
+-  :ref:`DIY Camera Trigger using Relay <common-pixhawk-camera-trigger-setup>`
 
 Control of Specific Camera Models
 ---------------------------------
@@ -110,7 +111,7 @@ more scenic photos. ArduPilot will stabilize the gimbal to whatever position you
     Seagull MAP-X2 Camera Trigger and Logger <common-camera-trigger-seagull-mapx2>
     Seagull REC Camera Trigger <common-camera-trigger-seagull-rec>
     StratosnapperV2 Camera Trigger <common-camera-trigger-stratosnapperv2>
-    Camera Trigger Directly from AUX Ports <common-pixhawk-camera-trigger-setup>
+    DIY Camera Trigger using Relay <common-pixhawk-camera-trigger-setup>
     Camera Triggering Configuration <common-camera-shutter-with-servo>
     RunCam Camera Control <common-camera-runcam>
     Gimbal / Mount Controls <common-mount-targeting>

--- a/common/source/docs/common-chdk-camera-control-tutorial.rst
+++ b/common/source/docs/common-chdk-camera-control-tutorial.rst
@@ -1,5 +1,7 @@
 .. _common-chdk-camera-control-tutorial:
 
+**ARCHIVED: page considered obsolete**
+
 ============================
 CHDK Camera Control Tutorial
 ============================

--- a/common/source/docs/common-pixhawk-camera-trigger-setup.rst
+++ b/common/source/docs/common-pixhawk-camera-trigger-setup.rst
@@ -1,8 +1,8 @@
 .. _common-pixhawk-camera-trigger-setup:
 
-================================
-Camera Trigger Setup for Pixhawk
-================================
+==============================
+DIY Camera Trigger using Relay
+==============================
 
 .. image:: ../../../images/CTimage0.png
     :width: 450px


### PR DESCRIPTION
This simplifies/clarifies the camera setup when using servo or relays.

I've removed a picture and perhaps that means we could remove the pic from the images directory as well, but sometimes we use images across pages.

I've tested it locally and it looks OK to me.