### PR TITLE
Cygwin: Resolve the error in dronecan_dsdlc.py

### DIFF
--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -129,7 +129,8 @@ Set up directories/paths and extra packages in Cygwin
 
     ln -s /usr/bin/python3.7 /usr/bin/python
     ln -s /usr/bin/pip3.7 /usr/bin/pip
-    pip install empy pyserial pymavlink
+    pip install pyserial pymavlink
+    pip install empy==3.3.4
 
 Download ArduPilot Source
 =========================

--- a/dev/source/docs/building-setup-windows-cygwin.rst
+++ b/dev/source/docs/building-setup-windows-cygwin.rst
@@ -129,8 +129,7 @@ Set up directories/paths and extra packages in Cygwin
 
     ln -s /usr/bin/python3.7 /usr/bin/python
     ln -s /usr/bin/pip3.7 /usr/bin/pip
-    pip install pyserial pymavlink
-    pip install empy==3.3.4
+    pip install pyserial pymavlink empy<4.0
 
 Download ArduPilot Source
 =========================


### PR DESCRIPTION

I wanted to build the latest ArduCopter by setting up CYGWIN.
However, I detected an error in dronecan_dsdlc.py.
My CYGWIN's EMPY was V4.1.
I was able to resolve the issue as follows.
I will fix the WIKI.

https://discuss.ardupilot.org/t/failed-to-build-an-old-commit-of-master-branch-15601e4-and-cannot-install-the-missing-module/112556