### PR TITLE
Update COMPASS description to clarify logs as raw mag field

### DIFF
--- a/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
+++ b/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
@@ -372,7 +372,8 @@ a mission):**
 +---------------------+----------------------------------------------------------------------------------------+
 | Field               | Description                                                                            |
 +---------------------+----------------------------------------------------------------------------------------+
-| MagX, MagY. MagZ    | Raw magnetic field values for x, y and z axis                                          |
+| MagX, MagY, MagZ    | Raw magnetic field values for x, y, and z axis. These are magnetometer readings with   |
+|                     | calibration applied, not raw magnetometer readings.                                    |
 +---------------------+----------------------------------------------------------------------------------------+
 | OfsX, OfsY, OfsZ    | Raw magnetic offsets (will only change if COMPASS_LEARN parameter is 1)                |
 +---------------------+----------------------------------------------------------------------------------------+


### PR DESCRIPTION
The logs represent raw magnetic field data with calibration parameters applied, not raw magnetometer values without calibration. Updated the description for clarity. (took me 2 days to figure it out)