### PR TITLE
Ubuntu24.04 setup

### DIFF
--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -44,7 +44,7 @@ If you are on a debian based system (such as Ubuntu or Mint), we provide `a scri
 
     Tools/environment_install/install-prereqs-ubuntu.sh -y
 
-Reload the path (log-out and log-in to make it permanent):
+This script installs all required dependencies including cross compilers, creates a python virtual environment at ~/venv.ardupilot, and updates your .profile and your .bashrc. Reload the path using this command (or log-out and log-in to make it permanent):
 
 ::
 
@@ -67,6 +67,12 @@ If there have been updates to some git submodules you may need to do a full clea
     ./waf clean
 
 That will remove the build artifacts so you can do a `build <https://github.com/ArduPilot/ardupilot/blob/master/BUILD.md>`__ from scratch
+
+Some changes such as updating lua bindings or hwdef files may require a full "distclean" which will force waf to rebuild the complete environment. To do that use:
+
+::
+
+    ./waf distclean
 
 --------------------
 

--- a/dev/source/docs/git-clone.rst
+++ b/dev/source/docs/git-clone.rst
@@ -13,10 +13,12 @@ Clone a repository
 
 Developers should clone the main `ArduPilot repository <https://github.com/ArduPilot/ardupilot>`__ (if they simply want to download and compile the latest code) or their own :ref:`fork <git-fork>` (if they want to make changes to the source code and potentially submit changes back).
 
-Instructions for commonly used tools are below but whichever tool is used, the URL for the source repo will be required.  This can be found on the right side of the screen on each Github repository home page but in general the URL is:
+Instructions for commonly used tools are below but whichever tool is used, the URL for the source repo will be required. This can be found on the right side of the screen on each Github repository home page but in general the URL is:
+
+.. note:: GitHub will not allow you to push changes if you use https. If you want to be able to submit PRs use an ssh address to clone your fork. Add an ssh key to your GitHub profile for each computer that will be used for ArduPilot development.
 
 - ``https://github.com/ArduPilot/ardupilot.git`` for the main ardupilot repo
-- ``https://github.com/your-github-account/ardupilot`` for your :ref:`fork <git-fork>` of the ardupilot repo
+- ``git@github.com:your-github-account/ardupilot.git`` for your :ref:`fork <git-fork>` of the ardupilot repo
 
 .. figure:: ../images/APM-Git-Github-Clone.jpg
 
@@ -28,7 +30,7 @@ Cloning with the command line
 
    ::
 
-       git clone --recurse-submodules https://github.com/your-github-userid/ardupilot
+       git clone --recurse-submodules git@github.com:your-github-userid/ardupilot
        cd ardupilot
 
 .. youtube:: kAli2y2-n-M


### PR DESCRIPTION
Better documents setup on Ubuntu 24.04 and also describes new GitHub requirement for cloning using ssh and the creation of a python virtual environment by the install scripts.