### PR TITLE
Traditional-helicopter-tailrotor-setup_corrected_default_params

### DIFF
--- a/copter/source/docs/traditional-helicopter-tailrotor-setup.rst
+++ b/copter/source/docs/traditional-helicopter-tailrotor-setup.rst
@@ -47,8 +47,8 @@ The Direct Drive Fixed Pitch (DDFP) tail type uses a fixed pitch tail rotor and 
 There are several parameters that provide the ability to linearize the thrust produced by the tail rotor motor and therefore provide better control:
 
 - :ref:`H_DDFP_THST_EXPO<H_DDFP_THST_EXPO>` - Tail rotor DDFP motor thrust curve exponent (0.0 for linear to 1.0 for second order curve). Default = 0.55
-- :ref:`H_DDFP_SPIN_MIN<H_DDFP_SPIN_MIN>` - Point at which the DDFP motor thrust starts expressed as a number from 0 to 1 in the entire output range.  Default = 0.95
-- :ref:`H_DDFP_SPIN_MAX<H_DDFP_SPIN_MAX>` - Point at which the DDFP motor thrust saturates expressed as a number from 0 to 1 in the entire output range. Default = 0.15
+- :ref:`H_DDFP_SPIN_MIN<H_DDFP_SPIN_MIN>` - Point at which the DDFP motor thrust starts expressed as a number from 0 to 1 in the entire output range.  Default = 0.15
+- :ref:`H_DDFP_SPIN_MAX<H_DDFP_SPIN_MAX>` - Point at which the DDFP motor thrust saturates expressed as a number from 0 to 1 in the entire output range. Default = 0.95
 - :ref:`H_DDFP_BAT_IDX<H_DDFP_BAT_IDX>` - Index of battery to be used for voltage compensation. Default = 0.
 - :ref:`H_DDFP_BAT_V_MAX<H_DDFP_BAT_V_MAX>` - Battery voltage compensation maximum voltage (voltage above this will have no additional scaling effect on thrust). Recommend 4.2 * cell count, 0 = Disabled. Default = 0.
 - :ref:`H_DDFP_BAT_V_MIN<H_DDFP_BAT_V_MIN>` - Battery voltage compensation minimum voltage (voltage below this will have no additional scaling effect on thrust). Recommend 3.3 * cell count, 0 = Disabled. Default = 0.


### PR DESCRIPTION
Default veules for H_DDFP_SPIN_MIN/MAX were mixed up. According to parameters doc the default for min is 0.15, default for max is 0.95