### PR TITLE
Dev: gazebo installation update

### DIFF
--- a/dev/source/docs/sitl-with-gazebo.rst
+++ b/dev/source/docs/sitl-with-gazebo.rst
@@ -89,6 +89,7 @@ is hosted on GitHub at: `https://github.com/ArduPilot/ardupilot_gazebo <https://
 
         sudo apt update
         sudo apt install libgz-sim7-dev rapidjson-dev
+        sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
 
       For Gazebo Harmonic
 
@@ -96,6 +97,7 @@ is hosted on GitHub at: `https://github.com/ArduPilot/ardupilot_gazebo <https://
 
         sudo apt update
         sudo apt install libgz-sim8-dev rapidjson-dev
+        sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
 
     macOS
 
@@ -103,6 +105,7 @@ is hosted on GitHub at: `https://github.com/ArduPilot/ardupilot_gazebo <https://
 
       brew update
       brew install rapidjson
+      brew install opencv gstreamer
 
 #. Create a workspace folder and clone the repository
 

--- a/dev/source/docs/sitl-with-gazebo.rst
+++ b/dev/source/docs/sitl-with-gazebo.rst
@@ -20,14 +20,10 @@ external simulator for ArduPilot Rover, Coper and Plane.
 .. youtube:: rJCEN5Htu2s
     :width: 100%
 
-|
-
-.. tip::
-
-   Gazebo is particularly useful for defining autonomous indoor flights,
-   swarms, non-flying vehicle types such as rovers and boats,
-   and multi-vehicle scenarios such as the ship landing simulation in the
-   video above.
+Gazebo is particularly useful for defining autonomous indoor flights,
+swarms, non-flying vehicle types such as rovers and boats,
+and multi-vehicle scenarios such as the ship landing simulation in the
+video above.
 
 
 Install ArduPilot SITL

--- a/dev/source/docs/sitl-with-gazebo.rst
+++ b/dev/source/docs/sitl-with-gazebo.rst
@@ -61,6 +61,8 @@ macOS Big Sur (11), Monterey (12), and Ventura (13).
 Install the ArduPilot Gazebo Plugin
 -----------------------------------
 
+These instructions can also be found in the `ardupilot_gazebo/README.md <https://github.com/ArduPilot/ardupilot_gazebo/blob/main/README.md>`__
+
 We use a standard version of ArduPilot with a custom plugin for Gazebo which
 is hosted on GitHub at: `https://github.com/ArduPilot/ardupilot_gazebo <https://github.com/ArduPilot/ardupilot_gazebo>`__.
 


### PR DESCRIPTION
This includes a few changes that I've separated into different commits so that we can easily drop those that aren't acceptable to @khancyr and @srmainwaring:

1. most importantly the dependencies are updated
2. added a reference to the ardupilot_gazebo plugin's README which had the correct instructions

The next two i feel less strongly about but I thought they were improvements

3. changed the tip at the top to regular text
4. changed the recommended ardupilot_gazebo path be in the home directory which matches the [README](https://github.com/ArduPilot/ardupilot_gazebo/blob/main/README.md)

I've tested this locally and it looks OK to me