### PR TITLE
common: correct link to SDModel's we store

### DIFF
--- a/common/source/docs/common-SDMODELH7V2.rst
+++ b/common/source/docs/common-SDMODELH7V2.rst
@@ -11,7 +11,7 @@ SDMODELH7V2
 Where to Buy
 ============
 
-- Available from `SDMODEL <www.sdmodel.com.tw>`__
+- Available from `SDMODEL <https://www.sdmodel.com.tw>`__
 
 Specifications
 ==============


### PR DESCRIPTION
Broken link appears on this page: https://ardupilot.org/copter/docs/common-SDMODELH7V2.html
