### PR TITLE
Updated the instructions for adding a simulated RPM sensor

### DIFF
--- a/dev/source/docs/adding_simulated_devices.rst
+++ b/dev/source/docs/adding_simulated_devices.rst
@@ -169,20 +169,35 @@ Go for a flight and see if you get reasonable data.
 Adding an RPM sensor
 ====================
 
+Depending on the frame/vehicle you are simulating, its physics model might provide either the first or second RPM sensor, or both:
+
 You can add an RPM sensor like this:
 
 ::
 
-    param set RPM_TYPE 10
+    param set RPM1_TYPE 10
 
-When using RealFlight with the flightaxis link, the second instace should be used:
+
+ or
 
 ::
 
-
    param set RPM2_TYPE 10
 
-This allows to display and log your virtual motor's rotational speed.
+the rpm sensor(s) can be associated with any motor output using the ``SIM_VIB_MOT_MASK`` parameter. For example, to associate an RPM sensor to the SITL plane model's forward motor, which is default assigned to output 3, set the third bit in ``SIM_VIB_MOT_MASK`` parameter(value = 4).
+
+The RPM can be displayed using:
+
+::
+
+  graph RPM.rpm1 or RPM.rpm2 
+
+or
+
+::
+
+  status RPM
+
 
 Adding Wheel Encoders
 =====================

--- a/dev/source/docs/adding_simulated_devices.rst
+++ b/dev/source/docs/adding_simulated_devices.rst
@@ -173,7 +173,14 @@ You can add an RPM sensor like this:
 
 ::
 
-    param set RPM_TYPE 1
+    param set RPM_TYPE 10
+
+When using RealFlight with the flightaxis link, the second instace should be used:
+
+::
+
+
+   param set RPM2_TYPE 10
 
 This allows to display and log your virtual motor's rotational speed.
 


### PR DESCRIPTION
Changed RPM_TYPE from 1 to 10 for normal SITL as 1 does not work. Added RPM2_TYPE which needs to be used when running flightaxis link for RealFlight