### PR TITLE
Update dependency 2024

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,9 @@
 # Docutils version is for correct bullet point rendering. Can be rolled forward after the theme is updated to >=0.5.1
 # See https://stackoverflow.com/a/68685753/2578171
 sphinx==7.1.2; python_version=="3.8"
-sphinx==7.2.6; python_version>"3.8"
+sphinx==7.4.7; python_version>"3.8"
 sphinx-tabs==3.*
-docutils<0.19
+docutils<0.21
 requests>=2.31.0
 
 # lxml for parameter parsing:

--- a/update.py
+++ b/update.py
@@ -773,7 +773,7 @@ def check_imports():
     '''check key imports work'''
     import pkg_resources
     # package names to check the versions of. Note that these can be different than the string used to import the package
-    requires = ["sphinx_rtd_theme>=1.3.0", "sphinxcontrib.youtube>=1.2.0", "sphinx>=7.1.2", "docutils<0.19"]
+    requires = ["sphinx_rtd_theme>=1.3.0", "sphinxcontrib.youtube>=1.2.0", "sphinx>=7.1.2", "docutils<0.21"]
     for r in requires:
         debug("Checking for %s" % r)
         try:


### PR DESCRIPTION
update theme to 2.0.0. need https://github.com/ArduPilot/sphinx_rtd_theme/pull/22
-> this fix some small html and js errors
-> allow to use python 3.11 and recent docutil to generate html
update youtube plugin to latest version need https://github.com/ArduPilot/sphinxcontrib-youtube/pull/6
-> fix the status_iterator warning
->fix privacy video link
-> don't generate thumbnails unless building for latex or pdf


raise docutil dependency to 0.20
raise sphinx version to 7.4.4