### PR TITLE
Common: fix infinite recursion

### DIFF
--- a/blimp/source/index.rst
+++ b/blimp/source/index.rst
@@ -35,3 +35,4 @@ Getting more info
    Complete log message list <docs/logmessages>
    Simulation<docs/simulation>
    Upcoming Features <docs/common-master-features>
+   docs/common-appendix

--- a/common/source/docs/common-abbreviations.rst
+++ b/common/source/docs/common-abbreviations.rst
@@ -1,4 +1,4 @@
-.. common-abbreviations:
+.. _common-abbreviations:
 
 ====================
 Common Abbreviations
@@ -30,4 +30,4 @@ TECS    Total Energy Control System (altitude/speed controller for Plane)
 WP      Waypoint
 ======  =====================================================================
 
-[copywiki destination="copter,plane,rover,planner,planner2,dev,antennatracker,mavproxy,ardupilot"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,dev,antennatracker,mavproxy,ardupilot"]

--- a/common/source/docs/common-acknowledgments.rst
+++ b/common/source/docs/common-acknowledgments.rst
@@ -10,4 +10,4 @@ These days ArduPilot is financially supported by our `Partners <https://ardupilo
 
 We also want to acknowledge `Helpmonks <https://helpmonks.com>`__ for providing their Bliss plan free of cost. Managing e-mail in ArduPilot's team is now easier.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-appendix.rst
+++ b/common/source/docs/common-appendix.rst
@@ -23,7 +23,9 @@ the wiki.
     History of ArduPilot <common-history-of-ardupilot>
     Partners <common-partners>
     Partners Program <common-partners-program>
+[site wiki="plane, copter, rover, sub, blimp"]
     Ready-To-Use vehicles <common-rtf>
+[/site]
     Stores <common-stores>
     Top Contributors <common-team>
 [site wiki="plane, copter, rover"]    
@@ -56,4 +58,4 @@ the wiki.
 
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,dev,antennatracker,mavproxy,ardupilot"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,dev,antennatracker,mavproxy,ardupilot"]

--- a/common/source/docs/common-commercial-support.rst
+++ b/common/source/docs/common-commercial-support.rst
@@ -154,7 +154,7 @@ support for ArduPilot including vehicle design, tuning, log analysis, bug fixes 
             <div class="line">ArduPilot Initiative provides tailored services to professional</div>
             <div class="line">and commercial users of ArduPilot. Services include log analysis,</div>
             <div class="line">new features, integrating sensors/payloads, developing hardware</div>
-            <div class="line">and tuning assitance</div>
+            <div class="line">and tuning assistance</div>
             </div>
         </td>
     </tr>
@@ -225,7 +225,7 @@ support for ArduPilot including vehicle design, tuning, log analysis, bug fixes 
             </div>
         </td>
     </tr>
-	    <tr class="row-odd">
+        <tr class="row-odd">
         <td><center><a class="first last reference external image-reference" href="https://www.Event38.com/"><img alt="Event 38 Unmanned Systems" src="../_images/Event38.png" style="width: 90px;" /></a><br/><br/>USA</center></td>
         <td><div class="first last line-block">
             <div class="line">Event38 Unmanned Systems, <a href="mailto:help@event38.com" target="_top">help@event38.com</a></div>
@@ -234,8 +234,8 @@ support for ArduPilot including vehicle design, tuning, log analysis, bug fixes 
             <div class="line">Customizations of any part of ArduPilot code</div>
             <div class="line">Airframe design and manufacturing</div>
             <div class="line">Systems integration</div>
-			<div class="line">Aircraft Tuning</div>
-			<div class="line">Companion Computers and offboard navigation</div>
+            <div class="line">Aircraft Tuning</div>
+            <div class="line">Companion Computers and offboard navigation</div>
             </div>
         </td>
     </tr>
@@ -381,4 +381,4 @@ Fleet Management Systems
 - `Drone LogBook <https://www.dronelogbook.com/hp/1/index.html>`__
 - `flyfreely <https://flyfreely.io/>`__
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-contact-us.rst
+++ b/common/source/docs/common-contact-us.rst
@@ -45,4 +45,4 @@ DroneKit
 - `DroneKit for Android Gitter chat <https://gitter.im/dronekit/dronekit-android>`__
 - `DroneKit for Python Gitter chat <https://gitter.im/dronekit/dronekit-python>`__
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-donation.rst
+++ b/common/source/docs/common-donation.rst
@@ -19,4 +19,4 @@ Australian non-profit incorporated association.
 
 `How are donations spent? <https://ardupilot.org/copter/docs/common-partners-program.html#how-are-collected-funds-spent>`__
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-downloads_advanced_user_tools.rst
+++ b/common/source/docs/common-downloads_advanced_user_tools.rst
@@ -426,4 +426,4 @@ Since we want you to have a great experience, please make sure that you do all o
   The software and hardware we provide is only for use in unmanned vehicles.
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,mavproxy,ardupilot"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,mavproxy,ardupilot"]

--- a/common/source/docs/common-downloads_developer_tools.rst
+++ b/common/source/docs/common-downloads_developer_tools.rst
@@ -158,4 +158,4 @@ Since we want you to have a great experience, please make sure that you do all o
 
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,mavproxy,ardupilot"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,mavproxy,ardupilot"]

--- a/common/source/docs/common-downloads_firmware.rst
+++ b/common/source/docs/common-downloads_firmware.rst
@@ -102,4 +102,4 @@ Since we want you to have a great experience, please make sure that you do all o
 
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-glossary.rst
+++ b/common/source/docs/common-glossary.rst
@@ -290,4 +290,4 @@ from \ `sparkfun <https://www.sparkfun.com/products/11812>`__.
 than Bluetooth but lower power consumption than WiFi.
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-history-of-ardupilot.rst
+++ b/common/source/docs/common-history-of-ardupilot.rst
@@ -241,4 +241,4 @@ Dec 2019 - Copter 4.0.0 with RCx_OPTION support, LUA Scripting support, new mode
    for a more complete list of contributors to the project.
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-makeflyeasy-fighter-hand-throw.rst
+++ b/common/source/docs/common-makeflyeasy-fighter-hand-throw.rst
@@ -35,12 +35,4 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/10000223175280.html>`__
 
-.. toctree::
-   :hidden:
-    
-   MakeFLyEasy - Striver Mini <common-makeflyeasy-striver-mini-hand-throw>
-   MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>
-   MakeFLyEasy - Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>
-   
-
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="plane,copter,rover,blimp"]

--- a/common/source/docs/common-makeflyeasy-fighter-vtol.rst
+++ b/common/source/docs/common-makeflyeasy-fighter-vtol.rst
@@ -37,4 +37,4 @@ Where to Buy
 
 `Aliexpress  <https://www.aliexpress.com/item/10000223165284.html>`__
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="plane,copter,rover,blimp"]

--- a/common/source/docs/common-makeflyeasy-striver-mini-hand-throw.rst
+++ b/common/source/docs/common-makeflyeasy-striver-mini-hand-throw.rst
@@ -38,5 +38,5 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/1005002723370301.html>`__
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="plane,copter,rover,blimp"]
 

--- a/common/source/docs/common-makeflyeasy-striver-mini-vtol.rst
+++ b/common/source/docs/common-makeflyeasy-striver-mini-vtol.rst
@@ -37,10 +37,4 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/1005002723289589.html>`__
 
-.. toctree::
-   :hidden:
-    
-   MakeFLyEasy - Fighter <common-makeflyeasy-fighter-hand-throw>
-   
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
-
+[copywiki destination="plane,copter,rover,blimp"]

--- a/common/source/docs/common-partners-program.rst
+++ b/common/source/docs/common-partners-program.rst
@@ -111,5 +111,5 @@ I want a new feature, do I have to be a partner to get it?
 ==========================================================
 No.  ArduPilot is, and always will be, open source.  Contributions to the code base, wherever they come from, are accepted based on their technical merits.  If you're not in a position to make the changes yourself, please add it to the `Issues list <https://github.com/ArduPilot/ardupilot/issues>`__ or consider contracting one of the companies listed on the :ref:`Commercial Support page <common-commercial-support>` to make the change.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
 

--- a/common/source/docs/common-partners.rst
+++ b/common/source/docs/common-partners.rst
@@ -846,4 +846,4 @@ Details on the Partners Program and how to join can be found on the :doc:`Partne
             :align: center
             :target:  https://arcoworldwide.ng/
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -48,6 +48,8 @@ Planes from Partners
 * `MakeFLyEasy - Believer <https://www.aliexpress.com/item/30000002380639.html?spm=a2g0o.store_home.productList_1076398524.pic_4>`__
 * :ref:`MakeFLyEasy - Fighter <common-makeflyeasy-fighter-hand-throw>`
 * :ref:`MakeFLyEasy - Striver Mini <common-makeflyeasy-striver-mini-hand-throw>`
+* :ref:`MakeFLyEasy - Fighter Hand Throw <common-makeflyeasy-fighter-hand-throw>`
+* :ref:`MakeFLyEasy - Striver Mini Hand Throw <common-makeflyeasy-striver-mini-hand-throw>`
 * `mRobotics - Nano Talon <https://store.mrobotics.io/ProductDetails.asp?ProductCode=mRo-talon0318-mr>`__
 * Various from `UAVSystems <https://uavsystemsinternational.com/collections/fixed-wing-long-range-drones>`__
 
@@ -65,8 +67,8 @@ VTOL/QuadPlanes from Partners
 * `FlyDragonDroneTech - FDG50F <https://www.droneassemble.com/product/hybrid-vtol-uav-7-hours-endurance-with-10kgs-payload/>`__
 * :ref:`Holybro Swan-K1 <common-Swan-K1>`
 * :ref:`MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>`
-* `MakeFLyEasy - Freeman 2300 <https://www.aliexpress.com/item/10000223137957.html?spm=a2g0o.store_home.productList_1076398524.pic_3>`__
-* `MakeFLyEasy - Freeman 2100 <https://www.aliexpress.com/item/10000223137957.html?spm=a2g0o.store_home.productList_1076398524.pic_2>`__
+* `MakeFLyEasy - Freeman 2300 <https://www.uavmodel.com/collections/vtol/products/makeflyeasy-freeman-4-1-2300mm-uav-vtol>`__
+* `MakeFLyEasy - Freeman 2100 <https://www.uavmodel.com/products/makeflyeasy-striver-mini-4-1-4-2-2100mm-vtol-uav?variant=41656322654362>`__
 * :ref:`MakeFLyEasy - Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>`
 
 Rovers from Partners
@@ -105,4 +107,12 @@ Vehicles from Non-Partners
 
    If you are a manufacturer of a RTF vehicle based on ArduPilot and do not appear in this list, please get in touch through one of the methods listed on our :ref:`Contact Us page <common-contact-us>`.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+.. toctree::
+   :hidden:
+
+    MakeFLyEasy Fighter Hand Throw <common-makeflyeasy-fighter-hand-throw>
+    MakeFLyEasy Fighter VTOL <common-makeflyeasy-fighter-vtol>
+    MakeFLyEasy Striver Mini Hand Throw <common-makeflyeasy-striver-mini-hand-throw>
+    MakeFLyEasy Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>
+
+[copywiki destination="plane,copter,rover,blimp"]

--- a/common/source/docs/common-stores.rst
+++ b/common/source/docs/common-stores.rst
@@ -42,4 +42,4 @@ recommended for use with ArduPilot (in alphabetical order).  You may also want t
 
 The `ArduPilot Swag store is here <https://www.redbubble.com/people/ardupilot/shop?asc=u>`__.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-team.rst
+++ b/common/source/docs/common-team.rst
@@ -24,4 +24,4 @@ with some related projects, including:
 -  The `MatrixPilot team <https://github.com/MatrixPilot/MatrixPilot/wiki>`__
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-archiving.rst
+++ b/common/source/docs/common-wiki-editing-archiving.rst
@@ -40,4 +40,4 @@ Wiki pages can be deleted by removing them from github and any menu in which the
     Before deleting a wiki page it is important to ensure that it is not the 
     parent of other menu items (e.g. it does not contain a "toctree")
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-infra-overview.rst
+++ b/common/source/docs/common-wiki-editing-infra-overview.rst
@@ -20,4 +20,4 @@ manually set up a build environment (just inspect the Vagrantfile for dependenci
 
 The wikis use a `common theme <https://github.com/ArduPilot/sphinx_rtd_theme>`__ that provides the top menu bar. 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-quick-edit.rst
+++ b/common/source/docs/common-wiki-editing-quick-edit.rst
@@ -31,4 +31,4 @@ For more information see the Github Help topic: `Editing files in another user's
 
     Wiki home pages (named "index.html") do not have the **Edit on GitHub** link. You can still edit them by manually navigating to the desired page on Github.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-setup.rst
+++ b/common/source/docs/common-wiki-editing-setup.rst
@@ -234,4 +234,4 @@ RST rendering on Linux
 
 
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-style-guide.rst
+++ b/common/source/docs/common-wiki-editing-style-guide.rst
@@ -381,4 +381,4 @@ Note that the path is absolute, and relative to the source directory for the wik
 
     .. image:: /images/image_file_name.jpg
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki-editing-submitting-changes.rst
+++ b/common/source/docs/common-wiki-editing-submitting-changes.rst
@@ -87,4 +87,4 @@ How to get changes approved
 
 All changes to the wiki are `reviewed <https://github.com/ArduPilot/ardupilot_wiki/pulls>`__ by the wiki "maintainers" to help reduce the chance of misleading or incorrect information being posted.  Feel free to post comments in the PullRequest and/or attend the :ref:`weekly dev meeting <dev:ardupilot-discord-server>` to escalate getting your changes submitted.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]

--- a/common/source/docs/common-wiki_editing_guide.rst
+++ b/common/source/docs/common-wiki_editing_guide.rst
@@ -40,4 +40,4 @@ FAQ - Why are my changes not published?
 
 All changes to the wiki are `reviewed <https://github.com/ArduPilot/ardupilot_wiki/pulls>`__ by the wiki "maintainers" to help reduce the chance of misleading or incorrect information being posted.  Feel free to post comments in the PullRequest and/or attend the :ref:`weekly dev meeting <dev:ardupilot-discord-server>` to escalate getting your changes submitted.
 
-[copywiki destination="copter,plane,rover,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]
+[copywiki destination="copter,plane,rover,blimp,planner,planner2,antennatracker,dev,ardupilot,mavproxy"]


### PR DESCRIPTION
fix infinite recursion that show with newer sphinx versionx
```
writing output... [ 44%] docs/common-makeflyeasy-fighter-hand-throw
Extension error (sphinx.ext.mathjax):
Handler <function install_mathjax at 0x7f848975a840> for event 'html-page-context' threw an exception (exception: maximum recursion depth exceeded)
```

Recusion comes from the hidden toc on makefly rtf pages, there are two that are referencing each other.
Removing one, then trigger a not included into doctree issue, so I move up the hidden doctree to the common rtf page. This now trigger issue with missing include for blimp, thus the massive update on blimp