### PR TITLE
smart-battery-landingpage: Remove limitation

### DIFF
--- a/common/source/docs/common-smart-battery-landingpage.rst
+++ b/common/source/docs/common-smart-battery-landingpage.rst
@@ -37,8 +37,3 @@ Additional information
 ======================
 
 - `SMBus specifications (see ver 1.1, ver 2.0) <http://smbus.org/specs/>`__
-
-Limitations
-===========
-
--  Battery "address discovery" is not supported so the battery must use the I2C address 0x0B (7 bit address).  Most smart batteries use this address.


### PR DESCRIPTION
It looks like this is a hangover from a while back.  The limitation that enforced smart batteries to have an address of 0x0B was removed when the address parameter was added in this PR: https://github.com/ArduPilot/ardupilot/pull/17820

Had a report of it confusing a user about to write their own smart battery driver.  Hence removing.