### PR TITLE
Add tab structure to document different version run commands for DDS

### DIFF
--- a/Sphinxsetup.bat
+++ b/Sphinxsetup.bat
@@ -2,7 +2,7 @@ rem remove any existing packages that may cause conflicts
 pip uninstall -y sphinx lxml sphinx-rtd-theme sphinxcontrib-youtube beautifulsoup4
 
 rem Install sphinx
-pip install --upgrade sphinx==7.1.2 "docutils<0.19" requests>=2.31.0
+pip install --upgrade sphinx==7.1.2 "docutils<0.19" requests>=2.31.0 sphinx-tabs==3.*
 
 rem lxml for parameter parsing:
 pip install --upgrade lxml

--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -51,7 +51,7 @@ rm -f get-pip.py
 
 # Install python packages using known working versions
 # Install sphinx with a specific docutils version
-python3 -m pip install --user --upgrade sphinx==${SPHINX_VERSION} "docutils<0.19"  "requests>=2.31.0"
+python3 -m pip install --user --upgrade sphinx==${SPHINX_VERSION} "docutils<0.19"  "requests>=2.31.0" sphinx-tabs==3.*
 
 # lxml for parameter parsing:
 python3 -m pip install --user --upgrade lxml

--- a/common_conf.py
+++ b/common_conf.py
@@ -15,6 +15,7 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube',  # For youtube embedding
     'sphinxcontrib.jquery',
+    'sphinx_tabs.tabs'        # For clickable tabs
 ]
 
 # Set False to re-enable warnings for non-local images.

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -6,15 +6,31 @@ ROS 2 with SITL
 
 Once ROS2 is correctly :ref:`installed <ros2>`, and SITL is also :ref:`installed <sitl-simulator-software-in-the-loop>`, source your workspace and launch ArduPilot SITL with ROS 2!
 
-.. code-block:: bash
+You will need to run this command on every new shell you open to have access to the ROS 2 commands, like so:
 
-    source /opt/ros/humble/setup.bash
-    cd ~/ros2_ws/
-    colcon build --packages-up-to ardupilot_sitl
-    source ~/ros2_ws/install/setup.bash
-    # ArduPilot 4.5
-    ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
-    # ArduPilot 4.6 removed the refs argument
+.. tabs::
+
+   .. group-tab:: ArduPilot 4.5
+
+      .. code-block:: bash
+
+        source /opt/ros/humble/setup.bash
+        cd ~/ros2_ws/
+        colcon build --packages-up-to ardupilot_sitl
+        source install/setup.bash
+        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
+
+
+   .. group-tab:: ArduPilot 4.6 and later
+
+      .. code-block:: bash
+
+        source /opt/ros/humble/setup.bash
+        cd ~/ros2_ws/
+        colcon build --packages-up-to ardupilot_sitl
+        source install/setup.bash
+        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
+
 
 If the ROS 2 topics aren't being published, set the ardupilot parameter DDS_ENABLE to 1 manually and reboot the launch.
 


### PR DESCRIPTION
We introduced a breaking change after 4.5 to remove the `refs` file which changed the build command. 
I think introducing the tab extension is a nice way to handle the difference between `4.5` and `master`/`4.6`. 

Ideally, ArduPilot wikii would have a version selector at the bottom for the entire site, but this seems like a simpler solution.

FYI @srmainwaring 


![image](https://github.com/user-attachments/assets/46c15c80-8160-4ff7-abdd-f72053360a60)
