### PR TITLE
Add GPIO current limit warning(s)

### DIFF
--- a/common/source/docs/common-buzzer.rst
+++ b/common/source/docs/common-buzzer.rst
@@ -31,6 +31,9 @@ First, the active buzzer can simply replace the passive piezo on autopilots desi
 
 Alternatively, you can set the :ref:`NTF_BUZZ_PIN<NTF_BUZZ_PIN>` to a GPIO pin, like those used for :ref:`relay control <common-relay>`, and attach an active buzzer to that pin with its negative lead, and apply power (usually +5V) to the buzzer's positive lead. This is usually how the "BUZZ" or "BUZZ-" output pin on some autopilots is intended to be used
 
+.. warning::
+    :ref:`This function is a GPIO and has limited current capabilities.<gpio-warning>`
+
 If an active buzzer is used, the :ref:`NTF_BUZZ_ON_LVL<NTF_BUZZ_ON_LVL>` parameter determines the pin level needed to activate it.
 
 If an active buzzer is used, it can indicate the following:

--- a/common/source/docs/common-camera-shutter-with-servo.rst
+++ b/common/source/docs/common-camera-shutter-with-servo.rst
@@ -30,6 +30,9 @@ Configure the autopilot by setting these parameters:
 Relay control connection and configuration
 ==========================================
 
+.. warning::
+    :ref:`This function is a GPIO and has limited current capabilities.<gpio-warning>`
+
 Connect one of the autopilot's GPIO pins to the camera or the camera control cable that accepts high/low voltage input.  As mentioned on the :ref:`relay wiki page<common-relay>` the autopilot's servo/motor outputs can normally be used but, in addition, some autopilots have dedicated pins purely for use as relays/GPIOs.
 
 Configure the autopilot by setting these parameters:

--- a/common/source/docs/common-gpios.rst
+++ b/common/source/docs/common-gpios.rst
@@ -8,6 +8,9 @@ GPIOs
 
 .. warning:: When upgrading to 4.2 or later from pre 4.2 firmware, be aware that previously defined GPIOs MAY have to be re-designated using the SERVOx_FUNCTION or, alternatively, the :ref:`SERVO_GPIO_MASK<SERVO_GPIO_MASK>` parameter and that after upgrade any GPIO dependent release mechanisms (parachute, sprayers, etc.) may actuate until this re-definition is done.
 
+.. _gpio-warning:
+.. warning:: GPIOs should only source or sink 8mA (20mA absolute maximum). They are intended as logic-level IO and must not be used to directly drive relay coils, motors, LED strings, etc. Directly connecting electromechanical or high-current devices to GPIOs can permanently damage the autopilot.
+
 General Purpose Input/Outputs (GPIOs) are used in ArduPilot for control of :ref:`relays<common-relay>`, actuators, LEDs, :ref:`camera triggers<common-camera-shutter-with-servo>`, :ref:`Start Button<startstop-switch>` etc. Some functions also use a GPIO pin as an input, like :ref:`common-rpm`. Some autopilots provide dedicated GPIO pins (sometimes labeled "CAPTURE" pins). In addition, GPIOs can be obtained by re-configuring the PWM outputs.
 
 Configuring GPIOS
@@ -32,7 +35,7 @@ in firmware versions 4.2 and later, the method for setting a PWM/SERVO/MOTOR out
 
 .. note:: for autopilots using IOMCUs, if a "MAIN" output is configured as a GPIO, it can only function as an output (ie RELAY,etc.) not an input. "AUX" outputs can function either as inputs or outputs when configures as a GPIO.
 
-Everytime the autopilot initializes, it sends a log message to the ground control station, showing which outputs are PWM/Oneshot/or DShot. The remaining higher numbered outputs are assigned as GPIOs.
+Every time the autopilot initializes, it sends a log message to the ground control station, showing which outputs are PWM/Oneshot/or DShot. The remaining higher numbered outputs are assigned as GPIOs.
 
 .. image:: ../../../images/RCOutbanner.jpg
 
@@ -40,7 +43,7 @@ Everytime the autopilot initializes, it sends a log message to the ground contro
 GPIO "PIN" NUMBER
 =================
 
-Some GPIO-based functions require that the GPIO "pin number" to be entered into an associated parameter.This pin number is assigned in the autopilot's hardware definition file. Usually, the first GPIO capable output is assigned pin 50, the second 51, etc. So in the above case of the Pixhawk, AUX OUT 6 is pin 55.
+Some GPIO-based functions require that the GPIO "pin number" to be entered into an associated parameter. This pin number is assigned in the autopilot's hardware definition file. Usually, the first GPIO capable output is assigned pin 50, the second 51, etc. So in the above case of the Pixhawk, AUX OUT 6 is pin 55.
 
 You can verify an output's GPIO pin number assignment easily. First, find its hwdef.dat file `here <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_HAL_ChibiOS/hwdef>`__ and determine the GPIO pin number listed beside its output number, as shown below:
 

--- a/common/source/docs/common-parachute.rst
+++ b/common/source/docs/common-parachute.rst
@@ -68,6 +68,9 @@ Servo Release
 Relay Release
 -------------
 
+.. warning::
+    :ref:`This function is a GPIO and has limited current capabilities.<gpio-warning>`
+
 - Determine/Configure a pin to be a GPIO (see :ref:`common-gpios`).
 - Set that pin number as one of the RELAY functions. ie For GPIO pin 51 using the first RELAY function, set :ref:`RELAY1_PIN<RELAY1_PIN>` = 51.
 - Since GPIOs are always set low initially during the bootloader period, to avoid accidental release, always use a release mechanism that needs a high output level to trigger and set:

--- a/common/source/docs/common-relay.rst
+++ b/common/source/docs/common-relay.rst
@@ -4,7 +4,10 @@
 Relay Switch
 ============
 
-A "Relay" is an digital output pin on the autopilot that can be switched between 0 volts and either 3.3V or 5V, depending on the autopilot.  Similar to a servo it allows the autopilot to invoke some action from another device on the vehicle.  Up to 6 relays can be implemented.
+.. warning::
+    :ref:`This function is a GPIO and has limited current capabilities.<gpio-warning>`
+
+A "Relay" is a digital output pin on the autopilot that can be switched between 0 volts and either 3.3V or 5V, depending on the autopilot.  Similar to a servo it allows the autopilot to invoke some action from another device on the vehicle.  Up to 6 relays can be implemented.
 
 The digital outputs that can be used as a relay are GPIOs. Normal servo/motor outputs can be configured for GPIO use. Occasionally, an autopilot will dedicate some pins for purely GPIO use as internal power controls, general purpose use,.etc. Consult the autopilot's documentation for pin number and information. In addition, it is possible to create a DroneCAN peripheral that has dedicated pins for relay use and these can be controlled as remote relays.
 
@@ -32,7 +35,7 @@ RELAYx_FUNCTION    FUNCTION
 9                   ICE Starter (Plane Only)
 ===============    ========
 
-- :ref:`RELAY2_PIN<RELAY2_PIN>`: the autopilot designated GPIO pin to be used for the function. See  the :ref:`common-gpios` page for information on how to determine the pin numbers and setup for using autopilot servo/motor outputs. DroneCAN peripherals with remote relay outputs have pin numbers in the 1000 to 1015 range. Consult the peripheral's documentation for proper pin number to use.
+- :ref:`RELAY2_PIN<RELAY2_PIN>`: the autopilot designated GPIO pin to be used for the function. See the :ref:`common-gpios` page for information on how to determine the pin numbers and setup for using autopilot servo/motor outputs. DroneCAN peripherals with remote relay outputs have pin numbers in the 1000 to 1015 range. Consult the peripheral's documentation for proper pin number to use.
 - :ref:`RELAY2_DEFAULT<RELAY2_DEFAULT>`: After boot up, should the relay default to on or off. This only applies to RELAYx_FUNC "Relay" (1). All other uses will pick the appropriate default output state from within the controlling function's parameters.
 
 


### PR DESCRIPTION
Included a GPIO current limit warning and referenced it on associated common articles.