### PR TITLE
speedybeef405wing readme, adds MAVLink ELRS howto

### DIFF
--- a/common/source/docs/common-speedybeef405wing.rst
+++ b/common/source/docs/common-speedybeef405wing.rst
@@ -135,6 +135,8 @@ To allow CRSF and embedded telemetry available in Fport, CRSF, and SRXL2 receive
 
 - SRXL2 requires a connection to TX1 and automatically provides telemetry.  Set :ref:`SERIAL2_OPTIONS<SERIAL2_OPTIONS>` to "4".
 
+- If you wish to use ELRS's upcoming `MAVLink support <https://www.expresslrs.org/software/mavlink/#flashing-and-configuring-the-mavlink-branch>`__ on UART1 (i.e. the default CRSF port), you need to set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to "4" for MAVLink telemetry (such as GPS location) to arrive on the radio. Otherwise, only ELRS telemetry (such as RQly) will arrive.
+
 .. note:: UART1 is configured by default for serial receivers. You can also have more than one receiver in the system at a time (usually used for long range hand-offs to a remote TX). See :ref:`common-multiple-rx` for details.
 
 Any UART can be used for RC system connections in ArduPilot also, and is compatible with all protocols except PPM (SBUS requires external inversion on other UARTs). See :ref:`common-rc-systems` for details.


### PR DESCRIPTION
This add a sentence about how to configure SERIAL1 to have MAVLink telemetry on the radio. Otherwise, while MAVLink will work (through backpack->wifi->QGC for example), the radio will only show ELRS telemetry.