### PR TITLE
all: don't copy rst sources in build directory

### DIFF
--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -184,6 +184,9 @@ html_js_files = [
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -177,6 +177,9 @@ html_static_path = ['_static']
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/blimp/source/conf.py
+++ b/blimp/source/conf.py
@@ -187,6 +187,9 @@ html_js_files = [
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -187,6 +187,9 @@ html_js_files = [
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -177,6 +177,9 @@ html_static_path = ['_static']
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -177,6 +177,9 @@ html_static_path = ['_static']
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -186,6 +186,9 @@ html_js_files = [
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -177,6 +177,9 @@ html_static_path = ['_static']
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -177,6 +177,9 @@ html_static_path = ['_static']
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -185,6 +185,9 @@ html_js_files = [
 # If true, the index is split into individual pages for each letter.
 # html_split_index = False
 
+# If True, the reStructuredText sources are included in the HTML build as _sources/docname.
+html_copy_source = False
+
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 


### PR DESCRIPTION
Prevent to copy rst source into the build directory : 
![image](https://github.com/user-attachments/assets/3158e705-2b74-4151-b562-cbc460fa0a57)

We don't use this for the edit as we forward to github repo directory, so those copied files are useless.