### PR TITLE
tradheli: rework of heli wiki to include flight modes and inverted flight feature

### DIFF
--- a/common/source/docs/common-archived-topics.rst
+++ b/common/source/docs/common-archived-topics.rst
@@ -66,6 +66,7 @@ value to users with old hardware.
     Advanced Tuning <tuning>
     Basic Tuning <basic-tuning>
     Auxiliary Function Switches (3.6 and earlier) <channel-7-and-8-options>
+    TradHeli Loading Firmware <loading-the-code>
 [/site]
 [site wiki="rover"]
     Pre-4.0 Rover Avoidance <rover-object-avoidance>

--- a/copter/source/docs/flight-modes.rst
+++ b/copter/source/docs/flight-modes.rst
@@ -46,8 +46,8 @@ The table below shows for each flight mode whether it provides altitude or posit
    <tr><td>Sport</td><td>s</td><td>s</td><td></td><td>Alt-hold, but holds pitch & roll when sticks centered</td></tr>
    <tr><td>Stabilize</td><td>-</td><td>+</td><td></td><td>Self-levels the roll and pitch axis</td></tr>
    <tr><td>SysID</td><td>-</td><td>+</td><td></td><td>Special diagnostic/modeling mode</td></tr>
-   <tr><td>Throw</td><td>A</td><td>A</td><td>Y</td><td>Holds position after a throwing takeoff</td></tr>
-   <tr><td>Turtle</td><td>-</td><td>-</td><td></td><td>Allows reversing and spinning up adjacent pairs of motors in order to flip a crashed, inverted vehicle back upright</td></tr>
+   <tr><td>Throw</td><td>A</td><td>A</td><td>Y</td><td>Holds position after a throwing takeoff. Multirotors only.</td></tr>
+   <tr><td>Turtle</td><td>-</td><td>-</td><td></td><td>Allows reversing and spinning up adjacent pairs of motors in order to flip a crashed, inverted vehicle back upright. Multirotors only.</td></tr>
    <tr><td>ZigZag</td><td>A</td><td>A</td><td>Y</td><td>Useful for crop spraying</td></tr>
    </table>
 
@@ -93,12 +93,12 @@ Additional flight modes:
 -  :ref:`Land <land-mode>`
 -  :ref:`PosHold <poshold-mode>`
 -  :ref:`Sport <sport-mode>`
--  :ref:`Throw <throw-mode>`
+-  :ref:`Throw <throw-mode>` for multirotors only.
 -  :ref:`Follow Me <ac2_followme>`
 -  :ref:`Simple and Super Simple <simpleandsuper-simple-modes>`
 -  :ref:`Smart RTL (Return-to-Launch) <smartrtl-mode>`
 -  :ref:`SysID (System Identification) <systemid-mode>`
--  :ref:`Turtle <turtle-mode>`
+-  :ref:`Turtle <turtle-mode>` for multirotors only.
 -  :ref:`ZigZag <zigzag-mode>`
 -  :ref:`Avoid_ADSB <common-ads-b-receiver>` for ADS-B based avoidance of manned aircraft.  Should not be set-up as a pilot selectable flight mode.
 

--- a/copter/source/docs/loading-the-code.rst
+++ b/copter/source/docs/loading-the-code.rst
@@ -1,5 +1,7 @@
 .. _loading-the-code:
 
+**ARCHIVED**
+
 =============================================
 Traditional Helicopter – Loading the Firmware
 =============================================

--- a/copter/source/docs/throw-mode.rst
+++ b/copter/source/docs/throw-mode.rst
@@ -7,6 +7,10 @@ Throw Mode
 This slightly dangerous flight mode allows the pilot to throw the vehicle into the air (or drop the vehicle) in order to start the motors.
 Once in the air, this mode does not accept any input from the pilot.  This mode requires GPS.
 
+.. note::
+
+    This flight mode is available for multirotors only. 
+
 .. warning::
 
    Use with caution!  It is dangerous to get close to an armed multicopter as is required to throw the vehicle.  It is recommended to takeoff normally instead of using throw mode whenever possible.

--- a/copter/source/docs/traditional-helicopter-autopilot-assembly-instructions.rst
+++ b/copter/source/docs/traditional-helicopter-autopilot-assembly-instructions.rst
@@ -1,0 +1,20 @@
+.. _traditional-helicopter-autopilot-assembly-instructions:
+
+======================================
+Autopilot System Assembly Instructions
+======================================
+
+This section contains the instructions for assembling the "essential
+components" of Arducopter firmware on Pixhawk and other autopilots. The
+instructions for adding other hardware are covered in 
+:ref:`Optional Hardware <common-optional-hardware>`.
+
+.. toctree::
+    :maxdepth: 1
+
+    Mounting the Autopilot <trad-heli-mounting>
+    Autopilot Wiring <common-flight-controller-wiring>
+    NAVIO2 (Linux based) Wiring QuickStart <common-navio2-wiring-and-quick-start>
+    Installing GPS+Compass Module <common-installing-3dr-ublox-gps-compass-module>
+    Vibration Damping <common-vibration-damping>
+    Magnetic Interference <common-magnetic-interference>

--- a/copter/source/docs/traditional-helicopter-configuring-hardware.rst
+++ b/copter/source/docs/traditional-helicopter-configuring-hardware.rst
@@ -1,0 +1,34 @@
+.. _traditional-helicopter-configuring-hardware:
+
+================================
+Mandatory Hardware Configuration
+================================
+
+As part of first time setup, you'll need to configure some required
+hardware components. The linked articles describe the process for
+selecting frame orientation and configuring the RC transmitter/receiver,
+compass, and accelerometer using *Mission Planner* and how to configure
+the ESCs.
+
+In addition to mandatory calibration, you may also choose to :ref:`Configure Optional Hardware <common-optional-hardware>`
+including battery monitor, sonar, airspeed sensor, optical flow, OSD,
+camera gimbal, antenna tracker etc.
+
+.. toctree::
+    :maxdepth: 1
+
+    Basic System Overview <common-basic-operation>
+    Frame Type Configuration <frame-type-configuration>
+    Helicopter Parameter List at a Glance <traditional-helicopter-parameter-list>
+    Configuring Servo, Motor, and RC Connections with the autopilot <traditional-helicopter-connecting-apm>
+    Radio Control Calibration <traditional-helicopter-rc-calibration>
+    Accelerometer Calibration <common-accelerometer-calibration>
+    Compass Calibration <common-compass-calibration-in-mission-planner>
+    RC Transmitter Mode Setup <common-rc-transmitter-flight-mode-configuration>
+    ESC Calibration <traditional-helicopter-esc-calibration>
+    Swashplate Setup <traditional-helicopter-swashplate-setup>
+    Tailrotor Setup <traditional-helicopter-tailrotor-setup>
+    Rotor Speed Control Setup <traditional-helicopter-rsc-setup>
+    Internal Rotor Speed Governor <traditional-helicopter-internal-rsc-governor>
+    Failsafe Mechanisms <failsafe-landing-page>
+    Flight Modes <flight-modes>

--- a/copter/source/docs/traditional-helicopter-connecting-apm.rst
+++ b/copter/source/docs/traditional-helicopter-connecting-apm.rst
@@ -1,8 +1,8 @@
 .. _traditional-helicopter-connecting-apm:
 
-==============================================================
-Traditional Helicopter — Connecting and Calibrating the System
-==============================================================
+=====================================================================
+Traditional Helicopter — Configuring Servo, Motor, and RC Connections
+=====================================================================
 
 This page covers how to make the physical connections between the autopilot, RC receiver, ESC and servos as well as calibrating the RC transmitter, Compass, Accelerometer, and ESC.  The following video covers making the connections and setting up the transmitter to work with the autopilot.
 
@@ -72,40 +72,3 @@ The throttle servo or ESC for the main rotor motor is defaulted to output 8.  Th
 Check the docs for your selected autopilot but most require a separate power supply to the servo rail to power your servos at their appropriate rated voltage. 
 
 Connect telemetry radios, GPS/compass module, power to autopilot itself, and any other peripherals as per the instructions in the owners manual for the unit.
-
-RC Calibration
---------------
-
-.. warning::
-
-   Before powering the autopilot and servo rail for the first time, 
-   disconnect the rudder linkage from the tail servo or bellcrank on the tail 
-   gearbox. If you have a piston engine helicopter, also disconnect the throttle
-   servo linkage. 
-
-The RC MUST be calibrated before proceeding once the autopilot is powered up. RC calibration is identical to all other vehicles. With helicopters using the ArduPilot system there can be no mixes in the RC radio. All the outputs must be
-"pure", i.e. use either airplane mode in your radio, or helicopter mode with H1 or "straight" swash.
-:ref:`See this topic <common-radio-control-calibration>`.
-
-Compass Calibration
--------------------
-
-It is recommended to calibrate the compasses at this time as well. This is the same as all other vehicles.
-:ref:`See this topic <common-compass-calibration-in-mission-planner>`.
-
-Accelerometer Calibration
--------------------------
-If the accelerometers were not calibrated on the bench prior to installation it must be calibrated before proceeding.(It is usually easier to calibrate on the bench and then re-calibrate only the level position, if required, once installed.)
-:ref:`See this topic <common-accelerometer-calibration>`.
-
-ESC Calibration
----------------
-
-
-.. warning:: be sure to remove all blades when doing ESC calibration.
-
-Some ESCs must be calibrated to the throttle range (ie HeliRSC output range, which defaults to 1000 to 2000us). In addition, it is often required to change ESC settings, such as enabling the governor mode and/or setting voltage protection levels.
-
-In order to do this, you must be able to directly control the input to the ESC. By default the output function where it is attached is set to HeliRSC (:ref:`SERVO8_FUNCTION<SERVO8_FUNCTION>` = 31). In order to pass the throttle stick directly to the ESC for ESC programming per the ESC's instructions, temporarily change this to :ref:`SERVO8_FUNCTION<SERVO8_FUNCTION>` = 53. Remember to change it back to "31", after completing the ESC programming.
-
-In addition, check to see that :ref:`RC3_MIN<RC3_MIN>` and :ref:`RC3_MAX<RC3_MAX>` match the MIN and MAX range of the HeliRSC output, which defaults to SERVO8 output (:ref:`SERVO8_MIN<SERVO8_MIN>`, :ref:`SERVO8_MAX<SERVO8_MAX>`), since passing through the throttle input will be direct and ignore those values, hich you are trying to match in the calibration. If not, temporarily change them to  match and then return them to the values when :ref:`common-radio-control-calibration` was done.

--- a/copter/source/docs/traditional-helicopter-esc-calibration.rst
+++ b/copter/source/docs/traditional-helicopter-esc-calibration.rst
@@ -1,0 +1,16 @@
+.. _traditional-helicopter-esc-calibration:
+
+========================================
+Traditional Helicopter — ESC Calibration
+========================================
+
+This page covers specific details about calibrating the ESC for a helicopter.  If using the ESC's internal governor, ESC calibration is not required.
+
+
+.. warning:: be sure to remove all blades when doing ESC calibration.
+
+Some ESCs must be calibrated to the throttle range (ie HeliRSC output range, which defaults to 1000 to 2000us). In addition, it is often required to change ESC settings, such as enabling the governor mode and/or setting voltage protection levels.
+
+In order to do this, you must be able to directly control the input to the ESC. By default the output function where it is attached is set to HeliRSC (:ref:`SERVO8_FUNCTION<SERVO8_FUNCTION>` = 31). In order to pass the throttle stick directly to the ESC for ESC programming per the ESC's instructions, temporarily change this to :ref:`SERVO8_FUNCTION<SERVO8_FUNCTION>` = 53. Remember to change it back to "31", after completing the ESC programming.
+
+In addition, check to see that :ref:`RC3_MIN<RC3_MIN>` and :ref:`RC3_MAX<RC3_MAX>` match the MIN and MAX range of the HeliRSC output, which defaults to SERVO8 output (:ref:`SERVO8_MIN<SERVO8_MIN>`, :ref:`SERVO8_MAX<SERVO8_MAX>`), since passing through the throttle input will be direct and ignore those values, hich you are trying to match in the calibration. If not, temporarily change them to  match and then return them to the values when :ref:`common-radio-control-calibration` was done.

--- a/copter/source/docs/traditional-helicopter-first-time-setup.rst
+++ b/copter/source/docs/traditional-helicopter-first-time-setup.rst
@@ -5,17 +5,23 @@
 Traditional Helicopter Setup
 ============================
 
+First-time setup of the autopilot includes downloading and installing a Ground Control Station (GCS), 
+mounting the autopilot to the frame,
+connecting it to the receiver, power and motors, 
+and then performing initial configuration and calibration.
+
+For more information on each of these tasks (sorted by autopilot
+within the sections) see the topics below:
+
 .. toctree::
     :maxdepth: 1
 
+    Install Ground Station Software <common-install-gcs>
+    Autopilot System Assembly <traditional-helicopter-autopilot-assembly-instructions>
+    Loading Firmware to boards with existing ArduPilot firmware <common-loading-firmware-onto-pixhawk>
+    Loading Firmware to boards without existing ArduPilot firmware<common-loading-firmware-onto-chibios-only-boards>
+    Connect Mission Planner to AutoPilot <common-connect-mission-planner-autopilot>
     Suggested Parts List <traditional-heli-parts-list>
-    Loading the Firmware <loading-the-code>
-    Mounting the Autopilot <trad-heli-mounting>
-    Helicopter Parameter List at a Glance <traditional-helicopter-parameter-list>
-    Connecting and Calibration <traditional-helicopter-connecting-apm>
-    Swashplate Setup <traditional-helicopter-swashplate-setup>
-    Tailrotor Setup <traditional-helicopter-tailrotor-setup>
-    Rotor Speed Control Setup <traditional-helicopter-rsc-setup>
-    Internal Rotor Speed Governor <traditional-helicopter-internal-rsc-governor>
+    Configuration <traditional-helicopter-configuring-hardware>
 
 After initial setup, be sure to follow the instructions in :ref:`traditional-helicopter-first-flight`

--- a/copter/source/docs/traditional-helicopter-rc-calibration.rst
+++ b/copter/source/docs/traditional-helicopter-rc-calibration.rst
@@ -1,0 +1,18 @@
+.. _traditional-helicopter-rc-calibration:
+
+=======================================
+Traditional Helicopter — RC Calibration
+=======================================
+
+This page covers specific details about calibrating the RC controller for a helicopter.
+
+.. warning::
+
+   Before powering the autopilot and servo rail for the first time, 
+   disconnect the rudder linkage from the tail servo or bellcrank on the tail 
+   gearbox. If you have a piston engine helicopter, also disconnect the throttle
+   servo linkage. 
+
+The RC MUST be calibrated before proceeding once the autopilot is powered up. RC calibration is identical to all other vehicles. With helicopters using the ArduPilot system there can be no mixes in the RC radio. All the outputs must be
+"pure", i.e. use either airplane mode in your radio, or helicopter mode with H1 or "straight" swash.
+:ref:`General Radio Control Calibration Wiki <common-radio-control-calibration>`.

--- a/copter/source/docs/turtle-mode.rst
+++ b/copter/source/docs/turtle-mode.rst
@@ -6,6 +6,10 @@ Turtle Mode
 
 Turtle Mode is a special mode that can be invoked either as a :ref:`flight mode <flight-modes>` via the flight mode switch or as an :ref:`Auxilary function <common-auxiliary-functions>` assigned to an RC switch (channel). Turtle mode allows a user to attempt to flip the Copter upright, if inverted, by reversing the direction of adjacent pairs of motors and producing thrust to un-invert the vehicle after a crash.
 
+.. note::
+
+    This flight mode is available for multirotors only. 
+
 DShot capable ESCs are required for this mode to function, allowing the DShot reverse command to be sent to the ESCs. :ref:`SERVO_DSHOT_ESC<SERVO_DSHOT_ESC>` must be set to a non-zero value and :ref:`MOT_PWM_TYPE<MOT_PWM_TYPE>` to a DSHOT value also, to allow DShot commands to be sent to the ESC.
 
 Once in this mode, moving the roll and/or pitch stick of the transmitter away from center will reverse and spin up the designated pair of motors, increasing thrust to maximum at full stick throw.


### PR DESCRIPTION
This PR reworks the helicopter setup instructions to mimic the other vehicle setup wikis.  It also modifies the flight modes to indicate those not supported by tradheli and adds the inverted flight feature.  

@Hwurzburg -this is still a work in progress.  will add the inverted flight feature tomorrow