### PR TITLE
Dev: Recommend a new ardu_ws instead of ros2_ws

### DIFF
--- a/dev/source/docs/ros2-cartographer-slam.rst
+++ b/dev/source/docs/ros2-cartographer-slam.rst
@@ -15,19 +15,19 @@ Once that's done, simply run:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws/src
+    cd ~/ardu_ws/src
     git clone git@github.com:ArduPilot/ardupilot_ros.git
 
 .. code-block:: bash
     
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     rosdep install --from-paths src --ignore-src -r --skip-keys gazebo-ros-pkgs
 
 Now source your workspace and build `ardupilot_ros`:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     source ./install/setup.bash
     colcon build --packages-up-to ardupilot_ros ardupilot_gz_bringup
 
@@ -39,7 +39,7 @@ To launch rviz and gazebo, run:
 
 .. code-block:: bash
     
-    source ~/ros2_ws/install/setup.sh
+    source ~/ardu_ws/install/setup.sh
     ros2 launch ardupilot_gz_bringup iris_maze.launch.py
 
 Now, we can launch Google Cartographer to generate SLAM, check if a map is being generated correctly in RVIZ.
@@ -47,7 +47,7 @@ In another terminal, run:
 
 .. code-block:: bash
     
-    source ~/ros2_ws/install/setup.sh
+    source ~/ardu_ws/install/setup.sh
     ros2 launch ardupilot_ros cartographer.launch.py
 
 Configure ArduPilot

--- a/dev/source/docs/ros2-gazebo.rst
+++ b/dev/source/docs/ros2-gazebo.rst
@@ -25,7 +25,7 @@ We will clone the required repositories using `vcstool <https://github.com/dirk-
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     vcs import --input https://raw.githubusercontent.com/ArduPilot/ardupilot_gz/main/ros2_gz.repos --recursive src
 
 Set the Gazebo version to either ``harmonic`` (recommended) or ``garden``.
@@ -39,7 +39,7 @@ Update ROS dependencies:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     source /opt/ros/humble/setup.bash
     sudo apt update
     rosdep update
@@ -52,14 +52,14 @@ Build:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     colcon build --packages-up-to ardupilot_gz_bringup
 
 If you'd like to test your installation, run:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     source install/setup.bash
     colcon test --packages-select ardupilot_sitl ardupilot_dds_tests ardupilot_gazebo ardupilot_gz_applications ardupilot_gz_description ardupilot_gz_gazebo ardupilot_gz_bringup
     colcon test-result --all --verbose

--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -15,7 +15,7 @@ You will need to run this command on every new shell you open to have access to 
       .. code-block:: bash
 
         source /opt/ros/humble/setup.bash
-        cd ~/ros2_ws/
+        cd ~/ardu_ws/
         colcon build --packages-up-to ardupilot_sitl
         source install/setup.bash
         ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
@@ -26,7 +26,7 @@ You will need to run this command on every new shell you open to have access to 
       .. code-block:: bash
 
         source /opt/ros/humble/setup.bash
-        cd ~/ros2_ws/
+        cd ~/ardu_ws/
         colcon build --packages-up-to ardupilot_sitl
         source install/setup.bash
         ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
@@ -43,7 +43,7 @@ Once everything is running, you can now interact with ArduPilot through the ROS 
 
 .. code-block:: bash
 
-    source ~/ros2_ws/install/setup.bash
+    source ~/ardu_ws/install/setup.bash
     # See the node appear in the ROS graph
     ros2 node list
     # See which topics are exposed by the node
@@ -55,7 +55,7 @@ If the ROS 2 topics aren't being published, ensure the ardupilot parameter ref:`
 
 .. code-block:: bash
 
-    export PATH=$PATH:~/ros2_ws/src/ardupilot/Tools/autotest
+    export PATH=$PATH:~/ardu_ws/src/ardupilot/Tools/autotest
     sim_vehicle.py -w -v ArduPlane --console -DG --enable-dds
 
     param set DDS_ENABLE 1

--- a/dev/source/docs/ros2-waypoint-goal-interface.rst
+++ b/dev/source/docs/ros2-waypoint-goal-interface.rst
@@ -20,15 +20,15 @@ Once that's done, simply run:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws/src
-    source ~/ros2_ws/install/setup.bash
+    cd ~/ardu_ws/src
+    source ~/ardu_ws/install/setup.bash
     cd ardupilot/libraries/AP_DDS
     ros2 run micro_ros_agent micro_ros_agent udp4 -p 2019 -r dds_xrce_profile.xml
 
 .. code-block:: bash
 
-    cd ~/ros2_ws/src/ardupilot
-    source ~/ros2_ws/install/setup.bash
+    cd ~/ardu_ws/src/ardupilot
+    source ~/ardu_ws/install/setup.bash
     ./Tools/autotest/sim_vehicle.py -w -v ArduPlane --console  --enable-dds --map -DG
 
 Now that SITL is running, you have two options: run the ROS2 Node or use CLI commands.
@@ -78,7 +78,7 @@ Using ROS2 Node
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     source ./install/setup.bash
     ros2 run ardupilot_dds_tests plane_waypoint_follower
 

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -25,7 +25,7 @@ First, make sure that you have successfully installed `ROS 2 Humble <https://doc
 Currently, ROS 2 Humble is the only version supported.
 
 You are about to create a new `ROS 2 workspace <https://docs.ros.org/en/humble/Tutorials/Beginner-Client-Libraries/Creating-A-Workspace/Creating-A-Workspace.html#id4>`__.
-This page assumes that your workspace is named `ros2_ws` in your home directory, but feel free to adjust to your preferred location.
+This page assumes that your workspace is named `ardu_ws` in your home directory, but feel free to adjust to your preferred location.
 
 Before anything else, make sure that you have `sourced your ROS 2 environment <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`__
 and check if it is `configured correctly <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#check-environment-variables>`__.
@@ -39,7 +39,8 @@ To make installation easy, we will clone the required repositories using `vcs` a
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    mkdir -p ~/ardu_ws/src
+    cd ~/ardu_ws
     vcs import --recursive --input  https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2.repos src
 
 This will take a few minutes to clone all the repositories your first time.
@@ -48,7 +49,7 @@ Now update all dependencies:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     sudo apt update
     rosdep update
     source /opt/ros/humble/setup.bash
@@ -59,7 +60,7 @@ Installing the `MicroXRCEDDSGen` build dependency:
 .. code-block:: bash
     
     sudo apt install default-jre
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     git clone --recurse-submodules https://github.com/ardupilot/Micro-XRCE-DDS-Gen.git
     cd Micro-XRCE-DDS-Gen
     ./gradlew assemble
@@ -86,7 +87,7 @@ And finally, build your workspace:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     colcon build --packages-up-to ardupilot_dds_tests
 
 If the build fails, when you request help, please re-run the build in verbose mode like so:
@@ -99,7 +100,7 @@ If you'd like to test your ArduPilot ROS 2 installation, run:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     source ./install/setup.bash
     colcon test --executor sequential --parallel-workers 0 --base-paths src/ardupilot --event-handlers=console_cohesion+
     colcon test-result --all --verbose
@@ -123,7 +124,7 @@ To make installation easy, we will install the required packages using `vcs` and
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     vcs import --recursive --input https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/ros2/ros2_macos.repos src
 
 Now update all dependencies:
@@ -137,7 +138,7 @@ Build microxrcedds_gen:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws/src/microxrcedds_gen
+    cd ~/ardu_ws/src/microxrcedds_gen
     ./gradlew assemble
     export PATH=$PATH:$(pwd)/scripts
 
@@ -145,7 +146,7 @@ And finally, build your workspace:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     colcon build --symlink-install --cmake-args \
     -DBUILD_TESTING=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -161,7 +162,7 @@ If you'd like to test your installation, run:
 
 .. code-block:: bash
 
-    cd ~/ros2_ws
+    cd ~/ardu_ws
     colcon test \
     --pytest-args -s -v \
     --event-handlers console_cohesion+ desktop_notification- \


### PR DESCRIPTION
# Purpose

We want to recommend ardupilot users to create a fresh workspace instead of whatever random code that have in their first ROS2 workspace. Therefore, name it `ardu_ws`. Also, make sure the "src" folder exists before calling VCS.
