### PR TITLE
editorconfig: dot file fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,6 @@ indent_style = space
 indent_size = 4
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = false # These are the correct rules for coding standards, but fixing up old files causes git spam
+# These are the correct rules for coding standards, but fixing up old files causes git spam
+trim_trailing_whitespace = false
 insert_final_newline = false


### PR DESCRIPTION
Extremely minor fix with no impact to build functionality or wiki content.

- Newer versions of [neovim](https://neovim.io/) complain about the trailing comment (observed in v0.10.1).
- Moving the comment to the line above the referenced settings fixes the nag warning that must be acknowledged when editing with neovim.

Nag warning that is fixed by this PR:
![image](https://github.com/user-attachments/assets/b607a4f1-60ff-49aa-9647-f981194a36f7)