### PR TITLE
Common: Fix incorrect user

### DIFF
--- a/common/source/docs/common-wiki-editing-setup.rst
+++ b/common/source/docs/common-wiki-editing-setup.rst
@@ -112,7 +112,7 @@ Setup with Docker
    .. code-block:: bash
 
        cd ardupilot_wiki
-       docker build . -t ardupilot_wiki
+       docker build . -t ardupilot_wiki --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
 
 This will build a docker image with all package setup to build the wiki and name it ``ardupilot_wiki``.
 


### PR DESCRIPTION
* If you aren't user 1000, this command will build with the wrong user
* Then python can't find any packages and you get a requests import error

Fixes this issue testing another PR:
https://github.com/ArduPilot/ardupilot_wiki/pull/6255#pullrequestreview-2288626098

![image](https://github.com/user-attachments/assets/cda93067-0619-40ea-b438-6c1e8a544c4a)
