### PR TITLE
Update sprayer.rst

### DIFF
--- a/copter/source/docs/sprayer.rst
+++ b/copter/source/docs/sprayer.rst
@@ -25,7 +25,7 @@ A multicopter such as the `EnRoute AC 940-D <https://www.nttedt.co.jp/product?pg
 
 The pump controls the rate of flow of the fertilizer.
 
-The optional spinner should be attached to the end of the spraying nozzles and distributes the fertilizer to a wider area.
+The optional spinner (rotary atomizer) should be attached to the end of the spraying nozzles and enables control over spray droplet size. Higher PWM, faster rotation, smaller droplets. 
 
 Enabling the Sprayer
 ====================


### PR DESCRIPTION
updated description of the "Spinner" as it was phyisically incorrect. higher RPMs produce smaller droplets which if used improperly may drift away from the intended crop and damage local environment or other crops