### PR TITLE
Fix missing requirements.txt in Docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME} \
 USER ${USER_NAME}
 
 COPY Sphinxsetup.sh ${WORKDIRECTORY}/Sphinxsetup.sh
+COPY requirements.txt ${WORKDIRECTORY}/requirements.txt
 RUN --mount=type=cache,target=/var/cache/apt \
     bash -c "${WORKDIRECTORY}/Sphinxsetup.sh" && rm Sphinxsetup.sh
 


### PR DESCRIPTION
- Added `requirements.txt` to the Docker build context to resolve the missing file error during the `Sphinxsetup.sh` script execution.
- Updated Dockerfile to ensure `requirements.txt` is copied into the working directory before running the script.
- Verified successful Docker image build with all dependencies installed.

This change resolves the error:
```bash
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'requirements.txt'
```