### PR TITLE
Fix dockerfile missing requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,10 @@ RUN echo "${USER_NAME} ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/${USER_NAME} \
 
 USER ${USER_NAME}
 
-COPY Sphinxsetup.sh ${WORKDIRECTORY}/Sphinxsetup.sh
 RUN --mount=type=cache,target=/var/cache/apt \
-    bash -c "${WORKDIRECTORY}/Sphinxsetup.sh" && rm Sphinxsetup.sh
+    --mount=type=bind,source=Sphinxsetup.sh,target=${WORKDIRECTORY}/Sphinxsetup.sh \
+    --mount=type=bind,source=requirements.txt,target=${WORKDIRECTORY}/requirements.txt \
+    bash -c "./Sphinxsetup.sh"
 
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION

# Problem

The requirements file was not copied into the dockerfile.

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/c04dd8b5-88c4-418c-84cf-96b6e0a8059f">


# Solution

I switch to bind mount so you don't have to delete the file, and this is better for cache.


# Test 

```bash
docker build . -t ardupilot_wiki --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) --progress=plain
```