### PR TITLE
.github: Add CI for dockerfile

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,17 @@
+name: Build dockerfile
+
+on: [push, pull_request]
+
+jobs:
+
+  build-docker:
+
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false  # don't cancel if a job from the matrix fails
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: |
+          docker build . -t ardupilot_wiki --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)


### PR DESCRIPTION
# Purpose

Add CI, so we don't break the dockerfile like we did in https://github.com/ArduPilot/ardupilot_wiki/pull/4642 and have to patch it.

# Dependencies

https://github.com/ArduPilot/ardupilot_wiki/pull/6341

^ Once that's in, rebase this and the job should pass. The current failing check shows that this PR would have caught the broken dockerfile.