### PR TITLE
Wiki: replace old command

### DIFF
--- a/dev/source/docs/sitl-with-jsbsim.rst
+++ b/dev/source/docs/sitl-with-jsbsim.rst
@@ -26,7 +26,7 @@ In the same directory (your home directory) run these commands:
 
 ::
 
-    git clone git://github.com/JSBSim-Team/jsbsim.git
+    git clone https://github.com/JSBSim-Team/jsbsim.git
     cd jsbsim
     mkdir build
     cd build


### PR DESCRIPTION
Discouraged older git protocol, use new one wich is more secure.