### PR TITLE
modules: chat requirements updated to spec vehicle version

### DIFF
--- a/mavproxy/source/docs/modules/chat.rst
+++ b/mavproxy/source/docs/modules/chat.rst
@@ -23,6 +23,7 @@ Prerequisites
 - On Linux/Ubuntu the pyaudio, wave and openai python packages must be installed manually
 - `OpenAI API key  <https://platform.openai.com/docs/quickstart/account-setup>`__
 - Setup the OpenAI Assistant (not required for core developers using ArduPilot's API key)
+- Vehicle must be running ArduPilot 4.6 (or higher)
 
 Installing Python Packages on Linux/Ubuntu
 ------------------------------------------


### PR DESCRIPTION
This updates the mavproxy chat module's page to specify that AP 4.6 must be used.  This is in response to a user in the Discord "ai" chat struggling to get the module to work.

This has been tested locally and looks OK to me