### PR TITLE
Use pip to install mavproxy

### DIFF
--- a/mavproxy/source/docs/development/mavdevenvlinux.rst
+++ b/mavproxy/source/docs/development/mavdevenvlinux.rst
@@ -27,6 +27,6 @@ changes to the source code. This can be done by:
 
 .. code:: bash
 
-    python setup.py build install --user
+    python3 -m pip install .
 
 MAVProxy can then be run as per normal.


### PR DESCRIPTION
* Invoking setup.py is deprecated
* https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#what-commands-should-be-used-instead
* This is a precursor to https://github.com/ArduPilot/ardupilot_wiki/pull/6371
* This is what both Peter and Tridge use nowadays