### PR TITLE
removed broken roadmap links

### DIFF
--- a/dev/source/docs/how-the-team-works.rst
+++ b/dev/source/docs/how-the-team-works.rst
@@ -15,7 +15,6 @@ These pages are less about the software directly and more about the procedures a
     Developer Code of Conduct <developer-code-of-conduct>
     Funding Committee <how-the-team-works-development-fund>
     Job Openings <job-openings>
-    Roadmap <https://github.com/orgs/ArduPilot/projects/2>
     Top Contributors <common-team>
     Voting <how-the-team-works-voting>
     Weekly meetings on Discord <ardupilot-discord-server>

--- a/frontend/includes/_topbar.html
+++ b/frontend/includes/_topbar.html
@@ -32,7 +32,6 @@
 						<a class="dropdown-item"
 							href="https://ardupilot.org/ardupilot/docs/common-partners.html">Partners</a>
 						<!-- There is a partners.html waiting for be enhanced -->
-						<a class="dropdown-item" href="https://github.com/orgs/ArduPilot/projects/2">Roadmap</a>
 						<a class="dropdown-item"
 							href="https://ardupilot.org/dev/docs/common-training-centers.html">Schools</a>
 						<a class="dropdown-item" href="https://ardupilot.org/ardupilot/docs/common-team.html">Team</a>


### PR DESCRIPTION
I removed the links to the Roadmap from the navigation menu, because they no longer worked.

One could replace it with the [project overviews page](https://github.com/orgs/ArduPilot/projects), but I wasn't sure what is the right choice there. 