### PR TITLE
Common: LDRobot LD-06 order on landing page fixed

### DIFF
--- a/common/source/docs/common-ld06.rst
+++ b/common/source/docs/common-ld06.rst
@@ -1,15 +1,14 @@
 .. _common-ld06:
 
 [copywiki destination ="plane,copter,rover,blimp"]
-===========
-LD-06 Lidar
-===========
+===================
+LDRobot LD-06 Lidar
+===================
 
 This Lidar is supplied by numerous sources:
 
 - `innomaker <https://www.inno-maker.com/product/lidar-ld06/>`__
-- `Yaboom <https://category.yahboom.net/products/ld06-dtof>`__
-- `LDROBOT <https://www.ldrobot.com>`__
+- `LDROBOT <https://www.ldrobot.com/SensorIndex>`__
 
 .. image:: ../../../images/ld-06.jpg
        :width: 480px

--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -72,7 +72,6 @@ Unidirectional Rangefinders
     HC-SR04 Sonar <common-rangefinder-hcsr04>
     JAE JRE-30 <common-rangefinder-jae-jre-30>
     JSN-SR04T Sonar <common-jsn-sr04t>
-    LD-06 TOF Lidar <common-ld06>
     LeddarTech Leddar One <common-leddar-one-lidar>
     LeddarTech LeddarVu8 <common-leddartech-leddarvu8-lidar>
     LightWare SF10 / SF11 Lidar <common-lightware-sf10-lidar>
@@ -94,6 +93,7 @@ Omnidirectional Proximity Rangefinders
 .. toctree::
     :maxdepth: 1
 
+    LDRobot LD-06 TOF <common-ld06>
     Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
     Lightware SF45/B (350 degree) <common-lightware-sf45b>
     Nanoradar MK72 (112 degree) <common-rangefinder-mr72>


### PR DESCRIPTION
The LD-06 was listed in the 1D section instead of the 360deg section.  I also updated the link and title to include the manufacturer name.

This has been tested locally and looks OK to me

This comes in response to [this 4.6 beta testing discussion](https://discuss.ardupilot.org/t/copter-4-6-0-beta1-is-available-for-beta-testing/126295/8)