### PR TITLE
Common: fix am32 link on blheli page

### DIFF
--- a/common/source/docs/common-blheli32-passthru.rst
+++ b/common/source/docs/common-blheli32-passthru.rst
@@ -17,7 +17,7 @@ Depending on the ESC, BLHeli/BLHeli_S/BLHeli32/AM32 provides the following featu
 
 - BLHeli was the original open source software that is no longer maintained and is not available on modern ESCs
 - BLHeli32is closed source and based on 32bit ARM MCUs and development and licensing was terminated in 2024.  All modern BLHeli ESCs use BLHeli32 but will be replaced with AM32 in the future.
-- 'AM32 <https://am32.ca>`__ is open source with the same features as BLHeli32 before it became unavailable for new designs but continues to evolve.
+- `AM32 <https://am32.ca>`__ is open source with the same features as BLHeli32 before it became unavailable for new designs but continues to evolve.
 - `BLHeli_S <https://github.com/bitdump/BLHeli>`__ is open source and 16bit.  This is no longer actively maintained but the last published version, 16.7, is installed by default on "BLHeli_S" ESCs when shipped from the factory
 - `BLHeli_S JESC <https://jflight.net>`__ is paid, closed source software and 16bit allowing it to run on lower end hardware
 - `BLHeli_S BlueJay <https://github.com/mathiasvr/bluejay>`__ is free, open source software and 16bit


### PR DESCRIPTION
This fixes a minor typo that breaks the am32 link on the blheli32 page

I've tested this locally and it looks OK