### PR TITLE
Copter/Rover: fix reference frame page's link to RTF page

### DIFF
--- a/copter/source/docs/reference-frames.rst
+++ b/copter/source/docs/reference-frames.rst
@@ -6,7 +6,7 @@ Reference Frames
 
 .. image:: ../images/reference-frames-top-image.jpg
 
-This section includes details on tested frames to speed up DIY builds of multicopters.  If you are looking for a completely ready-to-use vehicle please see our `RTF wiki page <https://ardupilot.org/ardupilot/docs/common-rtf.html>`__.
+This section includes details on tested frames to speed up DIY builds of multicopters.  If you are looking for a completely ready-to-use vehicle please see our :ref:`RTF wiki page <common-rtf>`.
 
 .. toctree::
     :maxdepth: 1

--- a/rover/source/docs/reference-frames.rst
+++ b/rover/source/docs/reference-frames.rst
@@ -6,7 +6,7 @@ Reference Frames
 
 .. image:: ../images/reference-frame-top-image.png
 
-This section includes details on tested frames to speed up DIY builds of rovers and boats.  If you are looking for a completely ready-to-use vehicle please see our `RTF wiki page <https://ardupilot.org/ardupilot/docs/common-rtf.html>`__.
+This section includes details on tested frames to speed up DIY builds of rovers and boats.  If you are looking for a completely ready-to-use vehicle please see our :ref:`RTF wiki page <common-rtf>`.
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
I've tested this locally and it looks OK to me

Thanks @tpwrules for noticing this!