### PR TITLE
Adjust BATT_MON parameters for disambiguation

### DIFF
--- a/common/source/docs/common-3DR_Control_Zero_OEM_G.rst
+++ b/common/source/docs/common-3DR_Control_Zero_OEM_G.rst
@@ -123,13 +123,13 @@ The following settings are set by default on the board to work with a Power Zero
 
 :ref:`BATT_MONITOR<BATT_MONITOR>` =4
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 15
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 15.3
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 15.3
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 50
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50
 
 Other Power Module will need to adjust these values.
 

--- a/common/source/docs/common-3dr-power-module.rst
+++ b/common/source/docs/common-3dr-power-module.rst
@@ -42,10 +42,10 @@ Configuration
 Most ground stations provide a battery monitor interface but the parameters can also be set manually:
 
 - :ref:`BATT_MONITOR <BATT_MONITOR>` = **3** to measure only voltage or **4** to measure both voltage and current (you will need to reboot the board after changing this)
-- :ref:`BATT_VOLT_PIN <BATT_VOLT_PIN>` = **2**. The autopilot pin connected to the power module's voltage pin
-- :ref:`BATT_VOLT_MULT <BATT_VOLT_MULT>` converts the analog voltage received from the power module's voltage pin to the battery's voltage
-- :ref:`BATT_CURR_PIN <BATT_CURR_PIN>` = **3**. The autopilot pin connected to the power module's current pin
-- :ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` converts the analog voltage received from the power module's current pin to the battery's current
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = **2**. The autopilot pin connected to the power module's voltage pin
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` converts the analog voltage received from the power module's voltage pin to the battery's voltage
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = **3**. The autopilot pin connected to the power module's current pin
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` converts the analog voltage received from the power module's current pin to the battery's current
 - :ref:`BATT_AMP_OFFSET <BATT_AMP_OFFSET>` voltage offset received from the power module's current pin when ther is no current being pulled from the battery
 
 Instructions for setup and calibration using the :ref:`Mission Planner can be found here <common-power-module-configuration-in-mission-planner>`

--- a/common/source/docs/common-CSKYF405.rst
+++ b/common/source/docs/common-CSKYF405.rst
@@ -105,7 +105,7 @@ protocols except bi-directional serial protocols such as CRSF, ELRS, etc. Instea
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enimages/CSKY405_wiring.pngable Battery monitor.
 
@@ -113,10 +113,10 @@ Enimages/CSKY405_wiring.pngable Battery monitor.
 
 Then reboot.
 
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 7
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 21
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 10.35
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 14
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 7
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 21
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 10.35
 
 VTX power control
 =================

--- a/common/source/docs/common-CUAV-7-Nano.rst
+++ b/common/source/docs/common-CUAV-7-Nano.rst
@@ -102,10 +102,10 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 9
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 8
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 31.0
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 9
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 8
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 31.0
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
 
 Compass

--- a/common/source/docs/common-MUPilot.rst
+++ b/common/source/docs/common-MUPilot.rst
@@ -460,10 +460,10 @@ The board has two dedicated power monitor ports on 6 pin connectors. The correct
 In order to enable monitoring, the :ref:`BATT_MONITOR<BATT_MONITOR>` or :ref:`BATT2_MONITOR<BATT2_MONITOR>` parameter must be set. By default :ref:`BATT_MONITOR<BATT_MONITOR>` is set to "4" for the included power module..
 
 Default params for the first monitor are set and are:
-* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 2
-* :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 1
-* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 18.0
-* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 24.0 (may need adjustment if supplied monitor is not used)
+* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 2
+* :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 1
+* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 18.0
+* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 24.0 (may need adjustment if supplied monitor is not used)
 
 Compass
 =======

--- a/common/source/docs/common-MicoAir405v2.rst
+++ b/common/source/docs/common-MicoAir405v2.rst
@@ -119,10 +119,10 @@ Battery Monitoring
 The board has a built-in voltage sensor via the VBAT pin, but no internal current sensor. An external current sensor can be connected to the Curr pin. Default parameters for both internal voltage and external current monitoring are set by default to :
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 21.2
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 40.2
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 21.2
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40.2
 
 Compass
 =======

--- a/common/source/docs/common-MicoAir743.rst
+++ b/common/source/docs/common-MicoAir743.rst
@@ -114,10 +114,10 @@ The default battery parameters are:
 
 
    - :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-   - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 10
-   - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 11
-   - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 21.2
-   - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 40.2
+   - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
+   - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11
+   - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 21.2
+   - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 40.2
 
 Compass
 =======

--- a/common/source/docs/common-NxtPX4v2.rst
+++ b/common/source/docs/common-NxtPX4v2.rst
@@ -118,10 +118,10 @@ Battery Monitoring
 The board has a built-in voltage sensor via the VBAT pin, but no internal current sensor. An external current sensor can be connected to the Curr pin. Default parameters for both internal voltage and external current monitoring are set by default to :
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 4
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 8
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.2
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 20.4
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 4
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 8
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.2
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 20.4
 
 Compass
 =======

--- a/common/source/docs/common-OrqaF405.rst
+++ b/common/source/docs/common-OrqaF405.rst
@@ -100,10 +100,10 @@ Battery Monitoring
 The board has a built-in voltage sensor via the VBAT pin, but no internal current sensor. An external current sensor can be connected to the Curr pin. Default parameters for both internal voltage and external current monitoring are set by default to :
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 8.3
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 92.6
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 8.3
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 92.6
 
 Compass
 =======

--- a/common/source/docs/common-SDMODELH7V2.rst
+++ b/common/source/docs/common-SDMODELH7V2.rst
@@ -143,10 +143,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 59.5
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 59.5
 
 Compass
 =======

--- a/common/source/docs/common-StampH743.rst
+++ b/common/source/docs/common-StampH743.rst
@@ -155,10 +155,10 @@ Battery Monitoring
 The board has a built-in voltage sensor via the ``Voltage Sense`` pin, but no internal current sensor. An external current sensor can be connected to the ``Current Sense`` pin. Default parameters for both internal voltage and external current monitoring are set by default to the below :
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 18
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 19
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 64
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 18
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 19
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 64
  
 Loading Firmware
 ================

--- a/common/source/docs/common-anyleafh7.rst
+++ b/common/source/docs/common-anyleafh7.rst
@@ -119,10 +119,10 @@ The board has a built-in voltage sensor via the ESC connector, but no internal c
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 18
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 16
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.4
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 40, but varies depending on external current sensor
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 18
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 16
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.4
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40, but varies depending on external current sensor
 
 Firmware
 ========

--- a/common/source/docs/common-aocoda-h743dual.rst
+++ b/common/source/docs/common-aocoda-h743dual.rst
@@ -178,17 +178,17 @@ Then reboot.
 
 First group of battery monitor pins & options:
 
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 17.0 (note: Please calibrate before use, depending on current sensor.)
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 17.0 (note: Please calibrate before use, depending on current sensor.)
 
 Second group of battery monitor pins & options:
 
- - :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 18
- - :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 7
- - :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 11
- - :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 17.0 (note: Please calibrate before use, depending on current sensor.)
+ - :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 18
+ - :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` = 7
+ - :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 11
+ - :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` = 17.0 (note: Please calibrate before use, depending on current sensor.)
 
 .. note:: this autopilot uses a high precision current sensor input which is sensitive to ESC switching noise. Please check carefully before use that current readings are accurate across the usage range. If not, low ESR capacitors on the ESC power inputs may need to be added.
 

--- a/common/source/docs/common-atomrcf405-navi.rst
+++ b/common/source/docs/common-atomrcf405-navi.rst
@@ -114,7 +114,7 @@ Any UART can be used for RC system connections in ArduPilot also, and is compati
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -122,13 +122,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.08836
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.08836
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 30 
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 30 
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-betafpvf405.rst
+++ b/common/source/docs/common-betafpvf405.rst
@@ -118,7 +118,7 @@ The BETAFPV F4 1S 12A AIO V3  supports DJI HD air units with telemetry using UAR
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -126,13 +126,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 70.8
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 70.8
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-blitz-f745.rst
+++ b/common/source/docs/common-blitz-f745.rst
@@ -142,10 +142,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 50 but varies depending on external current sensor
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50 but varies depending on external current sensor
 
 Compass
 =======

--- a/common/source/docs/common-cuav-x7-family-overview.rst
+++ b/common/source/docs/common-cuav-x7-family-overview.rst
@@ -143,9 +143,9 @@ The autopilot includes a DroneCAN power module and battery monitor, :ref:`common
 If you are using an analog battery monitor instead, connect to the Power A connector and set the following parameters (if used as second monitor use the BATT2 parameters instead):
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 17
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 16
-- Set the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` and :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` as required for the analog PMU used.
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 17
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 16
+- Set the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` and :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` as required for the analog PMU used.
 
 RC Input
 ========

--- a/common/source/docs/common-flywoo-f745.rst
+++ b/common/source/docs/common-flywoo-f745.rst
@@ -135,10 +135,10 @@ The board has a built-in voltage and current sensors.
 The correct battery monitor parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` =  4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 13
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` ~ 10.9
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 12
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` ~ 28.5 (when using AIO version)
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 13
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` ~ 10.9
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 12
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` ~ 28.5 (when using AIO version)
 
 These are set by default in the firmware and shouldn't need to be adjusted.
 

--- a/common/source/docs/common-flywoof405hd.rst
+++ b/common/source/docs/common-flywoof405hd.rst
@@ -111,13 +111,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 60.2
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 60.2
 
 Compass
 =======

--- a/common/source/docs/common-flywoof405pro.rst
+++ b/common/source/docs/common-flywoof405pro.rst
@@ -126,10 +126,10 @@ The board has a internal voltage sensor and connections on the ESC connector for
 The default battery parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 13
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 12
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.0
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 58.8 (will need to be adjusted for whichever current sensor is attached)
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 13
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 12
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 58.8 (will need to be adjusted for whichever current sensor is attached)
 
 Compass
 =======

--- a/common/source/docs/common-foxeerf405v2.rst
+++ b/common/source/docs/common-foxeerf405v2.rst
@@ -230,10 +230,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 142 but varies depending on external current sensor
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 142 but varies depending on external current sensor
 
 Compass
 =======

--- a/common/source/docs/common-foxeerf745aio.rst
+++ b/common/source/docs/common-foxeerf745aio.rst
@@ -132,10 +132,10 @@ The board has a built-in voltage and current sensors.
 The correct battery monitor parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` =  4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 13
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` ~ 10.9
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 12
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 100
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 13
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` ~ 10.9
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 12
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 100
 
 These are set by default in the firmware and shouldn't need to be adjusted.
 

--- a/common/source/docs/common-foxeerh743v1.rst
+++ b/common/source/docs/common-foxeerh743v1.rst
@@ -123,7 +123,7 @@ The FoxeerH743 does not have a builtin compass, but you can attach an external c
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -131,13 +131,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 35.4
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 35.4
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-fuel-sensors.rst
+++ b/common/source/docs/common-fuel-sensors.rst
@@ -55,8 +55,8 @@ Parameter Setup
 Like analog battery current and capacity monitoring, the key parameters are:
 
 -  :ref:`BATT_MONITOR<BATT_MONITOR>` This sets the type of sensor. In this case, type 11 for pulse fuel flow sensors, and 12 for PWM fuel level sensors.
--  :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` This is the GPIO pin where the sensor is attached.
--  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` This is set in milliliters per pulse for fuel flow sensors.
+-  :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` This is the GPIO pin where the sensor is attached.
+-  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` This is set in milliliters per pulse for fuel flow sensors.
 -  :ref:`BATT_CAPACITY<BATT_CAPACITY>` This is the capacity in milliliters.
 -  :ref:`BATT_LOW_MAH<BATT_LOW_MAH>` This is set in milliliters instead of mAh.
 -  :ref:`BATT_CRT_MAH<BATT_CRT_MAH>` This is set in milliliters instead of mAh.

--- a/common/source/docs/common-heewingf405.rst
+++ b/common/source/docs/common-heewingf405.rst
@@ -140,13 +140,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 7.71
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 7.71
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 26.7
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 26.7
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-holybro-kakutef4-mini.rst
+++ b/common/source/docs/common-holybro-kakutef4-mini.rst
@@ -128,10 +128,10 @@ sensor can handle up to 6S LiPo batteries.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.9
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 28.5
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.9
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 28.5
 
 Compass
 =======

--- a/common/source/docs/common-holybro-kakutef4.rst
+++ b/common/source/docs/common-holybro-kakutef4.rst
@@ -113,10 +113,10 @@ sensor can handle up to 6S LiPo batteries.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 17.0
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 17.0
 
 Compass
 =======

--- a/common/source/docs/common-holybro-kakutef7aio.rst
+++ b/common/source/docs/common-holybro-kakutef7aio.rst
@@ -152,10 +152,10 @@ LiPo batteries.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 17.0
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 17.0
 
 Compass
 =======

--- a/common/source/docs/common-holybro-kakutef7mini.rst
+++ b/common/source/docs/common-holybro-kakutef7mini.rst
@@ -124,10 +124,10 @@ sensor can be attached to pin 4 on the ESC connector.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4, if external sensor used; 3 for voltage only
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12 , if external sensor used.
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.9
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` should be set to match external current sensor, if used.
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12 , if external sensor used.
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.9
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` should be set to match external current sensor, if used.
  
 Compass
 =======

--- a/common/source/docs/common-holybro-kakuteh7-v2.rst
+++ b/common/source/docs/common-holybro-kakuteh7-v2.rst
@@ -213,10 +213,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` varies depending on external current sensor
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` varies depending on external current sensor
 
 Compass
 =======

--- a/common/source/docs/common-holybro-kakuteh7.rst
+++ b/common/source/docs/common-holybro-kakuteh7.rst
@@ -142,10 +142,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 59.5
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 59.5
 
 Compass
 =======

--- a/common/source/docs/common-holybro-kakuteh7mini-v13.rst
+++ b/common/source/docs/common-holybro-kakuteh7mini-v13.rst
@@ -159,10 +159,10 @@ sensor can be attached to pin 4 on the ESC connector.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4, if external sensor used; 3 for voltage only
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11 , if external sensor used.
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` should be set to match external current sensor, if used. For example, if the Holybro Teeko32 4in1 ESC is used, this value would be 59.5
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11 , if external sensor used.
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` should be set to match external current sensor, if used. For example, if the Holybro Teeko32 4in1 ESC is used, this value would be 59.5
  
  .. note:: these values are already set by default, but can be changed to trim the voltage and/or current as needed, or to suit other ESCs.
  

--- a/common/source/docs/common-holybro-kakuteh7mini.rst
+++ b/common/source/docs/common-holybro-kakuteh7mini.rst
@@ -114,10 +114,10 @@ sensor can be attached to pin 4 on the ESC connector.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4, if external sensor used; 3 for voltage only
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11 , if external sensor used.
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` should be set to match external current sensor, if used. For example, if the Holybro Teeko32 4in1 ESC is used, this value would be 59.5
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11 , if external sensor used.
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` should be set to match external current sensor, if used. For example, if the Holybro Teeko32 4in1 ESC is used, this value would be 59.5
  
  .. note:: these values are already set by default, but can be changed to trim the voltage and/or current as needed, or to suit other ESCs.
  

--- a/common/source/docs/common-holybro-pix32v6.rst
+++ b/common/source/docs/common-holybro-pix32v6.rst
@@ -75,15 +75,15 @@ The board has 2 dedicated power monitor ports with a 6 pin
 connector. The Pix32v6 uses analog power monitors on these ports.
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 8
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 4
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 18.182
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 36.364
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 8
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 4
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 5
-- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 14
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 18.182
-- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 36.364
+- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 5
+- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` = 14
+- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
+- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
 Compass
 =======

--- a/common/source/docs/common-holybro-pixhawk6C.rst
+++ b/common/source/docs/common-holybro-pixhawk6C.rst
@@ -79,15 +79,15 @@ The board has 2 dedicated power monitor ports with a 6 pin
 connector. The Pixhawk6C uses analog power monitors on these ports.
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 8
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 4
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 18.182
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 36.364
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 8
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 4
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 5
-- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 14
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 18.182
-- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 36.364
+- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 5
+- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` = 14
+- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
+- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
 Compass
 =======

--- a/common/source/docs/common-hv-pm.rst
+++ b/common/source/docs/common-hv-pm.rst
@@ -30,8 +30,8 @@ You can also enable it by setting the following parameters (shown for first batt
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` to 4 to Set to analog voltage and current.
 - Restart Mission Planner and autopilot
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` to 0 (for CUAV V5).
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` to 1 (for CUAV V5).
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` to 18
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` to 24
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` to 0 (for CUAV V5).
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` to 1 (for CUAV V5).
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` to 18
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` to 24
 - Restart Mission Planner and autopilot

--- a/common/source/docs/common-iflight-beastf7AIO.rst
+++ b/common/source/docs/common-iflight-beastf7AIO.rst
@@ -114,10 +114,10 @@ The board has a built-in voltage and current sensors.
 The correct battery monitor parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` =  4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 12
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` ~ 10.9
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` ~ 100
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 12
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` ~ 10.9
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` ~ 100
 
 These are set by default in the firmware.
 

--- a/common/source/docs/common-iflight-beasth7AIO.rst
+++ b/common/source/docs/common-iflight-beasth7AIO.rst
@@ -113,10 +113,10 @@ The board has a built-in voltage and current sensors.
 The correct battery monitor parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` =  4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 12
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` ~ 10.9
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` ~ 100
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 12
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` ~ 10.9
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` ~ 100
 
 These are set by default in the firmware.
 

--- a/common/source/docs/common-iflight-blitzf7AIO.rst
+++ b/common/source/docs/common-iflight-blitzf7AIO.rst
@@ -114,7 +114,7 @@ The Blitz Whoop F7 AIO supports analog video transmission using its internal OSD
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -122,10 +122,10 @@ Enable Battery monitor.
 
 Then reboot.
 
--  :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.9
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 50
+-  :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.9
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-iflight-thunder-H7.rst
+++ b/common/source/docs/common-iflight-thunder-H7.rst
@@ -116,10 +116,10 @@ The correct battery setting parameters are:
 
 
 * :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
-* :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
-* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.1
-* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 64 (needs to be adjusted for whatever current sensor is being used)
+* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+* :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.1
+* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 64 (needs to be adjusted for whatever current sensor is being used)
 
 Compass
 =======

--- a/common/source/docs/common-jae-jfb110.rst
+++ b/common/source/docs/common-jae-jfb110.rst
@@ -351,21 +351,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 16
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 16
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 6
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 6
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 18.182
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 36.364
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 9
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 9
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 18
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` = 18
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 18.182
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 18.182
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 36.364
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` = 36.364
 
 Compass
 =======

--- a/common/source/docs/common-jhemcu-h743hd.rst
+++ b/common/source/docs/common-jhemcu-h743hd.rst
@@ -89,10 +89,10 @@ The board has a built-in voltage sensor, but no internal current sensor. An exte
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 11
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 13
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 58.8
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 13
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 58.8
 
 Compass
 =======

--- a/common/source/docs/common-kakuteh7wing.rst
+++ b/common/source/docs/common-kakuteh7wing.rst
@@ -155,13 +155,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 8
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 8
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 4
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 4
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.18
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.18
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 36.6
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 36.6
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-longbowf405wing.rst
+++ b/common/source/docs/common-longbowf405wing.rst
@@ -115,13 +115,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 50
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50
 
 Compass
 =======

--- a/common/source/docs/common-makeflyeasy-PixPilot-C3.rst
+++ b/common/source/docs/common-makeflyeasy-PixPilot-C3.rst
@@ -417,21 +417,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 3
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
 DroneCAN capability
 ===================

--- a/common/source/docs/common-makeflyeasy-PixPilot-V3.rst
+++ b/common/source/docs/common-makeflyeasy-PixPilot-V3.rst
@@ -403,21 +403,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 3
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
 DroneCAN capability
 ===================

--- a/common/source/docs/common-makeflyeasy-PixPilot-V6.rst
+++ b/common/source/docs/common-makeflyeasy-PixPilot-V6.rst
@@ -367,21 +367,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 15
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 13
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 4
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 4
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
 DroneCAN capability
 ===================

--- a/common/source/docs/common-makeflyeasy-PixSurveyA1-IND.rst
+++ b/common/source/docs/common-makeflyeasy-PixSurveyA1-IND.rst
@@ -435,21 +435,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 3
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 14
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 13
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18.0
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24.0
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0
 
 DroneCAN capability
 ===================

--- a/common/source/docs/common-makeflyeasy-PixSurveyA1.rst
+++ b/common/source/docs/common-makeflyeasy-PixSurveyA1.rst
@@ -326,21 +326,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 3
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 13
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 14
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24
 
 
 Where to Buy

--- a/common/source/docs/common-makeflyeasy-PixSurveyA2.rst
+++ b/common/source/docs/common-makeflyeasy-PixSurveyA2.rst
@@ -337,21 +337,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 15
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 13
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 4
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 4
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 18
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 18
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 24
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 24
 
 Loading Firmware
 ================

--- a/common/source/docs/common-mamba-basic-mk3.rst
+++ b/common/source/docs/common-mamba-basic-mk3.rst
@@ -109,10 +109,10 @@ LiPo batteries. An external current sense input is also provided.
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` = 3 for voltage only or = 4 if external current sense is also used.
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.0
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` depends on external current sensor used
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` depends on external current sensor used
 
 Compass
 =======

--- a/common/source/docs/common-mamba405-mk2.rst
+++ b/common/source/docs/common-mamba405-mk2.rst
@@ -108,10 +108,10 @@ up to 6S LiPo batteries. An external current sensor input is also provided on th
 The correct battery setting parameters are:
 
 -  :ref:`BATT_MONITOR<BATT_MONITOR>` = 3
--  :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
--  :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
--  :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` =  13
--  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 25 with the Diattone 40A ESC sometimes bundled with the autopilot.
+-  :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+-  :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
+-  :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` =  13
+-  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 25 with the Diattone 40A ESC sometimes bundled with the autopilot.
 
 Compass
 =======

--- a/common/source/docs/common-mambaH743v4.rst
+++ b/common/source/docs/common-mambaH743v4.rst
@@ -125,10 +125,10 @@ The board does not have a built-in current sensor. The voltage sensor can handle
 Typical battery setting parameters are:
 
 -   :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
--   :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
--   :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
--   :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.1
--   :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 64 (will depend on external current sensor)
+-   :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+-   :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+-   :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.1
+-   :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 64 (will depend on external current sensor)
 
 Compass
 =======

--- a/common/source/docs/common-mambaf405-mini.rst
+++ b/common/source/docs/common-mambaf405-mini.rst
@@ -127,10 +127,10 @@ The board does not have a built-in current sensor. The voltage sensor can handle
 Typical battery setting parameters are:
 
 -   :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
--   :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
--   :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
--   :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.1
--   :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 64 (will depend on external current sensor)
+-   :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+-   :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+-   :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.1
+-   :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 64 (will depend on external current sensor)
 
 Compass
 =======

--- a/common/source/docs/common-matekf405-se.rst
+++ b/common/source/docs/common-matekf405-se.rst
@@ -116,7 +116,7 @@ Any UART can be used for RC system connections in ArduPilot also, and is compati
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded, except  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from 31.7 to 55.9 . However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded, except  :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from 31.7 to 55.9 . However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -124,13 +124,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 55.9
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 55.9
 
 .. note:: this autopilot uses a high precision current sensor which is sensitive to ESC switching noise. Be sure to use the bypass capacitor provided. In some cases, the ESCs themselves will need additional 200-330uF low ESR capacitors on their power inputs, if they do not incorporate them already. See `Matek FAQs <http://www.mateksys.com/?p=5712#tab-id-12>`__ for more information.
 

--- a/common/source/docs/common-matekf405-te.rst
+++ b/common/source/docs/common-matekf405-te.rst
@@ -176,15 +176,15 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 14
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 14
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 15
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 15
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 21.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 21.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 66.7
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 66.7
 
-.. note:: The -WMN uses a different current sensor and the default value for :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` should be changed to 40.
+.. note:: The -WMN uses a different current sensor and the default value for :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` should be changed to 40.
 
 .. note:: this autopilot uses a high precision current sensor which is sensitive to ESC switching noise. Be sure to use the bypass capacitor provided. In some cases, the ESCs themselves will need additional 200-330uF low ESR capacitors on their power inputs, if they do not incorporate them already. See `Matek FAQs <http://www.mateksys.com/?p=5712#tab-id-12>`__ for more information.
 

--- a/common/source/docs/common-matekf405-wing.rst
+++ b/common/source/docs/common-matekf405-wing.rst
@@ -106,7 +106,7 @@ Any UART can be used for RC system connections in ArduPilot also, and is compati
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -114,13 +114,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 31.7 
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 31.7 
 
 Where to Buy
 ============

--- a/common/source/docs/common-matekf765-wing.rst
+++ b/common/source/docs/common-matekf765-wing.rst
@@ -136,13 +136,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 13
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 40 
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40 
 
 .. note:: this autopilot uses a high precision current sensor which is sensitive to ESC switching noise. Be sure to use the bypass capacitor provided. In some cases, the ESCs themselves will need additional 200-330uF low ESR capacitors on their power inputs, if they do not incorporate them already. See `Matek FAQs <http://www.mateksys.com/?p=5712#tab-id-12>`__ for more information.
 

--- a/common/source/docs/common-matekf765-wse.rst
+++ b/common/source/docs/common-matekf765-wse.rst
@@ -143,13 +143,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 13
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 21.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 21.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 66.7 
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 66.7 
 
 .. note:: this autopilot uses a high precision current sensor which is sensitive to ESC switching noise. Be sure to use the bypass capacitor provided. In some cases, the ESCs themselves will need additional 200-330uF low ESR capacitors on their power inputs, if they do not incorporate them already. See `Matek FAQs <http://www.mateksys.com/?p=5712#tab-id-12>`__ for more information.
 

--- a/common/source/docs/common-matekh743-wing.rst
+++ b/common/source/docs/common-matekh743-wing.rst
@@ -139,19 +139,19 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.5 (note: WLITE needs this changed to 21)
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.5 (note: WLITE needs this changed to 21)
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 40.0 (note: WLITE and WING V2/V3 needs this changed to 66.7)
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40.0 (note: WLITE and WING V2/V3 needs this changed to 66.7)
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 18
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 18
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 7
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 7
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 11.0
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
 .. note:: this autopilot uses a high precision current sensor which is sensitive to ESC switching noise. Be sure to use the bypass capacitor provided. In some cases, the ESCs themselves will need additional 200-330uF low ESR capacitors on their power inputs, if they do not incorporate them already. See `Matek FAQs <http://www.mateksys.com/?p=5712#tab-id-12>`__ for more information.
 

--- a/common/source/docs/common-omnibusf4pro.rst
+++ b/common/source/docs/common-omnibusf4pro.rst
@@ -198,13 +198,13 @@ BATT_MONITOR=4
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 38.0 (note, this value may vary from 18 to 38, depending on specific board manufacturer...will need to be calibrated to match actual current)
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 38.0 (note, this value may vary from 18 to 38, depending on specific board manufacturer...will need to be calibrated to match actual current)
 
 
 How to trigger a camera with relay pin

--- a/common/source/docs/common-omnibusf7.rst
+++ b/common/source/docs/common-omnibusf7.rst
@@ -87,15 +87,15 @@ BATT_MONITOR=4
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
 :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` 0.008
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.925
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.925
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 58.0 (note, this value is valid if using Matek Systems FCHUB A5 current sensor)...will need to be calibrated to match actual current if using another make of PDB board)
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 58.0 (note, this value is valid if using Matek Systems FCHUB A5 current sensor)...will need to be calibrated to match actual current if using another make of PDB board)
 
 Dshot capability
 ================

--- a/common/source/docs/common-omnibusnanov6.rst
+++ b/common/source/docs/common-omnibusnanov6.rst
@@ -133,9 +133,9 @@ Set :ref:`BATT_MONITOR <BATT_MONITOR>` to 3 (= analog voltage only) and reboot.
 
 Default pin values:
 
-:ref:`BATT_VOLT_PIN <BATT_VOLT_PIN>` = 12
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 12
 
-:ref:`BATT_VOLT_MULT <BATT_VOLT_MULT>` = 11
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11
 
 Optionally add voltage and / or current monitoring using ESC telemetry capable ESCs. See instructions :ref:`here <blheli32-esc-telemetry>`.
 
@@ -145,15 +145,15 @@ V6.x revision
 
 V6.x revision has an additional ADC available for external current sensor hardware / PDB connection in 4in1 socket / respective pads.
 
-:ref:`BATT_CURR_PIN <BATT_CURR_PIN>` = 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11
 
-:ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` = 18.2
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 18.2
 
 Set :ref:`BATT_MONITOR <BATT_MONITOR>` to 4 (= analog voltage and current) and reboot for full battery monitoring support.
 
 .. note::
    
-   Current pin defaults to pin 11 in ardupilot runtime. Alternatively, it can be used for analog RSSI input or connecting an analog airspeed sensor. Adjust :ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` default of 18.2 as required by the individual current sensor hardware used.
+   Current pin defaults to pin 11 in ardupilot runtime. Alternatively, it can be used for analog RSSI input or connecting an analog airspeed sensor. Adjust :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` default of 18.2 as required by the individual current sensor hardware used.
 
 
 Flashing Firmware

--- a/common/source/docs/common-qiotek-zealot.rst
+++ b/common/source/docs/common-qiotek-zealot.rst
@@ -507,21 +507,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 13
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 13
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 12
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 12
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 20
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 20
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 17
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 17
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 9
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 9
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 8
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 8
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 20
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 20
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 17
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 17
 
 
 Where to Buy

--- a/common/source/docs/common-qiotek-zealoth7.rst
+++ b/common/source/docs/common-qiotek-zealoth7.rst
@@ -519,21 +519,21 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 16
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 16
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 17
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 17
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 20
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 20
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 17
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 17
 
-:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` 10
+:ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` 11
+:ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` 20
+:ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` 20
 
-:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` 17
+:ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` 17
 
 DroneCAN capability
 ===================

--- a/common/source/docs/common-radiolink-minipix.rst
+++ b/common/source/docs/common-radiolink-minipix.rst
@@ -81,7 +81,7 @@ Then follow the instructions on how to :ref:`load firmware onto ChibiOS boards <
     firmware's SERIALn assignments, this requires additional attention!
     
 .. note::
-    MiniPix voltage and current sensing pins use Pixhawk standard ( :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 2, :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 3).
+    MiniPix voltage and current sensing pins use Pixhawk standard ( :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 2, :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 3).
     The additional ADC pin can be used for either RSSI or analog airspeed. Set required option to PIN = 11.
 
 [copywiki destination="plane,copter,rover,blimp"]

--- a/common/source/docs/common-radiolinkpix6.rst
+++ b/common/source/docs/common-radiolinkpix6.rst
@@ -550,10 +550,10 @@ Power1 port(Analog)
 The parameters should be set:
 
 * :ref:`BATT_MONITOR <BATT_MONITOR>` = 4, then reboot.
-* :ref:`BATT_VOLT_PIN <BATT_VOLT_PIN>` = 2
-* :ref:`BATT_CURR_PIN <BATT_CURR_PIN>` = 5
-* :ref:`BATT_VOLT_MULT <BATT_VOLT_MULT>` = 18
-* :ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` = 24
+* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 2
+* :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 5
+* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 18
+* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 24
 
 Power2 port(I2C)
 ================

--- a/common/source/docs/common-radix2hd.rst
+++ b/common/source/docs/common-radix2hd.rst
@@ -158,7 +158,7 @@ to use the same pin for battery voltage monitoring and for powering the board.
 
 In addition to voltage sensing, the board also has an input for an external current sensor.
 
-Parameters for use with a typical 4in1 ESC are already set by default. The value of the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` may need to be changed to match your ESC:
+Parameters for use with a typical 4in1 ESC are already set by default. The value of the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` may need to be changed to match your ESC:
 
 The default parameter settings are:
 
@@ -168,13 +168,13 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 3
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 3
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 17.6
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 17.6
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 28.5
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 28.5
 
 Loading Firmware
 ================

--- a/common/source/docs/common-skystarsH7.rst
+++ b/common/source/docs/common-skystarsH7.rst
@@ -202,10 +202,10 @@ The board has a built-in voltage sensor via the B+ pin, but no internal current 
 The correct battery setting parameters are:
 
  - :ref:`BATT_MONITOR<BATT_MONITOR>` 4
- - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
- - :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
- - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.1
- - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` varies depending on external current sensor
+ - :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
+ - :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
+ - :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.1
+ - :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` varies depending on external current sensor
 
 Compass
 =======

--- a/common/source/docs/common-smartap-pdb.rst
+++ b/common/source/docs/common-smartap-pdb.rst
@@ -71,6 +71,6 @@ Configuration
 Set battery parameters as following: 
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` to 4 to Set to analog voltage and current.
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` to 18.4615
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` to 37.2300
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` to 18.4615
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` to 37.2300
 - :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` to 0.63

--- a/common/source/docs/common-speedybeef4-v3.rst
+++ b/common/source/docs/common-speedybeef4-v3.rst
@@ -128,10 +128,10 @@ The board has a internal voltage sensor and connections on the ESC connector for
 The default battery parameters are:
 
 -    :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
--    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 10
--    :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 11
--    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.2
--    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 52.7 (will need to be adjusted for whichever current sensor is attached)
+-    :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 10
+-    :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 11
+-    :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.2
+-    :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 52.7 (will need to be adjusted for whichever current sensor is attached)
 
 Compass
 =======

--- a/common/source/docs/common-speedybeef405-mini.rst
+++ b/common/source/docs/common-speedybeef405-mini.rst
@@ -140,13 +140,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 40
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 40
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-speedybeef405wing.rst
+++ b/common/source/docs/common-speedybeef405wing.rst
@@ -172,7 +172,7 @@ For example, use Channel 10 to control the switch using Relay 2:
 
 Battery Monitor Configuration
 =============================
-These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
+These settings are set as defaults when the firmware is loaded (except :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` which needs to be changed from the default value). However, if they are ever lost, you can manually set the parameters:
 
 Enable Battery monitor.
 
@@ -180,13 +180,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 10
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 10
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 11
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 11
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 11.05
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 11.05
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 50
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 50
 
 Connecting a GPS/Compass module
 ===============================

--- a/common/source/docs/common-spracingh7-extreme.rst
+++ b/common/source/docs/common-spracingh7-extreme.rst
@@ -123,10 +123,10 @@ Enable Battery monitor with these parameter settings :
 
 Then reboot.
 
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 11
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 10
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 10.9
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 28.5
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 11
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 10
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 10.9
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 28.5
 
 RSSI Input
 ==========

--- a/common/source/docs/common-synthetic-current-monitor.rst
+++ b/common/source/docs/common-synthetic-current-monitor.rst
@@ -17,16 +17,16 @@ the following examples are for the first Battery Monitor. The parameter names wi
 
 For Voltage, the normal Analog Sensor parameters apply:
 
-- :ref:`BATT_VOLT_PIN <BATT_VOLT_PIN>` The autopilot pin connected to the power module's voltage pin
-- :ref:`BATT_VOLT_MULT <BATT_VOLT_MULT>` converts the analog voltage received from the power module's voltage pin to the battery's voltage. Provided on the :ref:`autopilot's hardware page:<common-autopilots>` or manufacturers page.
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` The autopilot pin connected to the power module's voltage pin
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` converts the analog voltage received from the power module's voltage pin to the battery's voltage. Provided on the :ref:`autopilot's hardware page:<common-autopilots>` or manufacturers page.
 
 For the Current, some of the normal analog current sensor parameters have been re-tasked to save flash and their names are therefore a bit misleading in this application:
 
-- :ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` is the MAXIMUM current at full battery voltage in amps.
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` is the MAXIMUM current at full battery voltage in amps.
 - :ref:`BATT_AMP_OFFSET <BATT_AMP_OFFSET>` is the idle current (zero throttle) of the system in amps accounting for peripherals, video,etc. Normally in the 0.3 to 0.5 range.
 - :ref:`BATT_MAX_VOLT<BATT_MAX_VOLT>` is the MAXIMUM fresh battery voltage. Used to scale the estimate as the battery voltage decreases during use.
 
-Calibration of the :ref:`BATT_AMP_PERVLT <BATT_AMP_PERVLT>` value can either be done on the bench with a current meter, or iteratively by estimating an initial value, operating for while, measuring the amount of current needed to restore the battery to full charge, and using that value and a flight log's or OSD's total consumed mah for the flight to adjust the parameter value:
+Calibration of the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` value can either be done on the bench with a current meter, or iteratively by estimating an initial value, operating for while, measuring the amount of current needed to restore the battery to full charge, and using that value and a flight log's or OSD's total consumed mah for the flight to adjust the parameter value:
 
 new value = old value * (mah returned to batt/log or OSD value of consumed mah)
 

--- a/common/source/docs/common-tmotor-h7-mini.rst
+++ b/common/source/docs/common-tmotor-h7-mini.rst
@@ -82,10 +82,10 @@ The correct battery setting parameters are:
 
 
 * :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 11
-* :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 13
-* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 11.0
-* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 50.0
+* :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 11
+* :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 13
+* :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 11.0
+* :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 50.0
 
 Compass
 =======

--- a/common/source/docs/common-yjuav-a6se-h743.rst
+++ b/common/source/docs/common-yjuav-a6se-h743.rst
@@ -322,13 +322,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 4
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 4
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 21.0 (may need adjustment if supplied monitor is not used)
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 21.0 (may need adjustment if supplied monitor is not used)
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 34.0 (may need adjustment if supplied monitor is not used)
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 34.0 (may need adjustment if supplied monitor is not used)
 
 Compass
 =======

--- a/common/source/docs/common-yjuav-a6se.rst
+++ b/common/source/docs/common-yjuav-a6se.rst
@@ -311,13 +311,13 @@ Enable Battery monitor.
 
 Then reboot.
 
-:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` 2
+:ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` 2
 
-:ref:`BATT_CURR_PIN<BATT_CURR_PIN>` 4
+:ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` 4
 
-:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` 18.0
+:ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` 18.0
 
-:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` 24.0 (may need adjustment if supplied monitor is not used)
+:ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` 24.0 (may need adjustment if supplied monitor is not used)
 
 Compass
 =======

--- a/common/source/docs/common-yjuav-a6ultra.rst
+++ b/common/source/docs/common-yjuav-a6ultra.rst
@@ -540,18 +540,18 @@ The correct battery setting parameters are:
 Battery1 monitor:
 
 - :ref:`BATT_MONITOR<BATT_MONITOR>` = 4
-- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN>` = 2
-- :ref:`BATT_CURR_PIN<BATT_CURR_PIN>` = 4
-- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT>` = 21.0 (may need adjustment if supplied monitor is not used)
-- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = 34.6 (may need adjustment if supplied monitor is not used)
+- :ref:`BATT_VOLT_PIN<BATT_VOLT_PIN__AP_BattMonitor_Analog>` = 2
+- :ref:`BATT_CURR_PIN<BATT_CURR_PIN__AP_BattMonitor_Analog>` = 4
+- :ref:`BATT_VOLT_MULT<BATT_VOLT_MULT__AP_BattMonitor_Analog>` = 21.0 (may need adjustment if supplied monitor is not used)
+- :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = 34.6 (may need adjustment if supplied monitor is not used)
 
 Battery2 monitor:
 
 - :ref:`BATT2_MONITOR<BATT2_MONITOR>` = 4
-- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN>` = 12
-- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN>` = 16
-- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT>` = 21.0 (may need adjustment if supplied monitor is not used)
-- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT>` = 34.6 (may need adjustment if supplied monitor is not used)
+- :ref:`BATT2_VOLT_PIN<BATT2_VOLT_PIN__AP_BattMonitor_Analog>` = 12
+- :ref:`BATT2_CURR_PIN<BATT2_CURR_PIN__AP_BattMonitor_Analog>` = 16
+- :ref:`BATT2_VOLT_MULT<BATT2_VOLT_MULT__AP_BattMonitor_Analog>` = 21.0 (may need adjustment if supplied monitor is not used)
+- :ref:`BATT2_AMP_PERVLT<BATT2_AMP_PERVLT__AP_BattMonitor_Analog>` = 34.6 (may need adjustment if supplied monitor is not used)
 
 
 Loading Firmware

--- a/plane/source/docs/fpv-plane.rst
+++ b/plane/source/docs/fpv-plane.rst
@@ -200,13 +200,13 @@ On the bench while connected to MP and with propellor removed, make sure that FS
 Do NOT use the SETUP tab to setup the Battery Monitor for the newer
 Chibios boards. These boards have the default configuration already loaded when installing
 the firmware.
-You will probably have to slightly adjust the :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` and :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>`
+You will probably have to slightly adjust the :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` and :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>`
 parameters. Most systems will draw 400 to 600 ma when the motor is not running. This is set
-with the :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` parameter. You can adjust the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` parameter to match the capacity used 
+with the :ref:`BATT_AMP_OFFSET<BATT_AMP_OFFSET>` parameter. You can adjust the :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` parameter to match the capacity used 
 during your flight by taking the amount of current you recharge the battery with, and the displayed amount of mah used 
 using the following formula:
 
-    new :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` = old :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT>` * MAH -recharged/ MAH shown as used.
+    new :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` = old :ref:`BATT_AMP_PERVLT<BATT_AMP_PERVLT__AP_BattMonitor_Analog>` * MAH -recharged/ MAH shown as used.
 
 .. Note:: 
     this isn't 100% accurate due to several factors, but is close enough. You may have to iterate a few times. 


### PR DESCRIPTION
now another backend has parameters which duplicate some in the analog backend we need to fix links to link to the analogue backend rather than the AD7091R5 backend