### PR TITLE
Common: update RTF page

### DIFF
--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -90,6 +90,7 @@ Vehicles from Non-Partners
 ==========================
 
 * `Aton <https://traxxas.com/products/models/heli/Aton-Plus>`__ and `Aton-Plus from traxxas <https://traxxas.com/products/models/heli/Aton-Plus>`__ (firmware loaded using an SD Card)
+* `BathyDrone mapping boats <https://www.bathydrone-usv.com/>`__
 * `DRONEE Easy to Use Mapping Plane <https://dronee.aero/pages/droneeplane>`__
 * `MotoDoro Farm Mapper (Plane) <https://motodoro.com/blog/detail/00005-farm-mapper-vtol.html>`__
 * `SkyRocket - Journey <http://sky-viper.com/journey/>`__

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -24,20 +24,19 @@ Copters from Partners
 * `Hitec - SUI Endurance <https://hitecnology.com/drones/sui-endurance-multipurpose-professional-multirotor>`__
 * `Holybro - S500 V2 Kit <https://shop.holybro.com/s500-v2-kitmotor2216-880kv-propeller1045_p1153.html>`__
 * `Holybro - X500 Kit <https://shop.holybro.com/x500-kit_p1180.html>`__
-* `TT Robotix - X-1300 EagleEyes Quadcopter <http://www.ttrobotix.com/products/detail/923.html>`__
 * `TT Robotix - H2-X6 Phoenix H6 Multirotor <http://www.ttrobotix.com/products/detail/926.html>`__
 * `TT Robotix - X-450 Scout Quadcopter <http://www.ttrobotix.com/products/detail/928.html>`__
+* `TT Robotix - X-1300 EagleEyes Quadcopter <http://www.ttrobotix.com/products/detail/923.html>`__
 * Various from `UAVSystems <https://uavsystemsinternational.com/pages/heavy-lift-payload-drones/>`__
 * VimDrones `Mazzy Star Drone - Light Show RTF <https://vimdrones.com/products/e5586543-cf6d-452d-9e6b-f4ea43eabb52--Mazzy-Star-Drone>`__
-*  `WattsInnovations Prism Lite <https://wattsinnovations.com/pages/prismlite>`__
 
 Helicopters from Partners
 =========================
 
-* `TT Robotix - Thunder Hawk Helicopter <http://www.ttrobotix.com/products/detail/902.html>`__
+* `TT Robotix - CX-180 ICEMAN Helicopter <http://www.ttrobotix.com/products/detail/925.html>`__
 * `TT Robotix - SIRIUS Helicopter <http://www.ttrobotix.com/products/detail/905.html>`__
 * `TT Robotix - T-150 Maverick Helicopter <http://www.ttrobotix.com/products/detail/924.html>`__
-* `TT Robotix - CX-180 ICEMAN Helicopter <http://www.ttrobotix.com/products/detail/925.html>`__
+* `TT Robotix - Thunder Hawk Helicopter <http://www.ttrobotix.com/products/detail/902.html>`__
 
 Planes from Partners
 ====================
@@ -48,9 +47,7 @@ Planes from Partners
 * `MakeFLyEasy - Believer <https://www.aliexpress.com/item/30000002380639.html?spm=a2g0o.store_home.productList_1076398524.pic_4>`__
 * :ref:`MakeFLyEasy - Fighter <common-makeflyeasy-fighter-hand-throw>`
 * :ref:`MakeFLyEasy - Striver Mini <common-makeflyeasy-striver-mini-hand-throw>`
-* :ref:`MakeFLyEasy - Fighter Hand Throw <common-makeflyeasy-fighter-hand-throw>`
 * :ref:`MakeFLyEasy - Striver Mini Hand Throw <common-makeflyeasy-striver-mini-hand-throw>`
-* `mRobotics - Nano Talon <https://store.mrobotics.io/ProductDetails.asp?ProductCode=mRo-talon0318-mr>`__
 * Various from `UAVSystems <https://uavsystemsinternational.com/collections/fixed-wing-long-range-drones>`__
 
 VTOL/QuadPlanes from Partners
@@ -58,24 +55,23 @@ VTOL/QuadPlanes from Partners
 
 * `ARACE ROC QuadPlane <https://araceuas.com/roc/>`__
 * `ARACE Griffin QuadPlane <https://araceuas.com/griffin/>`__
-* `CUAV - Raefly <https://store.cuav.net/shop/raefly/>`__
-* `CUAV - Raefly VT260 <https://store.cuav.net/shop/raefly-vt260-vtol-uav/>`__
-* `Event38 - E400 <https://event38.com/fixed-wing/e400-vtol-drone/>`__
+* `CUAV - Raefly VT240 <https://store.cuav.net/shop/vt240-pro/>`__
+* `CUAV - Raefly VT290 <https://store.cuav.net/shop/cuav-new-vt290-vtol/>`__
+* `CUAV - Raefly VT370 Hybrid <https://store.cuav.net/shop/cuav-raefly-vt370-vtol-uav/>`__
 * `Drone Engr (Various VTOL Platforms) <https://www.droneassemble.com/product-category/vtol-drone-uav/>`__
+* `Event38 - E400 <https://event38.com/fixed-wing/e400-vtol-drone/>`__
 * `Event38 - E455 <https://event38.com/fixed-wing/e455-vtol-drone/>`__
-* `FlyDragonDroneTech - FDG30 <https://www.droneassemble.com/product/vtol-uav-6-hours-endurance-with-1kg-payload-for-survey-serveillance/>`__
-* `FlyDragonDroneTech - FDG50F <https://www.droneassemble.com/product/hybrid-vtol-uav-7-hours-endurance-with-10kgs-payload/>`__
+* `FlyDragonDroneTech - FDG23 <https://www.droneassemble.com/product/fdg23-pro-vtol-uav-drone-for-mapping-surveillance/>`__
+* `FlyDragonDroneTech - FDG410 <https://www.droneassemble.com/product/fdg410-electric-vtol-uav-10kgs-payload-lidar-carry-capacity-for-aerial-mapping-or-medicine-delivery/>`__
 * :ref:`Holybro Swan-K1 <common-Swan-K1>`
-* :ref:`MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>`
-* `MakeFLyEasy - Freeman 2300 <https://www.uavmodel.com/collections/vtol/products/makeflyeasy-freeman-4-1-2300mm-uav-vtol>`__
 * `MakeFLyEasy - Freeman 2100 <https://www.uavmodel.com/products/makeflyeasy-striver-mini-4-1-4-2-2100mm-vtol-uav?variant=41656322654362>`__
+* `MakeFLyEasy - Freeman 2300 <https://www.uavmodel.com/collections/vtol/products/makeflyeasy-freeman-4-1-2300mm-uav-vtol>`__
+* :ref:`MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>`
 * :ref:`MakeFLyEasy - Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>`
 
 Rovers from Partners
 ====================
 
-* `AION ROBOTICS - R6 UGV <https://www.aionrobotics.com/r6>`__
-* `AION ROBOTICS - M6 UGV <https://www.aionrobotics.com/m6-commercial-ugv>`__
 * `Robot to Society - SPARK Kit <https://www.robot-to-society.com/products/sparkkit>`__
 * `TT Robotix - Rhino 6x6 <http://www.ttrobotix.com/products/detail/906.html>`__
 * `TT Robotix - Base 1 Rover <http://www.ttrobotix.com/products/detail/907.html>`__
@@ -90,18 +86,16 @@ Subs from Partners
 
 * `Blue Robotics - BlueROV2 <https://bluerobotics.com/store/rov/bluerov2/>`__
 
-
 Vehicles from Non-Partners
 ==========================
 
 * `Aton <https://traxxas.com/products/models/heli/Aton-Plus>`__ and `Aton-Plus from traxxas <https://traxxas.com/products/models/heli/Aton-Plus>`__ (firmware loaded using an SD Card)
-* DRONEE  Easy to Use Mapping Plane Drone `DRONEE PLANE <https://dronee.aero/pages/droneeplane>`__
+* `DRONEE Easy to Use Mapping Plane <https://dronee.aero/pages/droneeplane>`__
 * `MotoDoro Farm Mapper (Plane) <https://motodoro.com/blog/detail/00005-farm-mapper-vtol.html>`__
 * `SkyRocket - Journey <http://sky-viper.com/journey/>`__
 * `UAV Mapper from TuffWing <http://www.tuffwing.com/products/drone_mapper.html>`__
 * 3DR Solo from `Amazon <https://www.amazon.com/3DR-Solo-Quadcopter-No-Gimbal/dp/B00ZPM7BOG>`__
 * `LP Mini Orca HVTOL Drone <https://lpbond.com/productos/miniorca.html>`__
-
 
 .. note::
 


### PR DESCRIPTION
These changes can be a big controversial but I've tried to update the page as best I can including:

- Refreshed links for product changes for Event38, CUAV, FlyDragonDroneTech
- Removed duplicate link for MakeFlyEasy Fighter
- removed links for AionRobotics, WattsInnovations
- Alphabetised ordering

Also I added BathyDrone to the non-partners section

I've tested this locally and it looks OK to me