### PR TITLE
Common: loading firmware via SD card made easier to find

### DIFF
--- a/common/source/docs/common-install-sdcard.rst
+++ b/common/source/docs/common-install-sdcard.rst
@@ -2,9 +2,9 @@
 
 [copywiki destination="copter,plane,rover,planner,blimp"]
 
-===========================
-Loading Firmware via sdcard
-===========================
+============================
+Loading Firmware via SD Card
+============================
 
 It is possible to update the ArduPilot firmware on certain autopilots by placing a specifically-named file onto an SD card and running the autopilot's bootloader (e.g. by power-cycling the board.
 

--- a/common/source/docs/common-loading-firmware-onto-pixhawk.rst
+++ b/common/source/docs/common-loading-firmware-onto-pixhawk.rst
@@ -118,6 +118,11 @@ Firmware Limitations
 - All the feature options currently **not** included in the 1MB autopilots, by default, are on the list of options on the Custom Firmware Build Server. There are also many features still included in the 1MB autopilots that may not be required for your application. So it is possible to create a build that includes some of the currently excluded features while removing some of the unneeded features. The list of feature options will be continuously expanded, allowing other large features to be dropped and more restricted features added to the custom build. For example, not including QuadPlane features will save space for Planes not requiring it. Drivers and peripheral support may be individually selected, allowing only those used to be in the code thus allowing other features to be included in the custom firmware.
 - Current build is from the daily master branch, Stable and Beta branches.
 
+Loading Firmware via SD Card
+============================
+
+The firmware on some autopilots may be uploaded by copying an 'ardupilot.abin' firmware file to the SD card and then power cycling the board.  Details on how to :ref:`update the firmware via SD Card can be found here <common-install-sdcard>`.
+
 Testing
 =======
 


### PR DESCRIPTION
This makes the page describing how to load firmware via the SD card slightly easier to find.  This also includes a drive-by change to the page's title.

I've tested this locally and it looks OK to me