### PR TITLE
dev: Document missing plane guided commands

### DIFF
--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -52,6 +52,6 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavl
 These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ message
 
 - `MAV_CMD_DO_REPOSITION <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_REPOSITION>`__
-
-
-
+- `MAV_CMD_GUIDED_CHANGE_SPEED <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED>`__
+- `MAV_CMD_GUIDED_CHANGE_ALTITUDE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_ALTITUDE>`__
+- `MAV_CMD_GUIDED_CHANGE_HEADING <https://mavlink.io/en/messages/common.html#MAV_CMD_GUIDED_CHANGE_HEADING>`__


### PR DESCRIPTION
Document which guided commands are supported: https://github.com/ArduPilot/ardupilot/blob/5a8bc161709aba97a8b7a6da3ce0ec1a49df2718/ArduPlane/GCS_Mavlink.cpp#L897

The wiki is missing a few.

Guided takeoff is not yet supported.