### PR TITLE
dev: Document position target and attitude target support in Plane

### DIFF
--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -10,6 +10,7 @@ This article lists the MAVLink commands that affect the movement of a Plane or Q
 
    The code which processes these commands can be found `here in GCS_Mavlink.cpp <https://github.com/ArduPilot/ardupilot/blob/master/ArduPlane/GCS_Mavlink.cpp>`__
 
+.. _movement_commands:
 Movement commands
 =================
 
@@ -55,3 +56,21 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavli
 - `MAV_CMD_GUIDED_CHANGE_SPEED <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_SPEED>`__
 - `MAV_CMD_GUIDED_CHANGE_ALTITUDE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_ALTITUDE>`__
 - `MAV_CMD_GUIDED_CHANGE_HEADING <https://mavlink.io/en/messages/common.html#MAV_CMD_GUIDED_CHANGE_HEADING>`__
+
+Position Targets
+================
+
+To command the altitude in any supported frame, use `SET_POSITION_TARGET_GLOBAL_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT>`__.
+Ensure to set the `POSITION_TARGET_TYPEMASK <https://mavlink.io/en/messages/common.html#POSITION_TARGET_TYPEMASK>`__ bit 3.
+
+To command the altitude in LOCAL frame, use `SET_POSITION_TARGET_LOCAL_NED <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__.
+It is currently not necessary to bother with `POSITION_TARGET_TYPEMASK <https://mavlink.io/en/messages/common.html#POSITION_TARGET_TYPEMASK>`__.
+The `MAV_FRAME <https://mavlink.io/en/messages/common.html#MAV_FRAME>`__ must be ``MAV_FRAME_LOCAL_OFFSET_NED``.
+
+No other fields in position target messages are currently supported. Use :ref:`movement_commands` to send a lat lon alt target.
+
+Attitude Targets
+================
+
+The low level attitude of the vehicle can be controlled with `SET_ATTITUDE_TARGET <https://mavlink.io/en/messages/common.html#SET_ATTITUDE_TARGET>`__.
+


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ee7179f3-63b4-4788-bd47-a40f56ffecfa)

Document the following undocumented interfaces:
* SET_POSITION_TARGET_GLOBAL_INT
* SET_POSITION_TARGET_LOCAL_NED
* SET_ATTITUDE_TARGET

The support in Plane is VERY different than copter. It would be a misnomer to say that plane supports the intent of these packets, hence the very specific notes on what's supported and how to use it. As an autonomy developer, this is one of the most frustrating things to have to handle to develop cross-platform autonomy.

As the support for Copter and Plane become more similar, then we can instead move this to a common wiki that's not vehicle-specific.