### PR TITLE
Plane: Document setup without GPS or airspeed sensor

### DIFF
--- a/common/source/docs/common-advanced-configuration.rst
+++ b/common/source/docs/common-advanced-configuration.rst
@@ -31,6 +31,7 @@ tuning options for the vehicle.
     Auxiliary Functions <common-auxiliary-functions>
     Battery Voltage Compensation <battery-voltage-compensation>
     Bootloader Update <common-bootloader-update>
+    Flying without GPS or Airspeed <no-gps-airspeed>
 [/site]
     BLHeli ESCs <common-blheli32-passthru>
     CAN Bus Setup <common-canbus-setup-advanced>

--- a/common/source/docs/common-non-gps-to-gps.rst
+++ b/common/source/docs/common-non-gps-to-gps.rst
@@ -11,6 +11,11 @@ ArduPilot 4.1 (and higher) support in-flight transitions between GPS and Non-GPS
 
 .. note:: Non-GPS navigation is available for all vehicles. However, it is not applicable to fast or high flying vehicles such as conventional Planes. QuadPlanes can utilize this when in VTOL operation and close to the ground, as when docking inside a hangar using 3D cameras or beacons.
 
+[site wiki="plane"]
+If you want to fly a Plane without a GPS or airspeed sensor installed, see :ref:`Flying without GPS or Airspeed <no-gps-or-airspeed>`.
+This wiki page covers flying with the sensor(s) installed and allowing the EKF to gracefully handle when GPS is lost.
+[/site]
+
 Setup
 -----
 

--- a/plane/source/docs/no-gps-airspeed.rst
+++ b/plane/source/docs/no-gps-airspeed.rst
@@ -1,0 +1,40 @@
+.. _no-gps-or-airspeed:
+
+==============================
+Flying without GPS or Airspeed
+==============================
+
+Generally, most features in ArduPlane rely on two assumptions:
+
+* The plane can determine where it is in the world, generally with the use of a GPS
+* The plane can determine its airspeed, either through a synthetic estimate or through a dedicated airspeed sensor.
+
+The default parameters for ArduPlane assume that the above statements are true.
+Much of the wiki is written assuming you have a GPS.
+In the special case that you want to fly without either of these,
+such as using just MANUAL and FBWA for initial flights, then follow this guide.
+
+Recommended Parameters
+======================
+
+* Disable stall prevention with :ref:`STALL_PREVENTION<STALL_PREVENTION>` set to 0
+* Disable GPS's with :ref:`GPS1_TYPE<GPS1_TYPE>` set to 0
+* Disable airspeed use with :ref:`ARSPD_USE<ARSPD_USE>` set to 0
+* Disable the first airspeed sensor with :ref:`ARSPD_TYPE<ARSPD_TYPE>` set to 0
+* Force DCM with :ref:`AHRS_EKF_TYPE<AHRS_EKF_TYPE>` set to 0
+* Change the failsafe long action to ``Glide`` with :ref:`FS_LONG_ACTN<FS_LONG_ACTN>`
+
+.. warning:: Using the :ref:`FS_LONG_ACTN<FS_LONG_ACTN>` default of ``Continue``, or ``ReturnToLaunch``, will cause a fly-away.
+             RTL requires GPS and should NOT be used.
+
+
+Limitations
+===========
+
+:ref:`SERVO_AUTO_TRIM<SERVO_AUTO_TRIM>` won't work - this requires a velocity estimate. Although it's disabled by default, you will have to rely on manual trimming.
+
+Most navigation modes won't be allowed, including AUTO, FBWB, and RTL.
+
+:ref:`AUTOTUNE <automatic-tuning-with-autotune>` is not possible because it requires the vehicle to be flying faster than :ref:`AIRSPEED_MIN<AIRSPEED_MIN>`.
+To tune your aircraft without GPS and airspeed sensor, you must do it manually.
+


### PR DESCRIPTION
Document how to set up ArduPlane to fly in FBWA without GPS or airspeed sensor. Document some known limitations.
This is for a minimal plane build to just use AP as a stabilizer.