### PR TITLE
Use python3 -m pip install rather than pip3 install

### DIFF
--- a/common/source/docs/common-beagle-bone-blue.rst
+++ b/common/source/docs/common-beagle-bone-blue.rst
@@ -413,8 +413,8 @@ In order to use the built-in Bluetooth connection as MAVLink some steps are requ
 
 ::
 
-    sudo pip3 install pybluez
-    sudo pip3 install pyserial
+    sudo python3 -m pip install pybluez
+    sudo python3 -m pip install pyserial
 
     sudo mkdir /usr/bin/bluetooth-serial
     sudo nano /usr/bin/bluetooth-serial/bluetooth-serial.py

--- a/common/source/docs/common-realsense-depth-camera.rst
+++ b/common/source/docs/common-realsense-depth-camera.rst
@@ -227,12 +227,12 @@ Install pip for Python3 `(pip3) <https://linuxize.com/post/how-to-install-pip-on
 .. code-block:: bash
 
     sudo apt-get install python3-pip
-    pip3 install pyrealsense2
-    pip3 install transformations
-    pip3 install dronekit
-    pip3 install apscheduler
-    pip3 install pyserial # For serial connection
-    pip3 install opencv-python
+    python3 -m pip install pyrealsense2
+    python3 -m pip install transformations
+    python3 -m pip install dronekit
+    python3 -m pip install apscheduler
+    python3 -m pip install pyserial # For serial connection
+    python3 -m pip install opencv-python
     sudo apt -y install python3-gst-1.0 gir1.2-gst-rtsp-server-1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-ugly libx264-dev
 
     # Only necessary if you installed the minimal version of Ubuntu

--- a/common/source/docs/common-vio-tracking-camera.rst
+++ b/common/source/docs/common-vio-tracking-camera.rst
@@ -142,12 +142,12 @@ Python Packages Installation
 
     # pip install may require sudo, so proceed accordingly
     pip install pyrealsense2
-    pip3 install transformations
-    pip3 install dronekit
-    pip3 install apscheduler
+    python3 -m pip install transformations
+    python3 -m pip install dronekit
+    python3 -m pip install apscheduler
 
     # Install serial packages for serial connection
-    sudo pip3 install pyserial
+    sudo python3 -m pip install pyserial
 
 - Download the script `t265_to_mavlink.py <https://github.com/thien94/vision_to_mavros/blob/master/scripts/t265_to_mavlink.py>`__. In case you have downloaded the `vision_to_mavros <https://github.com/thien94/vision_to_mavros>`__ package, it can be found in the script folder.
 

--- a/mavproxy/source/docs/getting_started/download_and_installation.rst
+++ b/mavproxy/source/docs/getting_started/download_and_installation.rst
@@ -39,7 +39,7 @@ For Debian based systems (including Ubuntu, WSL, Raspian):
 .. code:: bash
 
     sudo apt-get install python3-dev python3-opencv python3-wxgtk4.0 python3-pip python3-matplotlib python3-lxml python3-pygame
-    pip3 install PyYAML mavproxy --user
+    python3 -m pip install PyYAML mavproxy --user
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 
@@ -48,7 +48,7 @@ For Fedora based systems:
 .. code:: bash
 
     sudo dnf install python3-devel python3-opencv python3-wxpython4 python3-pip python3-matplotlib python3-pygame python3-lxml python3-yaml redhat-rpm-config
-    pip3 install PyYAML mavproxy --user
+    python3 -m pip install PyYAML mavproxy --user
     echo 'export PATH="$PATH:$HOME/.local/bin"' >> ~/.bashrc
 
 .. note::
@@ -70,13 +70,13 @@ To update an existing installation with the current release:
 
 .. code:: bash
 
-    pip3 install mavproxy pymavlink --user --upgrade
+    python3 -m pip install mavproxy pymavlink --user --upgrade
 
 To update an existing installation with the current development version (ie, from its master branch):
 
 .. code:: bash
 
-    pip3 install mavproxy --user git+https://github.com/ArduPilot/mavproxy.git@master
+    python3 -m pip install mavproxy --user git+https://github.com/ArduPilot/mavproxy.git@master
 
 .. _mavproxy-downloadinstallmac:
 
@@ -93,14 +93,14 @@ Uninstall python-dateutil (OSX and Windows come bundled with a version that is n
 
 .. code:: bash
 
-    sudo pip3 uninstall python-dateutil
+    sudo python3 -m pip uninstall python-dateutil
 
 Install MAVProxy and its remaining dependencies from the public PyPi repository:
 
 .. code:: bash
 
-    sudo pip3 install wxPython
-    sudo pip3 install gnureadline
-    sudo pip3 install billiard
-    sudo pip3 install numpy pyparsing
-    sudo pip3 install MAVProxy
+    sudo python3 -m pip install wxPython
+    sudo python3 -m pip install gnureadline
+    sudo python3 -m pip install billiard
+    sudo python3 -m pip install numpy pyparsing
+    sudo python3 -m pip install MAVProxy

--- a/rover/source/docs/walking-robots.rst
+++ b/rover/source/docs/walking-robots.rst
@@ -152,7 +152,7 @@ The following steps will get you running with the quadruped example.
 
 :: 
 
-   pip3 install pybullet
+   python3 -m pip install pybullet
    
 - cd to the ardupilot/Rover directory  
 - create a "scripts" directory and copy `quadruped.lua <https://github.com/ArduPilot/ardupilot/tree/master/libraries/AP_Scripting/examples>`_ into it


### PR DESCRIPTION
I have not addressed the use of "sudo" - that requires looking more closely at which sort of installation is being used.

This is also going to be out-of-date vis-a-vis venvs.

But pip3 vs python3 -m pip is an *important* time-saver.
