### PR TITLE
Docs: Plane: Add hint to solve 1Hz pitch oscillations

### DIFF
--- a/plane/source/docs/automatic-tuning-with-autotune.rst
+++ b/plane/source/docs/automatic-tuning-with-autotune.rst
@@ -153,6 +153,17 @@ This is a special level that does not change the rates or time constant (ie like
 Completing the tune
 ===================
 
+.. _automatic-tuning-with-autotune-completing-the-tune:
+
+.. warning::
+
+   If you have successfully tuned your plane with Autotune and see oscillations on the pitch axis around 1 Hz,
+   check if :ref:`PTCH_RATE_I<PTCH_RATE_I>` far exceeds :ref:`PTCH_RATE_P<PTCH_RATE_P>`.
+   This is an unwanted result of Autotune for Plane and it typically becomes visible if you fly straight for
+   a longer distance. Autotune does blindly copy the value of :ref:`PTCH_RATE_FF<PTCH_RATE_FF>` to 
+   :ref:`PTCH_RATE_I<PTCH_RATE_I>` due to a wrong design decision. In this case reduce the value of
+   :ref:`PTCH_RATE_I<PTCH_RATE_I>` to half of it's value.
+
 Once you have learned reasonable tuning parameters with
 autotune you should complete the tune by manually tuning some other key
 parameters.

--- a/plane/source/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.rst
+++ b/plane/source/docs/tecs-total-energy-control-system-for-speed-height-tuning-guide.rst
@@ -183,6 +183,9 @@ increasing the value of :ref:`TECS_TIME_CONST<TECS_TIME_CONST>` in increments of
    where throttle changes cause noticeable pitch angle changes. Ideally you
    should improve your pitch loop tuning first, before adjusting
    :ref:`TECS_PTCH_DAMP<TECS_PTCH_DAMP>` and :ref:`TECS_TIME_CONST<TECS_TIME_CONST>` as described here.
+   Low frequency pitch oscillations around 1Hz are an indicator that :ref:`PTCH_RATE_I<PTCH_RATE_I>` is
+   too high. Refer to the warning :ref:`Completing the tune <automatic-tuning-with-autotune-completing-the-tune>`.
+
 
 If using airspeed sensing, adjust the value of :ref:`TRIM_THROTTLE<TRIM_THROTTLE>` so
 that it matches the average amount of throttle required by the


### PR DESCRIPTION
This patch adds a warning about a nasty side effect of Autotune.

I had the situation that I was through with tuning by documentation, then flew a longer distance straight and the plane started to oscillate over 5deg pitch and 1m altitude at 1Hz.
The cause was that Autotune did copy the FF value to the I-Gain which was >150% of the P-Gain.

I'm not sure if I got the cross-side link correctly. Please advice and I'll rework as necessary.