### PR TITLE
Stop parameters page in Wiki from just disappearing

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -305,6 +305,8 @@ def get_commit_dict(releases_parsed):
     for i in commits_and_codes:
         if commits_and_codes[i][0] != 'error':
             commite_and_codes_cleanned[i] = commits_and_codes[i]
+    if len(commite_and_codes_cleanned) == 0:
+        error("Expected at least one commit")
     return commite_and_codes_cleanned
 
 

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -509,4 +509,4 @@ generate_rst_files(commits_to_checkout_and_parse)
 generate_json(VEHICLES)
 move_results(VEHICLES)
 
-# sys.exit(error_count)
+sys.exit(error_count)

--- a/update.sh
+++ b/update.sh
@@ -132,20 +132,14 @@ find -name "parameters*rst" -delete # Clean possible built and cached parameters
 
 END_UPDATES=$(date +%s)
 
-DO_PARAM_VERSIONING=true
-if $DO_PARAM_VERSIONING; then
-    progress "Starting to build multiple parameters pages"
-    python3 build_parameters.py || {
-	progress "build_parameters.py failed"
-	exit 1
-    }
-    END_BUILD_MPARAMS=$(date +%s)
-    MPARAMS_TIME=$(echo "($END_BUILD_MPARAMS - $END_UPDATES)" | bc)
-    progress "Time to run build_parameters.py: $MPARAMS_TIME seconds"
-else
-    # we use this hwne calculating times, below
-    END_BUILD_MPARAMS=$END_UPDATES
-fi
+progress "Starting to build multiple parameters pages"
+python3 build_parameters.py || {
+    progress "build_parameters.py failed"
+    exit 1
+}
+END_BUILD_MPARAMS=$(date +%s)
+MPARAMS_TIME=$(echo "($END_BUILD_MPARAMS - $END_UPDATES)" | bc)
+progress "Time to run build_parameters.py: $MPARAMS_TIME seconds"
 
 progress "Starting to build the wiki"
 # python3 update.py --clean --parallel 4 # Build without versioning for parameters. It is better for editing wiki.

--- a/update.sh
+++ b/update.sh
@@ -35,34 +35,49 @@ lock_file build.lck || {
     exit 1
 }
 
+progress() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] update.sh: $*"
+}
+
+LOGFILE="logs/update-latest.log"
+progress "update.sh starting (see $LOGFILE)"
+
 test -n "$FORCEBUILD" || {
-    (cd ardupilot_wiki && git fetch > /dev/null 2>&1)
-    (cd sphinx_rtd_theme && git fetch > /dev/null 2>&1)
+    progress "Fetching ardupilot_wiki"
+    (cd ardupilot_wiki && git fetch)
+    progress "Fetching sphinx_rtd_theme"
+    (cd sphinx_rtd_theme && git fetch)
 
     changed=0
+    progress "Getting oldhash for ardupilot_wiki"
     oldhash=$(cd ardupilot_wiki && git rev-parse origin/master)
+    progress "Getting newhash for ardupilot_wiki"
     newhash=$(cd ardupilot_wiki && git rev-parse HEAD)
     [ "$oldhash" = "$newhash" ] || {
-        echo "ardupilot_wiki has changed $newhash $oldhash"
+        progress "ardupilot_wiki has changed $newhash $oldhash"
         changed=1
     }
     
+    progress "Getting oldhash for sphinx_rtd_theme"
     oldhash=$(cd sphinx_rtd_theme && git rev-parse origin/master)
+    progress "Getting newhash for sphinx_rtd_theme"
     newhash=$(cd sphinx_rtd_theme && git rev-parse HEAD)
     [ "$oldhash" = "$newhash" ] || {
-        echo "sphinx_rtd_theme has changed $newhash $oldhash"
+        progress "sphinx_rtd_theme has changed $newhash $oldhash"
         changed=1
     }
 
+    progress "Fetching parameters"
     PARAMSITES="ArduPlane ArduCopter AntennaTracker Rover AP_Periph Blimp"
     mkdir -p old_params new_params
     for site in $PARAMSITES; do
-        wget "https://autotest.ardupilot.org/Parameters/$site/Parameters.rst" -O new_params/$site.rst 2> /dev/null
+        wget "https://autotest.ardupilot.org/Parameters/$site/Parameters.rst" -O new_params/$site.rst
     done
 
+    progress "Comparing parameters"
     for site in $PARAMSITES; do
         if ! cmp new_params/$site.rst old_params/$site.rst; then
-            echo "$site.rst has changed"
+            progress "$site.rst has changed"
             cp new_params/$site.rst old_params/$site.rst
             changed=1
         fi
@@ -71,30 +86,29 @@ test -n "$FORCEBUILD" || {
     LOGMESSAGESITES="Plane Copter Tracker Rover Blimp"
     mkdir -p old_logmessages new_logmessages
     for site in $LOGMESSAGESITES; do
-        wget "https://autotest.ardupilot.org/LogMessages/$site/LogMessages.rst" -O new_logmessages/$site.rst 2> /dev/null
+        wget "https://autotest.ardupilot.org/LogMessages/$site/LogMessages.rst" -O new_logmessages/$site.rst
     done
 
     for site in $LOGMESSAGESITES; do
         if ! cmp new_logmessages/$site.rst old_logmessages/$site.rst; then
-            echo "$site.rst has changed"
+            progress "$site.rst has changed"
             cp new_logmessages/$site.rst old_logmessages/$site.rst
             changed=1
         fi
     done
 
-    [ $changed = 1 ] || exit 0
+    [ $changed = 1 ] || {
+	progress "Nothing changed; no rebuild required, exiting"
+	exit 0
+    }
 }
+
+progress "update.sh starting build"
 
 (
 date
 
-report() {
-    cat <<EOF | mail -s 'wiki build failed' ardupilot.devel@gmail.com
-A wiki build failed
-EOF
-}
-
-echo "[Buildlog] Updating ardupilot_wiki at $(date '+%Y-%m-%d-%H-%M-%S')"
+progress "Updating ardupilot_wiki"
 pushd ardupilot_wiki
 git checkout -f master
 git fetch origin
@@ -103,7 +117,7 @@ git reset --hard origin/master
 git clean -f -f -x -d -d
 popd
 
-echo "[Buildlog] Updating sphinx_rtd_theme at $(date '+%Y-%m-%d-%H-%M-%S')"
+progress "Updating sphinx_rtd_theme"
 pushd sphinx_rtd_theme
 git checkout -f master
 git fetch origin
@@ -120,26 +134,37 @@ END_UPDATES=$(date +%s)
 
 DO_PARAM_VERSIONING=true
 if $DO_PARAM_VERSIONING; then
-    echo "[Buildlog] Starting to build multiple parameters pages at $(date '+%Y-%m-%d-%H-%M-%S')"
-    python3 build_parameters.py
+    progress "Starting to build multiple parameters pages"
+    python3 build_parameters.py || {
+	progress "build_parameters.py failed"
+	exit 1
+    }
     END_BUILD_MPARAMS=$(date +%s)
     MPARAMS_TIME=$(echo "($END_BUILD_MPARAMS - $END_UPDATES)" | bc)
-    echo "[Buildlog] Time to run build_parameters.py: $MPARAMS_TIME seconds"
+    progress "Time to run build_parameters.py: $MPARAMS_TIME seconds"
 else
     # we use this hwne calculating times, below
     END_BUILD_MPARAMS=$END_UPDATES
 fi
 
-echo "[Buildlog] Starting to build the wiki at $(date '+%Y-%m-%d-%H-%M-%S')"
+progress "Starting to build the wiki"
 # python3 update.py --clean --parallel 4 # Build without versioning for parameters. It is better for editing wiki.
-python3 update.py --destdir /var/sites/wiki/web --clean --paramversioning --parallel 4 --enablebackups --verbose # Enables parameters versioning and backups, should be used only on the wiki server
-
+python3 update.py --destdir /var/sites/wiki/web --clean --paramversioning --parallel 1 --enablebackups --verbose || {
+    progress "update.py failed"
+    exit 1
+}
 
 END_BUILD_WIKI=$(date +%s)
 WIKI_TIME=$(echo "($END_BUILD_WIKI - $END_BUILD_MPARAMS)/60" | bc)
-echo "[Buildlog] Time to build the wiki itself: $WIKI_TIME minutes"
+progress "Time to build the wiki itself: $WIKI_TIME minutes"
 SCRIPT_TIME=$(echo "($END_BUILD_WIKI - $START)/60" | bc)
-echo "[Buildlog] Time to run the full script: $SCRIPT_TIME minutes"
+progress "Time to run the full script: $SCRIPT_TIME minutes"
 
 
-) >> update.log 2>&1
+) >$LOGFILE 2>&1 || {
+    progress "update.sh failed; see $LOGFILE"
+}
+
+cat $LOGFILE >> logs/update.log
+
+progress "update.sh finished"

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # check for changes in docs and run sphinx
 
+set -e
+set -x
+
 export PYTHONUNBUFFERED=1
 
-cd $HOME/build_wiki || exit 1
+cd $HOME/build_wiki
 
 START=$(date +%s)
 


### PR DESCRIPTION
From what I've gleaned from the logs on the Wiki server, it is possible for build_parameters.py to parse out 0 versions to build from its scanning of the firmware server's directory listing pages.

This leads us to removing the parameters.rst file but not copying in a special "versioning" replacement for it based on the master branch.

So.  Run update.sh with `-e` so that it doesn't just rumble on if there's an error.

Change build_parameters.py to exit with a non-zero exit code if there's ever an error in it.

Require at least one version/commit from each directory listing parsed from the firmware server.

Future enhancements here:
 - make build_parameters.py a library, call it from update.py
 - stop parsing directory listing of firmware server in build_binaries.py, grab the manifest file instead and interpret it
    - generate parameter metadata into (eg.) https://firmware.ardupilot.org/Blimp/latest/3DRControlZeroG/, download that in build_parameters.py rather than doing the checkout-each-version thing; manifest would reference that .json / .rst
 