### PR TITLE
Update ros2-over-ethernet.rst to fix issue with ip adresses of companion and ardupilot

### DIFF
--- a/dev/source/docs/ros2-over-ethernet.rst
+++ b/dev/source/docs/ros2-over-ethernet.rst
@@ -36,8 +36,8 @@ Necessary parameters for static configuration
 This list of parameters is given as an example.
 If you had the following static IP addresses:
 
-* An autopilot has the IP address ``192.168.1.6``
-* A Computer running the MicroROS agent has the IP address ``192.168.1.5``
+* An autopilot has the IP address ``192.168.1.5``
+* A Computer running the MicroROS agent has the IP address ``192.168.1.6``
 * The MicroROS agent is running on port ``2019``
 
 Then, you would configure all of the below parameters.


### PR DESCRIPTION
changed IP-Adresse of Ardupilot and Companion-Computer to match the config-parameters in the table below. stumbled upon this when trying to find out if the DDS_IP-Parameters shall have the IP of the Companion or the Ardupilot itself.