### PR TITLE
Common: caddx version fix

### DIFF
--- a/common/source/docs/common-caddx-gimbal.rst
+++ b/common/source/docs/common-caddx-gimbal.rst
@@ -13,7 +13,7 @@ CADDX Gimbals
 
 .. warning::
 
-    Support for these gimbals is available in ArduPilot 4.7 (and higher) and requires the gimbal's firmware be 3.4 (or higher)
+    Support for these gimbals is available in ArduPilot 4.6 (and higher) and requires the gimbal's firmware be 3.4 (or higher)
 
 The `user manual can be found here <https://cdn.shopify.com/s/files/1/0036/3921/4169/files/GM_Series_Manual_V1.0_1.pdf>`__
 

--- a/common/source/docs/common-master-features.rst
+++ b/common/source/docs/common-master-features.rst
@@ -16,7 +16,6 @@ New Peripherals
     :maxdepth: 1
 
     Hexsoon 77G MWW Radar <common-rangefinder-hexsoon-radar>
-    CADDXFPV GM1, GM2, GM3 gimbals <common-caddx-gimbal>
 [/site]
 [site wiki="plane"]
 New Features


### PR DESCRIPTION
Now that we've backported CADDX support to 4.6 we can update the note re versions and remove it from the "upcoming features" section.

I've tested this locally and it looks OK to me