### PR TITLE
Common: ethernet adapters link to CubePilot switch

### DIFF
--- a/common/source/docs/common-ethernet-adapters.rst
+++ b/common/source/docs/common-ethernet-adapters.rst
@@ -19,7 +19,7 @@ Hardware
 - `BotBlox DroneNet for Ardupilot <https://botblox.io/dronenet-for-ardupilot/>`__ : ethernet switch with CAN, USART, RS485, and GPIO/PWM adapters allowing non-ethernet devices including autopilots to work over ethernet
 - `BotBlox SwitchBlox Cable Adapter for Ardupilot <https://botblox.io/switchblox-cable-adapter-for-ardupilot/>`__ : adapter to ease the ethernet port differences across different device manufacturers
 - `CubeNode ETH <https://docs.cubepilot.org/user-guides/cubenode/cubenode-eth>`__ : serial to ethernet adapter to allow non-ethernet autopilots to work over ethernet using PPP
-- `CubeLAN 8-Port Switch <https://irlock.com/products/cubelan-8-port-switch>`__ : ethernet switch using the CubePilot preferred 5-pin connector
+- `CubeLAN 8-Port Switch <https://docs.cubepilot.org/user-guides/switch/cubelan-8-port-switch>`__ : ethernet switch using the CubePilot preferred 5-pin connector
 
 PPP Setup
 =========


### PR DESCRIPTION
This updates the link for the CubePilot 8-port ethernet switch to point back to the official documentation (which has just been created)

I've tested this locally and it looks OK to me