### PR TITLE
dev: index.rst: fix broken link to MAVLink tutorial

### DIFF
--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -91,7 +91,7 @@ ArduPilot dev team.
    the protocol for communication between the ground station, flight
    controller and some peripherals including the OSD. A "Dummy's Guide" to
    working with MAVLink is
-   `here <https://diydrones.com/forum/topics/mavlink-tutorial-for-absolute-dummies-part-i?groupUrl=arducopterusergroup>`__.
+   `here <https://diydrones.com/group/arducopterusergroup/forum/mavlink-tutorial-for-absolute-dummies-part-i>`__.
 -  `UAVCAN* <http://uavcan.org>`__ -
    Lightweight protocol designed for reliable communication in aerospace and robotic 
    applications via CAN bus. ArduPilot is using the `Libuavcan <http://uavcan.org/Implementations/Libuavcan/>`__,


### PR DESCRIPTION
It seems DIY Drones have changed their site structure since the original link was generated.