### PR TITLE
common: ready-to-fly: avoid unwanted duplication

### DIFF
--- a/common/source/docs/common-appendix.rst
+++ b/common/source/docs/common-appendix.rst
@@ -23,7 +23,7 @@ the wiki.
     History of ArduPilot <common-history-of-ardupilot>
     Partners <common-partners>
     Partners Program <common-partners-program>
-[site wiki="plane, copter, rover, sub, blimp"]
+[site wiki="plane, copter, rover, sub"]
     Ready-To-Use vehicles <common-rtf>
 [/site]
 [site wiki="plane"]

--- a/common/source/docs/common-makeflyeasy-fighter-hand-throw.rst
+++ b/common/source/docs/common-makeflyeasy-fighter-hand-throw.rst
@@ -35,4 +35,4 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/10000223175280.html>`__
 
-[copywiki destination="plane,copter,rover,blimp"]
+[copywiki destination="plane"]

--- a/common/source/docs/common-makeflyeasy-fighter-vtol.rst
+++ b/common/source/docs/common-makeflyeasy-fighter-vtol.rst
@@ -37,4 +37,4 @@ Where to Buy
 
 `Aliexpress  <https://www.aliexpress.com/item/10000223165284.html>`__
 
-[copywiki destination="plane,copter,rover,blimp"]
+[copywiki destination="plane"]

--- a/common/source/docs/common-makeflyeasy-striver-mini-hand-throw.rst
+++ b/common/source/docs/common-makeflyeasy-striver-mini-hand-throw.rst
@@ -38,5 +38,5 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/1005002723370301.html>`__
 
-[copywiki destination="plane,copter,rover,blimp"]
+[copywiki destination="plane"]
 

--- a/common/source/docs/common-makeflyeasy-striver-mini-vtol.rst
+++ b/common/source/docs/common-makeflyeasy-striver-mini-vtol.rst
@@ -37,4 +37,4 @@ Where to Buy
 
 `Aliexpress <https://www.aliexpress.com/item/1005002723289589.html>`__
 
-[copywiki destination="plane,copter,rover,blimp"]
+[copywiki destination="plane"]

--- a/common/source/docs/common-rtf.rst
+++ b/common/source/docs/common-rtf.rst
@@ -12,6 +12,7 @@ Please check with the vendor prior to purchase.
 
    We recommend, when possible, to purchase from our `Partners <https://ardupilot.org/about/Partners>`__ because they directly support ArduPilot and we are more confident that users can upgrade the firmware on the vehicle.
 
+[site wiki="copter"]
 Copters from Partners
 =====================
 
@@ -37,7 +38,9 @@ Helicopters from Partners
 * `TT Robotix - SIRIUS Helicopter <http://www.ttrobotix.com/products/detail/905.html>`__
 * `TT Robotix - T-150 Maverick Helicopter <http://www.ttrobotix.com/products/detail/924.html>`__
 * `TT Robotix - Thunder Hawk Helicopter <http://www.ttrobotix.com/products/detail/902.html>`__
+[/site]
 
+[site wiki="plane"]
 Planes from Partners
 ====================
 
@@ -68,7 +71,9 @@ VTOL/QuadPlanes from Partners
 * `MakeFLyEasy - Freeman 2300 <https://www.uavmodel.com/collections/vtol/products/makeflyeasy-freeman-4-1-2300mm-uav-vtol>`__
 * :ref:`MakeFLyEasy - Fighter VTOL <common-makeflyeasy-fighter-vtol>`
 * :ref:`MakeFLyEasy - Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>`
+[/site]
 
+[site wiki="rover"]
 Rovers from Partners
 ====================
 
@@ -80,28 +85,40 @@ Boats from Partners
 ===================
 
 * `BlueRobotics BlueBoat <https://bluerobotics.com/store/boat/blueboat/blueboat/>`__
+[/site]
 
+[site wiki="sub"]
 Subs from Partners
 ==================
 
 * `Blue Robotics - BlueROV2 <https://bluerobotics.com/store/rov/bluerov2/>`__
+[/site]
 
+[site wiki="copter,plane,rover"]
 Vehicles from Non-Partners
 ==========================
+[/site]
 
+[site wiki="copter"]
 * `Aton <https://traxxas.com/products/models/heli/Aton-Plus>`__ and `Aton-Plus from traxxas <https://traxxas.com/products/models/heli/Aton-Plus>`__ (firmware loaded using an SD Card)
-* `BathyDrone mapping boats <https://www.bathydrone-usv.com/>`__
+* `SkyRocket - Journey <http://sky-viper.com/journey/>`__
+* 3DR Solo from `Amazon <https://www.amazon.com/3DR-Solo-Quadcopter-No-Gimbal/dp/B00ZPM7BOG>`__
+[/site]
+[site wiki="plane"]
 * `DRONEE Easy to Use Mapping Plane <https://dronee.aero/pages/droneeplane>`__
 * `MotoDoro Farm Mapper (Plane) <https://motodoro.com/blog/detail/00005-farm-mapper-vtol.html>`__
-* `SkyRocket - Journey <http://sky-viper.com/journey/>`__
 * `UAV Mapper from TuffWing <http://www.tuffwing.com/products/drone_mapper.html>`__
-* 3DR Solo from `Amazon <https://www.amazon.com/3DR-Solo-Quadcopter-No-Gimbal/dp/B00ZPM7BOG>`__
 * `LP Mini Orca HVTOL Drone <https://lpbond.com/productos/miniorca.html>`__
+[/site]
+[site wiki="rover"]
+* `BathyDrone mapping boats <https://www.bathydrone-usv.com/>`__
+[/site]
 
 .. note::
 
    If you are a manufacturer of a RTF vehicle based on ArduPilot and do not appear in this list, please get in touch through one of the methods listed on our :ref:`Contact Us page <common-contact-us>`.
 
+[site wiki="plane"]
 .. toctree::
    :hidden:
 
@@ -109,5 +126,6 @@ Vehicles from Non-Partners
     MakeFLyEasy Fighter VTOL <common-makeflyeasy-fighter-vtol>
     MakeFLyEasy Striver Mini Hand Throw <common-makeflyeasy-striver-mini-hand-throw>
     MakeFLyEasy Striver Mini VTOL <common-makeflyeasy-striver-mini-vtol>
+[/site]
 
-[copywiki destination="plane,copter,rover,blimp"]
+[copywiki destination="plane,copter,rover,sub"]

--- a/sub/source/index.rst
+++ b/sub/source/index.rst
@@ -23,7 +23,8 @@ Getting more info
     
 .. toctree::
    :hidden:
-   
+
+   Ready to Dive/Use Vehicles <docs/common-rtf>
    Complete parameter list <docs/parameters>
    Complete log message list <docs/logmessages>
    Board Feature List <docs/binary-features>


### PR DESCRIPTION
Only a subset of the listed vehicles are relevant to each vehicle type.

This PR
- splits those out (removing the unwanted ones from the copy action), while also
- removing blimp entirely (it has no pre-made purchaseable vehicles), and
- adding Sub as a target
    - ~cannot be merged before #6649 - hence draft PR for now (will need to be rebased over master once that's merged in)~