### PR TITLE
Rangefinder distance scaling fixes

### DIFF
--- a/common/source/docs/common-aerotenna-usd1.rst
+++ b/common/source/docs/common-aerotenna-usd1.rst
@@ -31,18 +31,18 @@ For a serial connection you can use any spare Serial/UART port.  The example bel
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 11 (USD1-Serial)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 50
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 4500
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimeters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.5
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 45
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in meters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 For the CAN version, connect via CAN to the autopilot and set the following parameters:
 
 -  :ref:`CAN_P1_DRIVER<CAN_P1_DRIVER>` =  1 (first can port driver set to driver 1)
 -  :ref:`CAN_D1_PROTOCOL<CAN_D1_PROTOCOL>` =  7 (USD1 protocol for driver 1)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 33 (USD1_CAN)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 50
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 4500
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimeters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.5
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 45
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in meters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 
 Testing the sensor

--- a/common/source/docs/common-ainstein-lrd1.rst
+++ b/common/source/docs/common-ainstein-lrd1.rst
@@ -30,9 +30,9 @@ For a serial connection you can use any spare Serial/UART port.  The example bel
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 42 (Ainstein_LR_D1)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 100
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 50000
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimeters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 1.0
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 500
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in meters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-arkflow.rst
+++ b/common/source/docs/common-arkflow.rst
@@ -88,7 +88,7 @@ Connection to Autopilot
 To use the onboard lidar:
 
 - Set :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 24 (DroneCAN)
-- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 3000 to set range finder's maximum range to 30m
+- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 30 to set range finder's maximum range to 30m
 
 Additional Notes
 -----------------

--- a/common/source/docs/common-arkflow_mr.rst
+++ b/common/source/docs/common-arkflow_mr.rst
@@ -88,7 +88,7 @@ Connection to Autopilot
 To use the onboard lidar:
 
 - Set :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 24 (DroneCAN)
-- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 5000 to set range finder's maximum range to 50m
+- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 50 to set range finder's maximum range to 50m
 
 Additional Notes
 -----------------

--- a/common/source/docs/common-benewake-tf02-lidar.rst
+++ b/common/source/docs/common-benewake-tf02-lidar.rst
@@ -36,9 +36,9 @@ If the SERIAL4 is being used then the following parameters should be set for the
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, =20 (Benewake-Serial) for TF03 if Copter 3.6.12, =27 (Benewake TF03) for TF03 and TF02 Pro for Copter 4.0 and later, and =20 for TF-Luna. Note: using type = 20 on a TF03 will restrict its maximum range to that of a TF02.
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 30 for TFMini, 10 for TFminiPlus and TF-Luna.
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>`: for TF02 use **2000** for indoor, **1000** for outdoor.  For TF03 use **3500** for indoor, **12000** for outdoor. For TF-Luna use **800** for indoor, **300** for outdoor. *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3 for TFMini, 0.1 for TFminiPlus and TF-Luna.
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>`: for TF02 use **20** for indoor, **10** for outdoor.  For TF03 use **35** for indoor, **12** for outdoor. For TF-Luna use **8** for indoor, **3** for outdoor. *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If instead the Telem2 port was used then the serial parameters listed above should instead be:
 

--- a/common/source/docs/common-benewake-tfmini-lidar.rst
+++ b/common/source/docs/common-benewake-tfmini-lidar.rst
@@ -32,9 +32,9 @@ If the SERIAL4 port on an autopilot is being used then the following parameters 
 - :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 - :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
 - :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 20 (Benewake-Serial)
-- :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 30 for TFmini, 10 for TFminiPlus
-- :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **1000** for indoor use OR **600** for outdoors.  *This is the distance in centimeters that the rangefinder can reliably read.*
-- :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+- :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3 for TFmini, 0.1 for TFminiPlus
+- :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **10** for indoor use OR **6** for outdoors.  *This is the distance in meters that the rangefinder can reliably read.*
+- :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Connecting using I2C
 --------------------
@@ -46,9 +46,9 @@ The diagram below shows how to connect to the autopilot's I2C port.
 
 - :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 25 (Benewake TFminiPlus-I2C)
 - :ref:`RNGFND1_ADDR<RNGFND1_ADDR>` = 16 (I2C address of lidar in decimal, equivalent to 0x10 hexadecimal)
-- :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 30 for TFmini, 10 for TFminiPlus
-- :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **1000** for indoor use OR **600** for outdoors.  *This is the distance in centimeters that the rangefinder can reliably read.*
-- :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+- :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3 for TFmini, 0.1 for TFminiPlus
+- :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **10** for indoor use OR **6** for outdoors.  *This is the distance in meters that the rangefinder can reliably read.*
+- :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-bluerobotics-ping.rst
+++ b/common/source/docs/common-bluerobotics-ping.rst
@@ -29,8 +29,8 @@ If the SERIAL2 port on the autopilot is being used then the following parameters
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115 (115200 baud)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 23 (BlueRoboticsPing)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 30
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 2600.  This is the distance in centimeters that the rangefinder can reliably read.
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 26.  This is the distance in meters that the rangefinder can reliably read.
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (down) if mounted on a boat
 
 PingViewer to test and upgrade the sensor

--- a/common/source/docs/common-echologger-ect400.rst
+++ b/common/source/docs/common-echologger-ect400.rst
@@ -40,8 +40,8 @@ If the SERIAL2 is used then the following parameters should be set:
 Then the following range finder related parameters should be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 13
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 10000 (i.e. 100m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.13
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 100 (i.e. 100m).  *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 Configuring the sensor

--- a/common/source/docs/common-hereflow.rst
+++ b/common/source/docs/common-hereflow.rst
@@ -37,7 +37,7 @@ Connection to Autopilot
 To use the onboard lidar (not recommended):
 
 - Set :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 24 (DroneCAN)
-- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 300 to set range finder's maximum range to 3m
+- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 3 to set range finder's maximum range to 3m
 
 Additional Notes
 -----------------

--- a/common/source/docs/common-hondex-sonar.rst
+++ b/common/source/docs/common-hondex-sonar.rst
@@ -35,8 +35,8 @@ If the SERIAL2 is used then the following parameters should be set:
 The following range finder related parameters should also be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 13
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 10000 (i.e. 100m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.13
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 100 (i.e. 100m).  *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 Testing the sensor

--- a/common/source/docs/common-jsn-sr04t.rst
+++ b/common/source/docs/common-jsn-sr04t.rst
@@ -18,8 +18,8 @@ Connection to the autopilot
 
 To setup as the first rangefinder. Reboot after setting parameters:
 
--  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "450" (i.e. 4.5m max range for v2.0 ver)
--  :ref:`RNGFND1_MIN<RNGFND1_MIN>` = "25" (i.e. 25cm min range for v2.0 ver)
+-  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "4.5" (i.e. 4.5m max range for v2.0 ver)
+-  :ref:`RNGFND1_MIN<RNGFND1_MIN>` = "0.25" (i.e. 0.25m min range for v2.0 ver)
 -  :ref:`RNGFND1_STOP_PIN<RNGFND1_STOP_PIN>` = Enter GPIO number for pin attached to JSN-SR04T "Trigger" pin. See :ref:`common-gpios`.
 -  :ref:`RNGFND1_PIN<RNGFND1_PIN>` = Enter GPIO number for pin attached to JSN-SR04T "Echo" pin.
 -  :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = “30" (HC-SR04 sonar)

--- a/common/source/docs/common-kogger-sonar.rst
+++ b/common/source/docs/common-kogger-sonar.rst
@@ -61,8 +61,8 @@ The sensor can be connected to any available serial/uart port on the autopilot. 
 Then the following range finder related parameters should be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 30
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 5000 (i.e. 50m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 50 (i.e. 50m).  *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 

--- a/common/source/docs/common-leddar-one-lidar.rst
+++ b/common/source/docs/common-leddar-one-lidar.rst
@@ -34,9 +34,9 @@ following parameters for the first rangefinder (this is done on the Mission Plan
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115200
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 12 (LeddarOne)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **4000** (40m) *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **40** (40m) *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115200
 

--- a/common/source/docs/common-leddartech-leddarvu8-lidar.rst
+++ b/common/source/docs/common-leddartech-leddarvu8-lidar.rst
@@ -27,9 +27,9 @@ The following parameters should be set
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115 (115200 baud)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 29 (LeddarVu8-Serial)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 15
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 16000.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.15
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 160.  *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Serial4 port on the autopilot then you would set :ref:`SERIAL4_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL4_BAUD <SERIAL2_BAUD>` to 115
 

--- a/common/source/docs/common-lightware-lw20-lidar.rst
+++ b/common/source/docs/common-lightware-lw20-lidar.rst
@@ -34,9 +34,9 @@ following parameters if its the first rangefinder in the system (this can be don
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud) for newer sensors, 19 (19200 baud) for sensors manufactured before mid 2018
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 8 (LightWareSerial)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **95**.  *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to 115 (115200 baud) or 19 (19200 baud)
 
@@ -59,9 +59,9 @@ You then need to configure the rangefinder parameters as shown below
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 7 (LightWareI2C)
 -  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 102 (I2C Address of lidar in decimal).  *Note that this setting is in decimal. The default address is 0x66 hexadecimal which is 102 in decimal.*
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **9500**.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **95**.  *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-lightware-sf10-lidar.rst
+++ b/common/source/docs/common-lightware-sf10-lidar.rst
@@ -58,9 +58,9 @@ following parameters in the case of the first rangefinder(this is done in the *M
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud) 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 8 (LightWareSerial)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **25** (for SF10A), **50** (for SF10B), **100** (for SF10C) or **120** (for SF11C).  *This is the distance in meters that the rangefinder can reliably read. The value depends on the model of the lidar.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If you instead were using the Telem2 port on the Pixhawk then you would set :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9, and :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115
 
@@ -85,9 +85,9 @@ List** page):
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 7 (LightWareI2C)
 -  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 102 (I2C Address of lidar in decimal).  *Please note that this setting is in decimal and not hexadecimal as shown in the lidar settings screen. The default address is 0x66 which is 102 in decimal.*
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **2500** (for SF10A), **5000** (for SF10B), **10000** (for SF10C) or **12000** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **25** (for SF10A), **50** (for SF10B), **100** (for SF10C) or **120** (for SF11C).  *This is the distance in meters that the rangefinder can reliably read. The value depends on the model of the lidar.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 It may be necessary to enable the sensor's "I2C compatibility mode (Pixhawk)".  This can be done by connecting the lidar to your PC using a USB cable, then download `Lightware Studio <https://lightwarelidar.com/pages/lightware-studio>`__, connect and check the checkbox shown below
 
@@ -123,9 +123,9 @@ List** page):
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 1 (Analog)
 -  :ref:`RNGFND1_PIN <RNGFND1_PIN>` = 14 (2nd pin of 3.3V ADC connector)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = **9.76** (for SF10A), **19.531** (for SF10B), **39.06** (for SF10C), **46.87** (for SF11C)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **2000** (for SF10A), **4500** (for SF10B), **9500** (for SF10C) or **11500** (for SF11C).  *This is the distance in centimeters that the rangefinder can reliably read. The value depends on the model of the lidar.  Note the range is 5m less than using Serial or I2C protocols so that out-of-range can be reliably detected*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **20** (for SF10A), **45** (for SF10B), **95** (for SF10C) or **115** (for SF11C).  *This is the distance in meters that the rangefinder can reliably read. The value depends on the model of the lidar.  Note the range is 5m less than using Serial or I2C protocols so that out-of-range can be reliably detected*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 The :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` value depends on the voltage on the rangefinders output pin at the maximum range. By default the SF10/B will output 2.56V at 50m, so the scaling factor is 50m / 2.56v ≈ 19.53 (the analog
 distance range for each of the rangefinder variants can be found in the `SF10 Manual <http://documents.lightware.co.za/SF10%20-%20Laser%20Altimeter%20Manual%20-%20Rev%2011.pdf>`__).

--- a/common/source/docs/common-lowrance-elite-ti2-sonar.rst
+++ b/common/source/docs/common-lowrance-elite-ti2-sonar.rst
@@ -32,8 +32,8 @@ If the autopilot's Serial2 port (aka Telem2) is used then the following paramete
 These rangefinder parameters should also be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 13
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 30000 (300m)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.13
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 300 (300m)
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (down)
 
 Testing the sensor

--- a/common/source/docs/common-mateksys-optflow-3901L0X.rst
+++ b/common/source/docs/common-mateksys-optflow-3901L0X.rst
@@ -43,7 +43,7 @@ Connection to Autopilot
 To use the onboard lidar (not recommended):
 
 - Set :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 32 (MSP)
-- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 120 to set range finder's maximum range to 1.2m
+- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 1.2 to set range finder's maximum range to 1.2m
 
 Additional Notes
 -----------------

--- a/common/source/docs/common-mtf-01.rst
+++ b/common/source/docs/common-mtf-01.rst
@@ -48,8 +48,8 @@ For the following we will assume it will be connected to Serial1 port of the aut
 - Set :ref:`FLOW_TYPE<FLOW_TYPE>` = 5 (MAVLink)
 - Set :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = 10 (MAVLink)
 - Reboot autopilot to see rangefinder parameters
-- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 800 to set range finder's maximum range to 8m
-- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 1
+- Set :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 8 to set range finder's maximum range to 8m
+- Set :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.01
 - Set :ref:`RNGFND1_ORIENT<RNGFND1_ORIENT>` = 25 (Downward) 
 
 Once the sensor is active you should be able to observe the optical flow and range sensor data on the Mission Planner’s “Status” page. The “opt_qua” and “rangefinder1” should have some value.

--- a/common/source/docs/common-rangefinder-gy-us42.rst
+++ b/common/source/docs/common-rangefinder-gy-us42.rst
@@ -16,7 +16,7 @@ For Triggered Pulse mode, tie the center pad to "L" and set the :ref:`RNGFND1_TY
 
 For Serial Mode, tie the center pad to "H" and set  :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = “31". And set the Serial Port used to communicate with it to ``SERIALx_PROTOCOL`` = "9" (Rangefinder) and ``SERIALx_BAUD`` = 9 (9600).
 
-This device has a maximum useful range of 4m, so set -  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "400".
+This device has a maximum useful range of 4m, so set -  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "4".
 
 Pinout:
 

--- a/common/source/docs/common-rangefinder-hcsr04.rst
+++ b/common/source/docs/common-rangefinder-hcsr04.rst
@@ -23,8 +23,8 @@ Two :ref:`GPIOs <common-gpios>` are required for the Trigger pin (starts the son
 
 To setup as the first rangefinder. Reboot after setting parameters:
 
--  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "200" (i.e. 2m max range)
--  :ref:`RNGFND1_MIN<RNGFND1_MIN>` = "20" (i.e. 20cm min range)
+-  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "2" (i.e. 2m max range)
+-  :ref:`RNGFND1_MIN<RNGFND1_MIN>` = "0.2" (i.e. 0.2m min range)
 -  :ref:`RNGFND1_STOP_PIN<RNGFND1_STOP_PIN>` = Enter GPIO number for pin attached to HC-SRO4 "Trigger" pin. For example, on PixHawk with ``BRD_PWM_COUNT`` = 4, AUX6 (GPIO 55) could be used here, and AUX5 (GPIO54) could be used below.
 -  :ref:`RNGFND1_PIN<RNGFND1_PIN>` = Enter GPIO number for pin attached to HC-SRO4 "Echo" pin.
 -  :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = “30" (HC-SR04 sonar)

--- a/common/source/docs/common-rangefinder-jae-jre-30.rst
+++ b/common/source/docs/common-rangefinder-jae-jre-30.rst
@@ -70,8 +70,8 @@ Set the following parameters which assume the radar is connected to the autopilo
 - Set :ref:`SERIAL1_PROTOCOL<SERIAL1_PROTOCOL>` =  9 (Rangefinders)
 - Set :ref:`SERIAL1_BAUD<SERIAL1_BAUD>` = 460 (460800 Baud)
 - Set :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = 41 (JRE Serial)
-- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 10 (cm)
-- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 5000 (cm)
+- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 0.1 (meters)
+- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 50 (meters)
 
 Setup using CAN
 ===============
@@ -86,6 +86,6 @@ Set the following parameters which assume the radar is connected to the autopilo
 - Set :ref:`CAN_P1_BITRATE<CAN_P1_BITRATE>` = 1000000 (1 Mbps)
 - Set :ref:`CAN_D1_PROTOCOL<CAN_D1_PROTOCOL>` = 1 (DroneCAN)
 - Set :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = 24 (DroneCAN)
-- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 10 (cm)
-- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 5000 (cm)
+- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 0.1 (meters)
+- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 50 (meters)
 - Set :ref:`RNGFND1_ADDR<RNGFND1_ADDR>` = 1

--- a/common/source/docs/common-rangefinder-lidarlite.rst
+++ b/common/source/docs/common-rangefinder-lidarlite.rst
@@ -71,8 +71,8 @@ The power to the rangefinder should be supplied from a separate external BEC as 
 Set the following parameters:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 3 "LidarLite-I2c"
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 3500 (the maximum range the lidar can accurately report in cm)
--  :ref:`RNGFND1_MIN <RNGFND1_MAX>` = 20 (the mininum range the lidar can accurately report in cm)
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 35 (the maximum range the lidar can accurately report in m)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.20 (the mininum range the lidar can accurately report in m)
 
 Connecting via PWM
 ==================
@@ -90,8 +90,8 @@ Set the following parameters:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 5 "PWM"
 -  :ref:`RNGFND1_PIN <RNGFND1_PIN>` = 54 "AUX5" (if using 4.0.0 or higher any Auxiliary output may be used)
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 3500 (the maximum range the lidar can accurately report in cm)
--  :ref:`RNGFND1_MIN <RNGFND1_MAX>` = 20 (the mininum range the lidar can accurately report in cm)
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 35 (the maximum range the lidar can accurately report in m)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.2 (the mininum range the lidar can accurately report in m)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1 ("0.8" may produce more accurate readings for some units)
 -  :ref:`RNGFND1_OFFSET <RNGFND1_OFFSET>` = 0
 -  ``BRD_PWM_COUNT`` = 4 (ensures AUX5 is not used as a servo output)

--- a/common/source/docs/common-rangefinder-maxbotix-analog.rst
+++ b/common/source/docs/common-rangefinder-maxbotix-analog.rst
@@ -36,10 +36,8 @@ Config/Tuning >> Full Parameter List page and set the following
 parameters (example shown if first rangefinder:
 
 -  :ref:`RNGFND1_PIN<RNGFND1_PIN>` = "14" for Pixhawk's ADC 3.3v pin #2
--  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "700" (i.e. 7m max range) if using EZ0 or EZ4,
-   "1000" if using EZL0
--  :ref:`RNGFND1_SCALING<RNGFND1_SCALING>` = "2.04" (i.e. 7m / 5v) if using EZ0 or EZ4, "4.08"
-   (i.e. 10m / 5v) if using EZL0
+-  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "7" (i.e. 7m max range) if using EZ0 or EZ4, "10" if using EZL0
+-  :ref:`RNGFND1_SCALING<RNGFND1_SCALING>` = "2.04" (i.e. 7m / 5v) if using EZ0 or EZ4, "4.08" (i.e. 10m / 5v) if using EZL0
 -  :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = “1" (Analog)
 
 .. note::

--- a/common/source/docs/common-rangefinder-maxbotixi2c.rst
+++ b/common/source/docs/common-rangefinder-maxbotixi2c.rst
@@ -38,7 +38,7 @@ To configure Copter, Plane or Rover to use the Maxbotix I2C, please
 first connect with the Mission Planner and then open the Config/Tuning
 >> Full Parameter List page and set the following parameters (example below is if it is first rangefinder):
 
--  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "700" (i.e. 7m max range)
+-  :ref:`RNGFND1_MAX<RNGFND1_MAX>` = "7" (i.e. 7m max range)
 -  :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = “2" (MaxbotixI2C sonar)
 
 .. image:: ../../../images/RangeFinder_MaxbotixI2C_MPSetup.png

--- a/common/source/docs/common-rangefinder-nooploop-tofsense-f.rst
+++ b/common/source/docs/common-rangefinder-nooploop-tofsense-f.rst
@@ -16,7 +16,7 @@ Connecting via UART to Autopilot
 ================================
 
 The same steps as the Nooploop TOFSense P (UART) can be followed, as linked :ref:`here <common-rangefinder-nooploop-tofsense-p>`.
-:ref:`RNGFND1_MAX <RNGFND1_MAX>` can be changed as per the sensor specifications (1500 for TOFSense F and 2500 for TOFSense FP)
+:ref:`RNGFND1_MAX <RNGFND1_MAX>` can be changed as per the sensor specifications (15 for TOFSense F and 25 for TOFSense FP)
 
 Connecting via I2C
 ==================

--- a/common/source/docs/common-rangefinder-nooploop-tofsense-p.rst
+++ b/common/source/docs/common-rangefinder-nooploop-tofsense-p.rst
@@ -36,8 +36,8 @@ Set the following parameters:
 -  :ref:`SERIAL4_PROTOCOL<SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD<SERIAL4_BAUD>` = 230400 (Or as set in NAssistant)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 37 (NoopLoop_TOFSense) Reboot after setting this.
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 800 (i.e. 8m max range)
--  :ref:`RNGFND1_MAX <RNGFND1_MIN>` = 2
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 8 (i.e. 8m max range)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.02
 
 
 Connecting via CAN
@@ -65,8 +65,8 @@ Set the following parameters
 -  :ref:`CAN_P2_BITRATE<CAN_P2_BITRATE>` = 1000000 (Or as set in NAssistant)
 -  :ref:`CAN_D2_PROTOCOL<CAN_D2_PROTOCOL>` = 13 (TOFSenseP protocol)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 38 (NoopLoop_TOFSense_CAN) Reboot after setting this.
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 8000 (i.e. 8m max range)
--  :ref:`RNGFND1_MAX <RNGFND1_MIN>` = 2
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 8 (i.e. 8m max range)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.02
 -  :ref:`RNGFND1_RECV_ID <RNGFND1_RECV_ID>` = ID of the sensor (0 to accept data from all CAN sensor IDs)
 
 

--- a/common/source/docs/common-rangefinder-nra24.rst
+++ b/common/source/docs/common-rangefinder-nra24.rst
@@ -31,11 +31,11 @@ For a serial connection you can use any spare CAN port. Since this is not a Dron
 Set the following parameters
 
 -  :ref:`CAN_P2_DRIVER <CAN_P2_DRIVER>` = 2 (to enable the second CAN driver)
--  :ref:`CAN_P2_BITRATE <CAN_P2_BITRATE>` = 500000 (Or as set in NSM tools)
+-  :ref:`CAN_P2_BITRATE <CAN_P2_BITRATE>` = 500000 (or as set in NSM tools)
 -  :ref:`CAN_D2_PROTOCOL <CAN_D2_PROTOCOL>` = 14 (NanoRadar)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 39 (NRA-24). Reboot after setting this.
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 19000 (i.e. 200m max range with 10m buffer)
--  :ref:`RNGFND1_MAX <RNGFND1_MIN>` = 50 (0.5m min range)
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 190 (i.e. 200m max range with 10m buffer)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.5 (0.5m min range)
 -  :ref:`RNGFND1_RECV_ID <RNGFND1_RECV_ID>` = ID of the sensor (0 to accept all CAN ids for distance)
 
 
@@ -52,8 +52,8 @@ Set the following parameters (Example for setup on TELEM1/SERIAL1)
 -  :ref:`SERIAL1_BAUD <SERIAL1_BAUD>` = 115 (Baud rate as per the official documentation `here <http://en.nanoradar.cn/File/view/id/436.html>`__)
 -  :ref:`SERIAL1_PROTOCOL <SERIAL1_PROTOCOL>` = 9 (which translates to Rangefinder)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 11 (which is USD1_Serial). Reboot after setting this.
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 19000 (i.e. 200m max range with 10m buffer)
--  :ref:`RNGFND1_MAX <RNGFND1_MIN>` = 50 (0.5m min range)
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 190 (i.e. 200m max range with 10m buffer)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.5 (0.5m min range)
 
 
 Testing the sensor

--- a/common/source/docs/common-rangefinder-sf02.rst
+++ b/common/source/docs/common-rangefinder-sf02.rst
@@ -28,7 +28,7 @@ To configure Copter, Plane or Rover to use the LIDAR-Lite, please first
 connect with the Mission Planner and then open the Config/Tuning >> Full
 Parameter List page and set:
 
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = "3700" (i.e. 40m max range - 3m buffer.  This buffer is required so the flight code can detect when there is nothing in range)
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 37 (i.e. 40m max range - 3m buffer.  This buffer is required so the flight code can detect when there is nothing in range)
 -  :ref:`RNGFND1_PIN <RNGFND1_PIN>` = "14" (2nd pin of 3.3V ADC connector)
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = "12.12" (ie. 40m / 3.3v = 12.12) **
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = “1" (Analog)

--- a/common/source/docs/common-sonar-L04xMTW-GL04xMT.rst
+++ b/common/source/docs/common-sonar-L04xMTW-GL04xMT.rst
@@ -37,6 +37,6 @@ If the SERIAL2 is used then the following parameters should be set:
 Then the following range finder related parameters should be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 600 (i.e. 6m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 6 (i.e. 6m).  *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat

--- a/common/source/docs/common-teraranger-neo.rst
+++ b/common/source/docs/common-teraranger-neo.rst
@@ -37,8 +37,8 @@ As a Plane altitude rangefinder used in auto landings:
 - Set :ref:`RNGFND_LANDING<RNGFND_LANDING>` = 1 to enable used of the rangefinder during landing phases of Plane and QuadPlane. The first rangefinder with "down" orientation will be used.
 
 - Set :ref:`RNGFND1_ORIENT<RNGFND1_ORIENT>` = 25 (down)
-- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 50 (.5m)
-- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 2200 (22m since grass landings will reduce reliable range down to this range instead of 30m)
+- Set :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 0.5 (meters)
+- Set :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 22 (22m since grass landings will reduce reliable range down to this range instead of 30m)
 
 .. image:: ../../../images/terabee-neo-landing.png
     :target: ../_images/terabee-neo-landing.png

--- a/common/source/docs/common-underwater-sonar-analog.rst
+++ b/common/source/docs/common-underwater-sonar-analog.rst
@@ -47,8 +47,8 @@ Connect with a ground station to the autopilot and set the following parameters 
 Then the following range finder related parameters should be set:
 
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 17 (NMEA)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 13
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 30000 (i.e. 300m).  *This is the distance in centimeters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.13
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 300 (i.e. 300m).  *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (i.e. down) if mounted on a boat
 
 Testing the sensor

--- a/common/source/docs/common-underwater-triducer.rst
+++ b/common/source/docs/common-underwater-triducer.rst
@@ -18,8 +18,8 @@ The following example provides schematics to install a triducer on a Pixhawk and
 
 Parameters for this particular hawdware:
 
-- :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 700
-- :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 50
+- :ref:`RNGFND1_MAX<RNGFND1_MAX>` = 7 (meters)
+- :ref:`RNGFND1_MIN<RNGFND1_MIN>` = 0.5 (meters)
 - :ref:`RNGFND1_ORIENT<RNGFND1_ORIENT>` = 25
 - :ref:`RNGFND1_TYPE<RNGFND1_TYPE>` = 17
 - :ref:`SERIAL2_PROTOCOL<SERIAL2_PROTOCOL>` = 9

--- a/common/source/docs/common-vl53l0x-lidar.rst
+++ b/common/source/docs/common-vl53l0x-lidar.rst
@@ -39,9 +39,9 @@ Please set the rangefinder parameters as shown below (this can be done using the
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 16 (VL53L0X)
 -  :ref:`RNGFND1_ADDR <RNGFND1_ADDR>` = 41 (I2C Address of lidar in decimal).  *The sensor's default I2C address is 0x29 hexadecimal which is 41 in decimal.*
 -  :ref:`RNGFND1_SCALING <RNGFND1_SCALING>` = 1
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 5
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **120** for the VL53L0X, **360** for the VL53L1X.  *This is the distance in cm that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in cm from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.05
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = **1.2** for the VL53L0X, **3.6** for the VL53L1X.  *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in meters from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-wasp200-lidar.rst
+++ b/common/source/docs/common-wasp200-lidar.rst
@@ -28,9 +28,9 @@ If the SERIAL4 port on a Pixhawk is being used then the following parameters sho
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 18 (Wasp200)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 200
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 20000.  *This is the distance in centimeters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 10 *or more accurately the distance in centimetres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 2
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = 200.  *This is the distance in meters that the rangefinder can reliably read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 If instead the Telem2 port was used then the serial parameters listed above should instead be:
 

--- a/copter/source/docs/terrain-following.rst
+++ b/copter/source/docs/terrain-following.rst
@@ -81,7 +81,7 @@ If the vehicle is executing a mission command that requires terrain data but it 
 
 Note that because it does not immediately have access to terrain data in this situation it will perform a normal RTL interpreting the :ref:`RTL_ALT <RTL_ALT>` as an altitude-above-home regardless of whether :ref:`TERRAIN_FOLLOW <TERRAIN_FOLLOW>` has been set to "1" or not.
 
-One common problem reported by users is the vehicle immediately disarms when the user switches to AUTO mode to start a mission while the vehicle is on the ground.  The cause is the altitude reported by the range finder (which can be checked from the MP's Flight Data screen's Status tab's sonar_range field) is shorter than the RNGFNDx_MIN_CM (for example :ref:`RNGFND1_MIN <RNGFND1_MIN>`)parameter which means the range finder reports "unhealthy" when on the ground.  The solution is to reduce the RNGFNDx_MIN_CM value (to perhaps "5").
+One common problem reported by users is the vehicle immediately disarms when the user switches to AUTO mode to start a mission while the vehicle is on the ground.  The cause is the altitude reported by the range finder (which can be checked from the MP's Flight Data screen's Status tab's sonar_range field) is shorter than the RNGFNDx_MIN (for example :ref:`RNGFND1_MIN <RNGFND1_MIN>`)parameter which means the range finder reports "unhealthy" when on the ground.  The solution is to reduce the RNGFNDx_MIN value (to perhaps "0.05").
 
 Terrain Spacing and Accuracy
 ============================

--- a/plane/source/docs/rangefinder-autolanding.rst
+++ b/plane/source/docs/rangefinder-autolanding.rst
@@ -26,7 +26,7 @@ Also note that if you have a longer range rangefinder then it is a very
 good idea to set the minimum range of the rangerfinder well above zero.
 For example, the PulsedLight Lidar has a typical range of over 40
 meters, and when it gets false readings it tends to read ranges of less
-than 1 meter. And setting :ref:`RNGFND1_MIN <RNGFND1_MIN>` to 150 , if its the first system rangefinder, will discard any rangefinder readings below 1.5 meters, and will
+than 1 meter. And setting :ref:`RNGFND1_MIN <RNGFND1_MIN>` to 1.5 , if its the first system rangefinder, will discard any rangefinder readings below 1.5 meters, and will
 greatly improve the robustness of the Lidar for landing.
 
 If the autopilot has a good rangefinder (:ref:`such as LIDAR <common-rangefinder-lidarlite>`) then you can safely choose quite small numbers for :ref:`LAND_FLARE_SEC<LAND_FLARE_SEC>` and :ref:`LAND_FLARE_ALT<LAND_FLARE_ALT>`, and flare closer to the ground than with the default values. 


### PR DESCRIPTION
This corrects the rangefinder page's parameter ranges for the RNGFND1_MIN, MAX and GNDCLR parameters to be in meters

I've also found two other places (one in Copter, one in Plane) where the ranges were incorrect

I've built this locally and it looks OK to me.