### PR TITLE
Dev: add alternative set-flight-mode command

### DIFF
--- a/dev/source/docs/mavlink-get-set-flightmode.rst
+++ b/dev/source/docs/mavlink-get-set-flightmode.rst
@@ -10,7 +10,7 @@ This page explains how MAVLink can be used by a ground station or companion comp
 - :ref:`Plane flight modes <plane:flight-modes>`, see :ref:`FLTMODE1 <plane:FLTMODE1>` for flightmode numbers
 - :ref:`Rover flight modes <rover:rover-control-modes>`, see :ref:`MODE1 <rover:MODE1>` for flightmode numbers
 
-The MAVLink enums for flight modes can be found `here <https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml#L1007>`__
+The MAVLink enums for flight modes can be found `here <https://github.com/ArduPilot/mavlink/blob/master/message_definitions/v1.0/ardupilotmega.xml#L1072>`__
 
 Get the Flightmode with HEARTBEAT
 ---------------------------------
@@ -18,7 +18,7 @@ Get the Flightmode with HEARTBEAT
 The vehicle's current flight mode is sent once per second within the `HEARTBEAT <https://mavlink.io/en/messages/common.html#HEARTBEAT>`__ message's custom_mode field.  The flightmode number varies by vehicle type (e.g. Copter, Plane, Rover, etc) so please refer to the links above to convert the custom_mode number to a human readable flightmode name.
 
 Set the Flightmode with MAV_CMD_DO_SET_MODE
---------------------------------------------
+-------------------------------------------
 
 Attempt to set the vehicle's flightmode by sending a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ with the command and param2 fields set as specified for the `MAV_CMD_DO_SET_MODE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MODE>`__ command.
 
@@ -100,3 +100,96 @@ The example commands below can be copy-pasted into MAVProxy (aka SITL) to test t
 |                                                      | Plane: change to FBWB mode (6)                      |
 |                                                      | Rover: change to Follow mode (6)                    |
 +------------------------------------------------------+-----------------------------------------------------+
+
+Set the Flightmode to Loiter, RTL or Land with COMMAND_INT
+----------------------------------------------------------
+
+The flight mode may be changed on some vehicle types to Loiter, RTL or Land by sending a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ with the command field set to one of the following:
+
+- Loiter: `MAV_CMD_NAV_LOITER_UNLIM <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_UNLIM>`__
+- RTL: `MAV_CMD_NAV_RETURN_TO_LAUNCH <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RETURN_TO_LAUNCH>`__
+- Land: `MAV_CMD_NAV_LAND <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND>`__ or `MAV_CMD_NAV_VTOL_LAND <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_VTOL_LAND>`__
+
+.. raw:: html
+
+   <table border="1" class="docutils">
+   <tbody>
+   <tr>
+   <th>Command Field</th>
+   <th>Type</th>
+   <th>Description</th>
+   </tr>
+   <tr>
+   <td><strong>target_system</strong></td>
+   <td>uint8_t</td>
+   <td>System ID of flight controller or just 0</td>
+   </tr>
+   <tr>
+   <td><strong>target_component</strong></td>
+   <td>uint8_t</td>
+   <td>Component ID of flight controller or just 0</td>
+   </tr>
+   <tr>
+   <td><strong>command</strong></td>
+   <td>uint16_t</td>
+   <td>MAV_CMD_NAV_LOITER_UNLIM=17, MAV_CMD_NAV_RETURN_TO_LAUNCH=20, MAV_CMD_NAV_LAND=21 or MAV_CMD_NAV_VTOL_LAND=85</td>
+   </td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>confirmation</strong></td>
+   <td>uint8_t</td>
+   <td>0</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param1</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param2</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param3</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param4</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param5</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param6</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param7</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   </tbody>
+   </table>
+
+**Example**
+
+The example commands below can be copy-pasted into MAVProxy (aka SITL) to test this command.  Before running these commands enter, "module load message"
+
++-------------------------------------------------+------------------------------------------+
+| Example MAVProxy/SITL Command                   | Description                              |
++=================================================+==========================================+
+| ``message COMMAND_LONG 0 0 17 0 0 0 0 0 0 0 0`` | Copter, Plane: change to Loiter mode     |
++-------------------------------------------------+------------------------------------------+
+| ``message COMMAND_LONG 0 0 20 0 0 0 0 0 0 0 0`` | Copter, Plane, Rover: change to RTL mode |
++-------------------------------------------------+------------------------------------------+
+| ``message COMMAND_LONG 0 0 21 0 0 0 0 0 0 0 0`` | Copter: change to Land mode              |
++-------------------------------------------------+------------------------------------------+
+| ``message COMMAND_LONG 0 0 85 0 0 0 0 0 0 0 0`` | Copter: change to Land mode              |
++-------------------------------------------------+------------------------------------------+


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot_wiki/issues/6669 by adding explanations for other MAV_CMDs that can be used to set the flight mode

I've built this locally and tested the commands in SITL and it all seems OK to me