### PR TITLE
Dev: copter and plane commands for loiter, rtl, land

### DIFF
--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -30,9 +30,9 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavl
 - :ref:`MAV_CMD_DO_PARACHUTE <copter:mav_cmd_do_parachute>`
 - :ref:`MAV_CMD_DO_SET_ROI <copter:mav_cmd_do_set_roi>`
 - :ref:`MAV_CMD_NAV_TAKEOFF <copter:mav_cmd_nav_takeoff>`
-- :ref:`MAV_CMD_NAV_LOITER_UNLIM <copter:mav_cmd_nav_loiter_unlim>`
-- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <copter:mav_cmd_nav_return_to_launch>`
-- :ref:`MAV_CMD_NAV_LAND <copter:mav_cmd_nav_land>`
+- `MAV_CMD_NAV_LOITER_UNLIM <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_UNLIM>`__ : changes to :ref:`Loiter mode <copter:loiter-mode>` (see :ref:`Get and Set FlightMode <mavlink-get-set-flightmode>`)
+- `MAV_CMD_NAV_RETURN_TO_LAUNCH <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RETURN_TO_LAUNCH>`__ : changes to :ref:`RTL mode <copter:rtl-mode>` (see :ref:`Get and Set FlightMode <mavlink-get-set-flightmode>`)
+- `MAV_CMD_NAV_LAND <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LAND>`__ : changes to :ref:`Land mode <copter:land-mode>` (see :ref:`Get and Set FlightMode <mavlink-get-set-flightmode>`)
 - `MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN>`__
 
 These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ message

--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -48,8 +48,8 @@ MAV_CMDs
 
 These MAV_CMDs can be processed if packaged within a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ message
 
-- :ref:`MAV_CMD_NAV_LOITER_UNLIM <plane:mav_cmd_nav_loiter_unlim>`
-- :ref:`MAV_CMD_NAV_RETURN_TO_LAUNCH <plane:mav_cmd_nav_return_to_launch>`
+- `MAV_CMD_NAV_LOITER_UNLIM <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_LOITER_UNLIM>`__ : changes to :ref:`Loiter mode <plane:loiter-mode>` (see :ref:`Get and Set FlightMode <mavlink-get-set-flightmode>`)
+- `MAV_CMD_NAV_RETURN_TO_LAUNCH <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RETURN_TO_LAUNCH>`__ : changes to :ref:`RTL mode <plane:rtl-mode>` (see :ref:`Get and Set FlightMode <mavlink-get-set-flightmode>`)
 
 These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ message
 


### PR DESCRIPTION
This is a follow up to https://github.com/ArduPilot/ardupilot_wiki/pull/6671

This further clarifies what the MAV_CMD_**NAV_LOITER_UNLIM**, MAV_CMD_NAV_**RETURN_TO_LAUNCH** and MAV_CMD_**NAV_LAND** mav commands do when executed while Copter and/or Plane are in Guided mode which is to actually change the flight mode.

Previously these lines referred the user to the corresponding mission commands which made one community developer at least think that the behaviour would be Loiter-within-Guided and they were thus surprised when the pilot's throttle was suddenly consumed and the vehicle descended quickly.

I haven't added anything to the Rover pages because they simply don't mention these commands.  The description for these commands is there (for all vehicles) in the Get and Set FlightMode page

I've tested this locally and it looks OK to me