### PR TITLE
Copter: add links to ChrisR's setup videos

### DIFF
--- a/common/source/docs/common-tuning.rst
+++ b/common/source/docs/common-tuning.rst
@@ -27,7 +27,10 @@ parameters. The following topics show you how.
     Configuring In-Flight FFT <common-imu-fft>
     Coping with Ground Resonance Oscillation <common-ground-resonance>
 
+Videos
+======
 
+- `Chris Rosser's Ultimate ArduPilot Tuning Guide <https://www.youtube.com/playlist?list=PLFPBjpbd5xKSGFJfuQJBPWOm-sGv0VxD1>`__
 
 [/site]
 


### PR DESCRIPTION
This adds a link to Chris Rosser's ArduPilot tuning video playlist

I originally wanted to add the link so that a preview was displayed and users watch the video within the AP web site but I couldn't figure out how to make that work

I've built this locally and it looks OK to me