### PR TITLE
Sub: add sidebar link to MAVLink support page

### DIFF
--- a/sub/source/index.rst
+++ b/sub/source/index.rst
@@ -26,4 +26,5 @@ Getting more info
    
    Complete parameter list <docs/parameters>
    Complete log message list <docs/logmessages>
+   MAVLink message support <https://ardupilot.org/dev/docs/ArduSub_MAVLink_Messages.html>
    Board Feature List <docs/binary-features>


### PR DESCRIPTION
### Preview

<img width="289" alt="Screenshot 2025-03-21 at 1 03 41 am" src="https://github.com/user-attachments/assets/57c17afd-0cd4-4c28-99f2-6dab5250fdb4" />

### Context
I wanted this to be [anchor-based](https://ardupilot.org/ardupilot/docs/common-wiki-editing-style-guide.html#internal-links), but that seemingly doesn't work for the sidebar, so I followed the approach used in the `ardupilot` wiki for linking to the other wikis (which is just a direct site URL).

This is a Sub-only change (@Williangalvani).
- [x] I've built the full wiki locally, with no warnings or errors.