### PR TITLE
mavproxy/dev: update outdated and broken links

### DIFF
--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -78,7 +78,7 @@ Vehicle Parameter References
 - :ref:`Copter Parameters <copter:parameters>`
 - :ref:`Plane Parameters <plane:parameters>`
 - :ref:`Rover Parameters <rover:parameters>`
-- `Sub Parameters <http://www.ardusub.com/developers/full-parameter-list.html>`_
+- :ref:`Sub Parameters <sub:parameters>`
 
 .. toctree::
     :maxdepth: 1

--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -55,25 +55,25 @@ different projects which are listed below.  Those marked with an asterix
 (\*) are peer projects that have their own owners outside the core
 ArduPilot dev team.
 
--  Plane (`wiki <http://plane.ardupilot.com/>`__,
+-  Plane (:ref:`wiki <plane:home>`,
    `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
    planes
--  Copter (`wiki <http://copter.ardupilot.com/>`__,
+-  Copter (:ref:`wiki <copter:home>`,
    `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
    multicopters and traditional helicopters
--  Rover (`wiki <http://rover.ardupilot.com/>`__,
+-  Rover (:ref:`wiki <rover:home>`,
    `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
    ground vehicles
--  Sub (`wiki <https://www.ardusub.com/>`__,
+-  Sub (:ref:`wiki <sub:home>`,
    `code <https://github.com/ArduPilot/ardupilot>`__) - autopilot for
    submersible vehicles
--  Antenna Tracker (`wiki <https://ardupilot.org/antennatracker/index.html>`__,
+-  Antenna Tracker (:ref:`wiki <antennatracker:home>`,
    `code <https://github.com/ArduPilot/ardupilot>`__) - for automatically aiming an antenna at a vehicle
--  Mission Planner (`wiki <http://planner.ardupilot.com/>`__,
+-  Mission Planner (:ref:`wiki <planner:home>`,
    `code <https://github.com/ArduPilot/MissionPlanner>`__) - the most
    commonly used ground station written in C# for windows but also runs
    on Linux and MacOS via mono
--  APM Planner 2.0 (`wiki <http://planner2.ardupilot.com/>`__,
+-  APM Planner 2.0 (:ref:`wiki <planner2:home>`,
    `code <https://github.com/ArduPilot/apm_planner>`__) is a ground
    station specifically for APM written in C++ using the Qt libraries
 -  :ref:`MAVProxy <mavproxy:home>`
@@ -87,7 +87,7 @@ ArduPilot dev team.
    - android ground station
 -  `QGroundControl* <http://www.qgroundcontrol.org/>`__ is an alternative ground station written in C++ using the Qt libraries
 -  `PX4* <https://pixhawk.org/start>`__ - designers of the original PX4FMU hardware (from which the Pixhawk was developed)
--  `MAVLink* <http://www.qgroundcontrol.org/mavlink/start>`__ -
+-  `MAVLink* <https://mavlink.io>`__ -
    the protocol for communication between the ground station, flight
    controller and some peripherals including the OSD. A "Dummy's Guide" to
    working with MAVLink is

--- a/mavproxy/source/docs/getting_started/faq.rst
+++ b/mavproxy/source/docs/getting_started/faq.rst
@@ -15,7 +15,7 @@ Frequently Asked Questions and Issues
 
 #. Which Flight controllers are compatible with MAVProxy?
 
-    The ArduPilot vehicle types (`ArduPlane <https://ardupilot.org/plane/>`_, `ArduCopter <https://ardupilot.org/copter/>`_, `ArduSub <http://www.ardusub.com/>`_ and `ArduRover <https://ardupilot.org/rover/>`_) are fully compatible. Other Mavlink-based flight controllers (such as the `PX4 <https://px4.io/>`_ stack) should be compatible, but may not show all flight data.
+    The ArduPilot vehicle types (:ref:`ArduPlane <plane:home>`, :ref:`ArduCopter <copter:home>`, :ref:`ArduSub <sub:home>` and :ref:`ArduRover <rover:home>`) are fully compatible. Other Mavlink-based flight controllers (such as the `PX4 <https://px4.io/>`_ stack) should be compatible, but may not show all flight data.
 
 
 #. How do I output a TCP connection to another GCS program?


### PR DESCRIPTION
- Change a bunch of cross-wiki links to `:ref:` style, so they can be tracked if/when they get broken
- Update remaining `ardusub.com` references to the new ArduPilot wiki site
- Fix some miscellaneous broken links in the process