### PR TITLE
Common: update macOS build setup documentation with usage instructions for prebuilt script

### DIFF
--- a/dev/source/docs/building-setup-mac.rst
+++ b/dev/source/docs/building-setup-mac.rst
@@ -10,7 +10,14 @@ This article shows how to manually setup a minimal build environment on MacOS (v
     :width: 100%
 
 
-There is a pre-built script at /ardupilot/Tools/environment_install/install-prereqs-mac.sh that will install these pre-requisites.
+There is a `pre-built script  <https://github.com/ArduPilot/ardupilot/blob/master/Tools/environment_install/install-prereqs-mac.sh>`__ that will install these pre-requisites.
+
+How to use it, cd to your ardupilot directory, and execute:
+
+::
+
+    sh ./Tools/environment_install/install-prereqs-mac.sh
+
 
 Setup steps
 -----------


### PR DESCRIPTION
This pull request includes a documentation update for the MacOS build environment setup guide. The most important change is the addition of instructions on how to use the pre-built script.

Documentation update:

* [`dev/source/docs/building-setup-mac.rst`](diffhunk://#diff-3d1dc20adf6b020b50313608b6d8ab50dbe5577cf5e129d42c3c82bd789438c5L13-R18): Added a section with instructions on how to use the pre-built script located at `/ardupilot/Tools/environment_install/install-prereqs-mac.sh`.