### PR TITLE
Common: fix formatting in SITL documentation for `sim_vehicle.py` script

### DIFF
--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -35,7 +35,7 @@ In addition to running the simulation, a ground control station program will nee
 Using sim_vehicle.py
 ====================
 
-A startup script, ```sim_vehicle.py`` is provided to automatically build the SITL firmware version for the current code branch, load the simulation models, start the simulator, setup environment and vehicle parameters, and start the MAVProxy GCS. Many script start-up parameters can be specified, type this for a full list:
+A startup script, ``sim_vehicle.py`` is provided to automatically build the SITL firmware version for the current code branch, load the simulation models, start the simulator, setup environment and vehicle parameters, and start the MAVProxy GCS. Many script start-up parameters can be specified, type this for a full list:
 
 ::
 


### PR DESCRIPTION
This pull request includes a minor documentation change to correct the formatting of a code identifier in the `using-sitl-for-ardupilot-testing.rst` file.

* Corrected the formatting of the `sim_vehicle.py` script name by changing triple backticks to double backticks in the `using-sitl-for-ardupilot-testing.rst` file.