### PR TITLE
Common: promote hexsoon radar to rangefinder landing page

### DIFF
--- a/common/source/docs/common-master-features.rst
+++ b/common/source/docs/common-master-features.rst
@@ -15,8 +15,6 @@ New Peripherals
 .. toctree::
     :maxdepth: 1
 
-    Hexsoon 77G MWW Radar <common-rangefinder-hexsoon-radar>
-    Hexsoon 24G Radar <common-rangefinder-hexsoon-24g>
     XFRobot camera gimbals <common-xfrobot-gimbal>
 [/site]
 [site wiki="plane"]

--- a/common/source/docs/common-rangefinder-hexsoon-24g.rst
+++ b/common/source/docs/common-rangefinder-hexsoon-24g.rst
@@ -16,7 +16,7 @@ The `Hexsoon 24G radar <http://www.hexsoon.com/en/list-4-27.html>`__ (available 
 
 .. note::
 
-    Support is available in ArduPilot versions 4.7 and higher
+    Support is available in ArduPilot versions 4.6 and higher
 
 Connecting to the Autopilot
 ===========================

--- a/common/source/docs/common-rangefinder-hexsoon-radar.rst
+++ b/common/source/docs/common-rangefinder-hexsoon-radar.rst
@@ -16,7 +16,7 @@ The `Hexsoon HS77G MMW radar <http://www.hexsoon.com/en/list-4-27.html>`__ (avai
 
 .. note::
 
-    Support is available in Copter and Rover versions 4.7 and higher
+    Support is available in Copter and Rover versions 4.6 and higher
 
 Connecting to the Autopilot
 ===========================

--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -68,6 +68,7 @@ Unidirectional Rangefinders
     Benewake TFmini / TFmini Plus / TF-Luna <common-benewake-tfmini-lidar>
     Garmin Lidar-Lite <common-rangefinder-lidarlite>
     GY-US42 Sonar <common-rangefinder-gy-us42>
+    Hexsoon 24G Radar <common-rangefinder-hexsoon-24g>
     Hondex Sonar<common-hondex-sonar>
     HC-SR04 Sonar <common-rangefinder-hcsr04>
     JAE JRE-30 <common-rangefinder-jae-jre-30>
@@ -93,6 +94,7 @@ Omnidirectional Proximity Rangefinders
 .. toctree::
     :maxdepth: 1
 
+    Hexsoon 77G MWW Radar <common-rangefinder-hexsoon-radar>
     LDRobot LD-06 TOF <common-ld06>
     Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
     Lightware SF45/B (350 degree) <common-lightware-sf45b>


### PR DESCRIPTION
The Hexsoon radar have been included in AP-4.6.0-beta5 so we can move them from the "upcoming features" page to the standard rangefinder landing pages

I've tested these changes locally and they look OK to me