### PR TITLE
Dev: add ochin carrier board to list of companion computers

### DIFF
--- a/dev/source/docs/companion-computers.rst
+++ b/dev/source/docs/companion-computers.rst
@@ -30,6 +30,7 @@ popular Companion Computer hardware are listed below.
     ModalAI VOXL2 <https://www.modalai.com/collections/blue-uas-framework-components/products/voxl-2>
     NVidia TX1 <companion-computer-nvidia-tx1>
     NVidia TX2 <companion-computer-nvidia-tx2>
+    Ochin Tiny Carrier Board V2 for Raspberry Pi CM4 <https://www.seeedstudio.com/Ochin-Tiny-Carrier-Board-V2-for-Raspberry-Pi-CM4-p-5887.html>
     ODroid <odroid-via-mavlink>
     Holybro Pixhawk Rasberry Pi CM4/CM5 Baseboard <https://holybro.com/products/pixhawk-rpi-cm4-baseboard>
     Holybro Pixhawk Jetson Baseboard <https://holybro.com/products/pixhawk-jetson-baseboard>


### PR DESCRIPTION
This adds a link to the Ochin carrier board which I've used successfully.  It's very small and relatively inexpensive.

I've built this locally and it looks OK to me