### PR TITLE
Siyi: add product specific download links

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -26,7 +26,7 @@ gimbals in which ArduPilot controls the stabilisation. Some gimbals also integra
 -  :ref:`Gremsy Mio, Pixy, S1, T3, T7 and ZIO <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
 -  :ref:`Servo Gimbals <common-camera-gimbal>` — older-style servo-driven gimbal where ArduPilot provides stabilisation
 -  :ref:`SimpleBGC (aka AlexMos) Gimbal Controller <common-simplebgc-gimbal>` - a popular 2-axis or 3-axis brushess gimbal controller which uses a custom serial interface
--  :ref:`Siyi ZR10, ZR30, ZT6, ZT30, and A8 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera
+-  :ref:`Siyi A8, ZR10, ZR30, ZT6, and ZT30 <common-siyi-zr10-gimbal>` - 3-axis gimbal and camera
 -  :ref:`SToRM32 Gimbal Controller <common-storm32-gimbal>` — an inexpensive 2-axis or 3-axis brushless gimbal controller which responds to MAVLink commands (a richer format than PWM) over a serial interface
 -  :ref:`Topotek Gimbal <common-topotek-gimbal>`
 -  :ref:`ViewPro gimbals <common-viewpro-gimbal>`

--- a/common/source/docs/common-siyi-zr10-gimbal.rst
+++ b/common/source/docs/common-siyi-zr10-gimbal.rst
@@ -70,8 +70,14 @@ Connect with a ground station and set the following parameters.  The params belo
 Configuring the Gimbal
 ----------------------
 
-- Download, install and run "SIYI PC Assistant" which can be found on the `SIYI ZR10 web page's Downloads tab <https://shop.siyi.biz/products/siyi-zr10>`__
+- Download, install and run "SIYI PC Assistant" which can be found on any of the links below
 - Ensure the gimbal is running a recent firmware.  For ZR10 use 0.2.1 or higher.  For A8 use 0.1.7 or higher.
+
+  - `A8's downloads page <https://siyi.biz/en/index.php?id=downloads&asd=22>`__
+  - `ZR10's download page <https://siyi.biz/en/index.php?id=downloads&asd=27>`__
+  - `ZR30's download page <https://siyi.biz/en/index.php?id=downloads&asd=25>`__
+  - `ZT6's download page <https://siyi.biz/en/index.php?id=downloads&asd=602>`__
+  - `ZT30's download page <https://siyi.biz/en/index.php?id=downloads&asd=25>`__
 
 .. image:: ../../../images/siyi-gimbal-firmversion.png
     :target: ../_images/siyi-gimbal-firmversion.png


### PR DESCRIPTION
The Siyi page's download page link has changed so I've taken the opportunity to add download links per product.  This will hopefully help users more quickly find the Assistant (although this doesn't depend upon the product) and the user manual and latest firmware.

I've tested this locally and it looks OK to me

Thanks to @andyp1per for finding this issue!