### PR TITLE
Common: Benewake TF02/TF03/TFLuna fixes

### DIFF
--- a/common/source/docs/common-benewake-tf02-lidar.rst
+++ b/common/source/docs/common-benewake-tf02-lidar.rst
@@ -1,12 +1,12 @@
 .. _common-benewake-tf02-lidar:
 
-===================================
-Benewake TF02 / TF03 lidar/ TF-Luna
-===================================
+====================================
+Benewake TF02 / TF03 lidar / TF-Luna
+====================================
 
 The TF02 lidar has an indoor range of 22m, an outdoor range of 10m, an update rate of 100Hz and weighs only 52g.
 
-The `TF02 Pro <https://en.benewake.com/TF02Pro/index.html>`__ has an indoor range of 40m, an outdoor range of 13.5m, an update rate of 100Hz and weighs only 50g.
+The `TF02-Pro <https://en.benewake.com/TF02Pro/index.html>`__ has an indoor range of 40m, an outdoor range of 13.5m, an update rate of 100Hz and weighs only 50g.
 
 The `TF03 <https://en.benewake.com/TF03/index.html>`__ has a range of 50m to 180m (depending upon the surface) and weighs 77g.
 
@@ -29,14 +29,14 @@ For a serial connection you can use any spare Serial/UART port.  The diagram bel
 
 .. image:: ../../../images/benewake-tf02-pixhawk.png
 
-.. note:: TF-03 TX/RX UART wires are different color since it also has a CAN interface option. Consult manufacturer's data sheet.
+.. note:: TF03 TX/RX UART wires are different color since it also has a CAN interface option. Consult manufacturer's data sheet.
 
 If the SERIAL4 is being used then the following parameters should be set for the first rangefinder:
 
 -  :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, =20 (Benewake-Serial) for TF03 if Copter 3.6.12, =27 (Benewake TF03) for TF03 and TF02 Pro for Copter 4.0 and later, and =20 for TF-Luna. Note: using type = 20 on a TF03 will restrict its maximum range to that of a TF02.
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.3 for TFMini, 0.1 for TFminiPlus and TF-Luna.
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, 27 (Benewake TF03) for TF03 and TF02-Pro, and 20 (Benewake-Serial) for TF-Luna
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.1
 -  :ref:`RNGFND1_MAX <RNGFND1_MAX>`: for TF02 use **20** for indoor, **10** for outdoor.  For TF03 use **35** for indoor, **12** for outdoor. For TF-Luna use **8** for indoor, **3** for outdoor. *This is the distance in meters that the rangefinder can reliably read.*
 -  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
@@ -45,7 +45,7 @@ If instead the Telem2 port was used then the serial parameters listed above shou
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9
 -  :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115
 
-.. note:: the TF03 can be programmed to use a DroneCAN interface instead of a serial interface. In this case the :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 34, and follow the 'DroneCAN setup instructions <common-uavcan-setup-advanced>`.
+.. note:: the TF03 can be programmed to use a DroneCAN interface instead of a serial interface. In this case the :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 34, and follow the :ref:`DroneCAN setup instructions <common-uavcan-setup-advanced>`.
 
 Testing the sensor
 ==================

--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -64,8 +64,8 @@ Unidirectional Rangefinders
     Ainstein LR-D1 Radar Altimerer <common-ainstein-lrd1>
     Attollo Engineering Wasp200 <common-wasp200-lidar>
     Avionics Anonymous DroneCAN LIDAR Interface <common-avanon-laserint>
-    Benewake TF02 / TF03 <common-benewake-tf02-lidar>
-    Benewake TFmini / TFmini Plus / TF-Luna <common-benewake-tfmini-lidar>
+    Benewake TF02 / TF03 / TF-Luna <common-benewake-tf02-lidar>
+    Benewake TFmini / TFmini Plus <common-benewake-tfmini-lidar>
     Garmin Lidar-Lite <common-rangefinder-lidarlite>
     GY-US42 Sonar <common-rangefinder-gy-us42>
     Hexsoon 24G Radar <common-rangefinder-hexsoon-24g>


### PR DESCRIPTION
This includes a few small fixes to the Benewake rangefinder TF02/TF03/TFLuna pages

- removed instructions on very old version
- simplify rngfnd1-min to remove mention of an unrelated model
- unify naming of TF02-Pro
- fix broken link for DroneCAN model

I've built this locally and it looks OK to me