### PR TITLE
Common: pre-arm failure to create log directory

### DIFF
--- a/common/source/docs/common-prearm-safety-checks.rst
+++ b/common/source/docs/common-prearm-safety-checks.rst
@@ -89,6 +89,7 @@ Pre-arm checks that are failing will also be sent as messages to the GCS while d
     EKF3 waiting for GPS config data                        automatic GPS configuration has not completed       Check GPS connection and configuration especially if using DroneCAN GPS
     EKF3 Yaw inconsistent by x degs                         Yaw angle estimates are inconsistent                Wait or reboot autopilot
     Failed to open mission.stg                              Failed to load mission from SD Card                 Check SD card.  Try to re-save mission to SD card
+    Failed to create log directory /APM/LOGS : ENOMEM       Failed to create log directory on SD card           Decrease :ref:`LOG_FILE_BUFSIZE<LOG_FILE_BUFSIZE>` or disable other features to reduce memory usage
     Fence requires position                                 If fences are enabled, position estimate required   Wait or move vehicle to a location with a clear view of the sky.  Reduce sources of radio-frequency interference
     FENCE_ALT_MAX < FENCE_ALT_MIN                           FENCE_ALT_MAX must be greater than FENCE_ALT_MIN    Increase :ref:`FENCE_ALT_MAX<FENCE_ALT_MAX>` or lower :ref:`FENCE_ALT_MIN<FENCE_ALT_MIN>`
     FENCE_MARGIN is less than FENCE_RADIUS                  FENCE_MARGIN must be larger than FENCE_RADIUS       Increase :ref:`FENCE_RADIUS<FENCE_RADIUS>` or reduce :ref:`FENCE_MARGIN<FENCE_MARGIN>`


### PR DESCRIPTION
This adds a short explanation of what to do if users see the "Failed to create log directory /APM/LOGS : ENOMEM" pre-arm failure.

This came up during 4.6 beta testing in [this discussion](https://discuss.ardupilot.org/t/logging-failed-failed-to-create-log-directory-apm-logs-enomem/132917).

I've tested this locally and it looks OK