### PR TITLE
Common: add VimDrones S50 ESC to AM32 page

### DIFF
--- a/common/source/docs/common-am32-escs.rst
+++ b/common/source/docs/common-am32-escs.rst
@@ -14,7 +14,8 @@ Where to Buy
 
 AM32 ESCs that support DroneCAN
 
-- `VimDrones ESC Nano <https://dev.vimdrones.com/products/vimdrones_esc_nano/>`__
+- `VimDrones ESC Nano (20 Amp) <https://dev.vimdrones.com/products/vimdrones_esc_nano/>`__
+- `VimDrones ESC S50 (50 Amp) <https://dev.vimdrones.com/products/vimdrones_esc_s50/>`__
 - `VimDrones ESC Development Board <https://dev.vimdrones.com/products/vimdrones_esc_dev/>`__
 
 More ESCs may be found from the `AM32 targets.h <https://github.com/am32-firmware/AM32/blob/main/Inc/targets.h>`__ file (seach for _CAN)


### PR DESCRIPTION
This adds a link to the new [VimDrones 50Amp ESC](https://dev.vimdrones.com/products/vimdrones_esc_s50/) to the AM32 page

I've built this locally and it looks OK to me