### PR TITLE
Common: remove some duplicate PPP setup instructions

### DIFF
--- a/common/source/docs/common-ethernet-adapters.rst
+++ b/common/source/docs/common-ethernet-adapters.rst
@@ -1,15 +1,15 @@
 .. _common-ethernet-adapters:
 
-=================
-Ethernet Adapters
-=================
+==============================
+Ethernet Adapters and Switches
+==============================
 
 Ardupilot has the ability to use Ethernet peripherals and networking (see :ref:`common-network`).  This page includes various switches and adapters known to work
 
 .. image:: ../../../images/Net_Adapter.png
     :target: ../_images/Net_Adapter.png
 
-Most H7 based autopilots do not include native ethernet support but ethernet networking capability can be added using an Ethernet Adapter (see `BotBlox DroneNet <https://botblox.io/dronenet-for-ardupilot/>`__ and `CubeLAN 8-Port Switch <https://irlock.com/products/cubelan-8-port-switch>`__ below) which provide connectivity using PPP protocol over the autopilot's serial port
+Most H7 based autopilots do not include native ethernet support but ethernet networking capability can be added using an Ethernet Adapter (see :ref:`BotBlox DroneNet <common-botblox-dronenet>` and :ref:`CubePilot CubeNode ETH <common-cubepilot-cubenodeeth>` below) which provide connectivity using :ref:`PPP protocol <ppp-config>` over the autopilot's serial port.
 
 Hardware
 ========
@@ -20,38 +20,6 @@ Hardware
 - `BotBlox SwitchBlox Cable Adapter for Ardupilot <https://botblox.io/switchblox-cable-adapter-for-ardupilot/>`__ : adapter to ease the ethernet port differences across different device manufacturers
 - :ref:`CubePilot CubeNode ETH <common-cubepilot-cubenodeeth>`: serial to ethernet adapter to allow non-ethernet autopilots to work over ethernet using PPP
 - `CubePilot CubeLAN 8-Port Switch <https://docs.cubepilot.org/user-guides/switch/cubelan-8-port-switch>`__ : ethernet switch using the CubePilot preferred 5-pin connector
-
-PPP Setup
-=========
-
-- PPP capability is not included by default on standard H7 autopilot firmware, so the `Custom Firmware Build Server <https://custom.ardupilot.org/>`__ must be used to build an firmware that includes it
-
-.. image:: ../../../images/build-server-ppp.jpg
-    :target: ../_images/build-server-ppp.jpg
-
-.. note:: if using a local build environment (:ref:`building-the-code`), you can include PPP capability by using the ``\-\-enable-PPP`` waf configuration option when building the code for an autopilot locally.
-
-- Connect one of the H7 based autopilot's serial ports to the ethernet switch's or Ethernet-to-PPP-adapter's USART port. For optimum performance a serial port with flow control should be used (e.g. normally SERIAL1 or SERIAL2).  In the following instructions SERIAL2 is used
-
-Autopilot Setup
-===============
-
-See ``PPP configuration`` and ``ArduPilot Port Configuration`` sections of :ref:`common-network`. Be sure to set :ref:`NET_ENABLE<NET_ENABLE>` = 1 and reboot first. The Ethernet MAC configuration is internal to the Adapter itself.
-
-Adapter Setup
-=============
-
-Currently available adapters use :ref:`DroneCAN <common-uavcan-setup-advanced>` to change or setup the Ethernet interface parameters such as MAC and IP addresses, NET mask, etc. Once setup/changed, the DroneCAN connection can be removed, if desired. When attached to a DroneCAN enabled port on the autopilot, you can use :ref:`Mission Planner<dronecan-uavcan-slcan>` or the :ref:`DroneCAN GUI <dronecan-uavcan-slcan>` tool to explore/change its Ethernet parameters.
-
-In addition, it may implement its own Web Browser interface for status and configuration on the network similar to:
-
-.. image:: ../../../images/PPP_web_server.jpg
-    :target: ../_images/PPP_web_server.jpg
-
-Video
-=====
-
-.. youtube:: bN6iDP4Zjzg
 
 .. toctree::
     :hidden:

--- a/common/source/docs/common-network.rst
+++ b/common/source/docs/common-network.rst
@@ -6,9 +6,7 @@ Ethernet / Network Setup
 
 ArduPilot 4.5 (and higher) provides a network interface framework to allow local and wide-area network connections. Several later generation autopilots, like Pixhawk6X and CubePilot CubeRed, provide Ethernet MAC interfaces, which allows ArduPilot to connect to vehicle peripherals, data servers, and even the wide area network via IP using transport layer UDP or TCP protocols.
 
-In addition, custom builds for H7 based processors that do not have an Ethernet MAC integrated can be created with the `ArduPilot Custom Firmware Server <https://firmware.ardupilot.org/>`__ that includes PPP(Point-To-Point Protocol) allowing network connections over a serial port of the autopilot using PPP.
-
-.. note:: for those :ref:`building firmware locally <building-the-code>`, PPP can be included with the \-\-enable-PPP configuration option.
+In addition, autopilots with H7 based processors can connect to Ethernet over a serial port using PPP (Point-to-Point Protocol), a :ref:`PPP to Ethernet Adapter <common-ethernet-adapters>` and a custom firmware build.  See the :ref:`PPP Configuration section <ppp-config>` below for more details.
 
 Currently, hooks into the normal serial manager within ArduPilot now allow serial protocols not only to be connected to the autopilot via the normal UART connections, but also via network connections. These can be used either with Etnernet or PPP interfaces.
 
@@ -71,6 +69,8 @@ The gateway IP address is used for routing when communicating with IP addresses 
 - :ref:`NET_GWADDR2<NET_GWADDR2>` (e.g. 144)
 - :ref:`NET_GWADDR3<NET_GWADDR3>` (e.g. 1)
 
+.. _ppp-config:
+
 PPP Configuration
 -----------------
 
@@ -80,13 +80,15 @@ This feature allows any H7 cpu-based autopilot to connect to networks via a Seri
 
 To enable this feature, it first must be present in the autopilot firmware. This can be done using the `Custom Firmware Build Server <https://firmware.ardupilot.org/>`__ or by building the code locally using the "\-\-enable-PPP" waf configuration option (See :ref:`building-the-code`)
 
+.. image:: ../../../images/build-server-ppp.jpg
+    :target: ../_images/build-server-ppp.jpg
+
+Connect one of the H7 based autopilot's serial ports to the ethernet switch's or Ethernet-to-PPP-adapter's USART port. For optimum performance a serial port with flow control should be used (e.g. normally SERIAL1 or SERIAL2).  If a port without flow control if used, the baud rate may be set as high as 921000
+
 To configure a serial port for PPP (Serial2 is used in this example):
 
 - set :ref:`SERIAL2_PROTOCOL<SERIAL2_PROTOCOL>` = 48 (PPP) requires a reboot to take effect.
 - set :ref:`SERIAL2_BAUD<SERIAL2_BAUD>` = 12500000 (12.5MBaud)
-
-.. note:: to get best throughput, the Serial port should have flow control (RTS/CTS) and it be enabled and used. If using a port without flow control, you may be able to set the baud rate as high as 921000, however.
-
 
 ArduPilot Port Configuration
 ----------------------------

--- a/common/source/docs/common-optional-hardware.rst
+++ b/common/source/docs/common-optional-hardware.rst
@@ -46,7 +46,7 @@ For guidance on cable design, colour coding, and EMI-compliant wiring, especiall
     DroneCAN Adapter Node <common-uavcan-adapter-node>
     DroneCAN Peripherals <common-uavcan-peripherals>
     ESCs and Motors <common-escs-and-motors>
-    Ethernet Adapters <common-ethernet-adapters>
+    Ethernet Adapters and Switches <common-ethernet-adapters>
     External AHRS Systems <common-external-ahrs>
     First Person View Video <common-fpv-first-person-view>
     Fuel Flow and Level Sensors <common-fuel-sensors>


### PR DESCRIPTION
This PR removes some duplicate PPP setup instructions:

- removed all PPP setup from the bottom of the Ethernet Adapters page.  This info is already present on the Dronenet and CubeNodeETH pages not to mention the Ethernet/Network Setup page.
- Ethernet/Network Setup page loses some info re PPP setup at the top of the page and instead refers the reader to the existing "PPP Configuration" section lower down on the page.  This "PPP Configuration" section is slightly reworded to make it consistent with the "DroneNet" and "CubeNodeETH" pages but mostly I've just added a picture of the custom build server page to highlight the exact option that users must select

I've also included a small fix to the Ethernet Adapters page to point some links to our internal pages instead of the manufacturer's pages

I've built this locally and it looks OK to me