### PR TITLE
Rover: fix circle mode reference label

### DIFF
--- a/rover/source/docs/circle-mode.rst
+++ b/rover/source/docs/circle-mode.rst
@@ -1,4 +1,4 @@
-.. circle-mode:
+.. _circle-mode:
 
 ===========
 Circle Mode


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot_wiki/issues/6783

I was strange because the reference didn't work from the [QuikTune page](https://ardupilot.org/rover/docs/quiktune.html) but it did work from the [Control Modes page.
](https://ardupilot.org/rover/docs/rover-control-modes.html)
I've tested this locally and it looks OK to me