### PR TITLE
Plane: Recommend not using autotune roll for RUDDER_ONLY planes

### DIFF
--- a/plane/source/docs/automatic-tuning-with-autotune.rst
+++ b/plane/source/docs/automatic-tuning-with-autotune.rst
@@ -34,6 +34,8 @@ You can also autotune the yaw axis during AUTOTUNE for yaw rate control in :ref:
 
 The :ref:`AUTOTUNE_AXES<AUTOTUNE_AXES>` bitmask selects which axes will be tuned while in Autotune. Default is roll, pitch and yaw.
 
+.. warning:: AUTOTUNE is not designed to work well with :ref:`RUDDER_ONLY<RUDDER_ONLY>` vehicles for tuning roll. :ref:`Manually tune the roll <new-roll-pitch-tuning>` axis instead.
+
 You also should choose a tuning level by setting the :ref:`AUTOTUNE_LEVEL<AUTOTUNE_LEVEL>`
 parameter in the advanced parameter screen of your ground station. The
 :ref:`AUTOTUNE_LEVEL<AUTOTUNE_LEVEL>` parameter controls how aggressive you want the tune to


### PR DESCRIPTION
According to Tridge, autotune was not designed with rudder only planes in mind. My experience has been very poor.
https://discuss.ardupilot.org/t/ardusoar-2025/128317/11
Although initially impressed with autotune, I found a few ways the controller breaks down with that tune. The P gain is far too low from autotune. I have tried a few different autotune levels, none are acceptable.