### PR TITLE
DO_FENCE_ENABLE: Add an explanation for parameter 2 in the command

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -4102,7 +4102,7 @@ Mission commands to enable the Plane :ref:`GeoFence <geofencing>`, Copter/Rover 
    <tr>
    <td><strong>param2</strong></td>
    <td>bitmask</td>
-   <td>The target fence is specified by the bitmask value of FENCE_TYPE.</td>
+   <td>The target fence is specified by the bitmask value of FENCE_TYPE. 0 is ALL configured fences.</td>
    </tr>
    <tr style="color: #c0c0c0">
    <td>param3</td>

--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -4099,10 +4099,10 @@ Mission commands to enable the Plane :ref:`GeoFence <geofencing>`, Copter/Rover 
    <td></td>
    <td>Set GeoFence enable state (0=disable, 1=enable, 2= disable only floor (Plane only)).</td>
    </tr>
-   <tr style="color: #c0c0c0">
-   <td>param2</td>
-   <td></td>
-   <td>Empty</td>
+   <tr>
+   <td><strong>param2</strong></td>
+   <td>bitmask</td>
+   <td>The target fence is specified by the bitmask value of FENCE_TYPE.</td>
    </tr>
    <tr style="color: #c0c0c0">
    <td>param3</td>


### PR DESCRIPTION
Parameter 2 can be used to specify which fence should be enabled or disabled.
This detail was not documented, so I will add it.