### PR TITLE
Copter: update vibration failsafe for EKF3

### DIFF
--- a/copter/source/docs/vibration-failsafe.rst
+++ b/copter/source/docs/vibration-failsafe.rst
@@ -4,9 +4,7 @@
 Vibration Failsafe
 ==================
 
-This feature is available only in Copter 4.0 and later firmware.
-
-Vibration Failsafe is a little different than most other failsafes in ArduPilot, in that it does not initiate a flight mode change. Instead it changes the algorithm which controls altitude and climb rate in altitude control modes. It is enabled by default, but can be disabled by setting :ref:`FS_VIBE_ENABLE<FS_VIBE_ENABLE>` = 0.
+The vibration failsafe is a little different than most other failsafes in ArduPilot, in that it does not initiate a flight mode change. Instead it changes the algorithm which controls altitude and climb rate in altitude control modes. It is enabled by default, but can be disabled by setting :ref:`FS_VIBE_ENABLE<FS_VIBE_ENABLE>` = 0.
 
 Impact of High Vibrations
 =========================
@@ -18,9 +16,9 @@ When the failsafe will trigger
 
 The vibration failsafe will trigger if all of the following are true for at least one second:
 
-- EKF’s vertical velocity innovations are positive (see onboard log's NKF4.IVD value)
-- EKF's vertical position innovations are positive (see NKF4.IPD)
-- EKF's velocity variance is 1 or higher (see NKF4.SV)
+- EKF’s vertical velocity innovations are positive (see onboard log's XKF3.IVD value)
+- EKF's vertical position innovations are positive (see XKF3.IPD)
+- EKF's velocity variance is 1 or higher (see XKF4.SV)
 
 .. note:: An ``Innovation`` is the difference between the predicted value and the latest (non-IMU) value. A ``Variance`` is the EKF’s reported confidence in its estimate. 0 is very good, >1 is bad.
 


### PR DESCRIPTION
This updates the EKF fields to look at now that EKF3 is the default (the old values were for the EKF2)

I've also removed mention of a very old version of AP.

The vibration failsafe came up in [this 4.6 beta testing discussion](https://discuss.ardupilot.org/t/jumps-with-gaining-altitude-when-changed-mode-from-rtl-to-loiter/133889)

I've built this locally and it looks OK to me.