### PR TITLE
Common: fix rangefinder landing page link for Nanoradar MR72

### DIFF
--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -98,7 +98,7 @@ Omnidirectional Proximity Rangefinders
     LDRobot LD-06 TOF <common-ld06>
     Lightware SF40/C (360 degree) <common-lightware-sf40c-objectavoidance>
     Lightware SF45/B (350 degree) <common-lightware-sf45b>
-    Nanoradar MK72 (112 degree) <common-rangefinder-mr72>
+    Nanoradar MR72 (112 degree) <common-rangefinder-mr72>
     RPLidar A2/C1/S1 360 degree Laser/TOF LIDAR <common-rplidar-a2>
     TerraRanger Tower/ Tower EVO (360 degree) <common-teraranger-tower-objectavoidance>
     Cygbot D1 (120 degree) <https://www.cygbot.com/_files/ugd/f5911d_726a54fc4f6644bcbec0d9b00236ffda.pdf>


### PR DESCRIPTION
This fixes the Nanoradar MR72s name on the landing page.  This was at the request of Nanoradar.

I've tested this locally and it looks OK to me