### PR TITLE
dev: adding-sim-devices gets ld06 proximity sensor

### DIFF
--- a/dev/source/docs/adding_simulated_devices.rst
+++ b/dev/source/docs/adding_simulated_devices.rst
@@ -123,11 +123,13 @@ distance.
 Adding a 360deg lidar
 =====================
 
-SITL can simulate a 360 deg lidar (either RPLidarA2 or SF45b) which is useful for testing object avoidance. To set it up use the following commands:
+SITL can simulate a 360 deg lidar (LD06, RPLidarA2 or SF45b) which is useful for testing object avoidance. To set it up use the following commands:
 
 ::
 
     param set SERIAL5_PROTOCOL 11 (Proximity)
+    param set PRX1_TYPE 16 (LD06)
+      OR
     param set PRX1_TYPE 5 (RPLidarA2)
       OR
     param set PRX1_TYPE 8 (SF45b)
@@ -136,8 +138,9 @@ Next start the simulator using one of the lines shown below.  This will start th
 
 ::
 
-    ../Tools/autotest/sim_vehicle.py -A --serial5=sim:sf45b -l 51.8752066,14.6487840,54.15,0
+    ../Tools/autotest/sim_vehicle.py -A --serial5=sim:ld06 -l 51.8752066,14.6487840,54.15,0
     ../Tools/autotest/sim_vehicle.py -A --serial5=sim:rplidara2 -l 51.8752066,14.6487840,54.15,0
+    ../Tools/autotest/sim_vehicle.py -A --serial5=sim:sf45b -l 51.8752066,14.6487840,54.15,0
     
 To display the barriers on the map run type the following into the terminal
 


### PR DESCRIPTION
This updates the [adding-simulated-devices](https://ardupilot.org/dev/docs/adding_simulated_devices.html) page to include the LD06

This simulator was added as part of PR: https://github.com/ArduPilot/ardupilot/pull/27045

I've tested this locally and it looks OK