### PR TITLE
dev: Add ROS 2 deployment to Pi with docker and systemd

### DIFF
--- a/dev/source/docs/ros2-pi.rst
+++ b/dev/source/docs/ros2-pi.rst
@@ -97,7 +97,7 @@ The simplest solution is to wire an open telemetry port.
    :target: ../_images/PiZero2WTelem.png
 
 ..
-    Cosider documenting flow control setup, and also any configuration to enable /dev/ttyS0
+    Consider documenting flow control setup, and also any configuration to enable /dev/ttyS0
 
 This allow GPIO13 and GPIO15 (/dev/ttySO) to communicate with ArduPilot.
 
@@ -107,9 +107,10 @@ Cross Compile an application with Docker
 ..
     Inspired by https://github.com/Ryanf55/ardupilot_ros/blob/docker-deploy-to-pi/docker/Dockerfile
 
-In order to run applications on a Raspberry Pi, we must cross compile them for the ARM architecture.
+In order to run applications on a Raspberry Pi, we can cross compile them for the ARM architecture.
 `Docker <https://www.docker.com/>`_ allows an easy way to cross compile. Because of the Pi's limited memory, 
-it is not recommended to attempt compiling on target hardware.
+it is not recommended to attempt compiling on target hardware. If you have a more powerful computer, see the 
+next section for direct compilation on ARM64.
 
 First, create a dockerfile like so on your laptop called ``Dockerfile``
 
@@ -129,7 +130,7 @@ First, create a dockerfile like so on your laptop called ``Dockerfile``
         --mount=target=/var/cache/apt,type=cache,sharing=locked \
         apt-get update && \
         rosdep update && \
-        rosdep install --from-paths . --ignore-src -y && \
+        rosdep install --from-paths . --ignore-src -y --dependency-types build && \
         apt-get -y --no-install-recommends install ros-humble-fastcdr
 
     RUN . /opt/ros/humble/setup.sh && colcon build
@@ -157,9 +158,14 @@ Now, the following steps build the docker image and copy the ROS 2 install direc
     rsync -aRv --exclude install/COLCON_IGNORE install ubuntu@ubuntu.local:/home/ubuntu
 
 
-Although we have copied the executable over, the runtime dependencies are not installed.
-Let's use rosdep to install those by cloning it on the target and invoking rosdep.
+Installing Dependencies
+=======================
+
+Although we have copied the executable(s) over, the runtime dependencies are not installed.
+Let's use rosdep to install those.
 The target only needs runtime dependencies, which are denoted with tag ``exec``.
+
+After SSH'ing into the target, run:
 
 .. code-block:: bash
 
@@ -168,6 +174,15 @@ The target only needs runtime dependencies, which are denoted with tag ``exec``.
     apt update
     rosdep update
     rosdep install --from-paths install --dependency-types exec
+
+Compiling the Micro ROS agent directly on ARM64
+===============================================
+
+Instead of cross compiling, some more powerful companion computers can support local compilation.
+
+.. note::
+
+    Instructions coming soon
 
 Test the Micro ROS Agent
 ========================
@@ -265,6 +280,8 @@ Coming Soon
 
 * Building and installing your own nodes alongside the Micro ROS Agent
 * Using DroneBridge as an alternative DHCP Server
+* Compiling ArduPilot with DDS, applying a custom hwdef to tune rates, and configuring parameters
+* Using the CLI to subscribe to topics on the remote laptop and ARM64 target
 
 References
 ==========

--- a/dev/source/docs/ros2-pi.rst
+++ b/dev/source/docs/ros2-pi.rst
@@ -51,8 +51,8 @@ We'll install all the packages before it's wired into the drone.
 ROS 2 Install
 =============
 
-When using Ubuntu 22.04, it's easiest to install ROS 2 through binaries.
-https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html
+When using Ubuntu 22.04, it's easiest to install ROS 2 through `binaries <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html>`_.
+
 
 First off, if you can't use ``apt update`` due to "Waiting for cache lock: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process 912 (unattended-upgr)",
 try removing unattended upgrades
@@ -95,3 +95,184 @@ The simplest solution is to wire an open telemetry port.
 
 .. figure:: ../images/PiZero2WTelem.png
    :target: ../_images/PiZero2WTelem.png
+
+This allow GPIO13 and GPIO15 (/dev/ttySO) to communicate with ArduPilot.
+
+Cross Compile an application with Docker
+========================================
+
+..
+    Inspired by https://github.com/Ryanf55/ardupilot_ros/blob/docker-deploy-to-pi/docker/Dockerfile
+
+In order to run applications on a Raspberry Pi, we must cross compile them for the ARM architecture.
+`Docker <https://www.docker.com/>`_ allows an easy way to cross compile. Because of the Pi's limited memory, 
+it is not recommended to attempt compiling on target hardware.
+
+First, create a dockerfile like so on your laptop called ``Dockerfile``
+
+.. code-block:: docker
+
+    FROM arm64v8/ros:humble
+
+    RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+        --mount=target=/var/cache/apt,type=cache,sharing=locked \
+        apt-get update && apt-get -y --no-install-recommends install \
+            git cmake build-essential
+
+    WORKDIR /ws
+    RUN git clone --branch humble https://github.com/micro-ROS/micro-ROS-Agent.git
+    WORKDIR /ws/micro-ROS-Agent
+    RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
+        --mount=target=/var/cache/apt,type=cache,sharing=locked \
+        apt-get update && \
+        rosdep update && \
+        rosdep install --from-paths . --ignore-src -y && \
+        apt-get -y --no-install-recommends install ros-humble-fastcdr
+
+    RUN . /opt/ros/humble/setup.sh && colcon build
+
+Next, use Docker's multi-platform build support to set up a cross compile in an ARM64v8 environment: https://docs.docker.com/build/building/multi-platform/#install-qemu-manually
+
+.. code-block:: bash
+
+    docker run --privileged --rm tonistiigi/binfmt --install all
+    cat /proc/sys/fs/binfmt_misc/qemu-arm | grep flags
+
+Now, the following steps build the docker image and copy the ROS 2 install directory to the target.
+
+.. code-block:: bash
+
+    # Build with multiplatform support
+    docker build . --platform linux/arm64 -t micro_ros_agent
+
+    # Copy the installation directory from the docker image to the host.
+    docker create --name dummy micro_ros_agent
+    docker cp dummy:/ws/micro-ROS-Agent/install install
+    docker rm -f dummy
+
+    # And now, from host to target's home directory
+    scp -r install/ ubuntu@ubuntu.local:/home/ubuntu
+
+..
+    TODO consider using rsync for when we get to larger workspaces
+
+Although we have copied the executable over, the runtime dependencies are not installed.
+Let's use rosdep to install those by cloning it on the target and invoking rosdep.
+
+.. code-block:: bash
+
+    cd ~
+    git clone --branch humble https://github.com/micro-ROS/micro-ROS-Agent.git
+    cd micro-ROS-Agent
+    sudo rosdep init
+    rosdep update
+    rosdep install --from-paths . --ignore-src -y
+    cd ..
+    sudo rm -r micro-ROS-Agent
+
+..
+    This is quite a hacky way to install runtime dependencies.
+
+Test the Micro ROS Agent
+========================
+
+Now that you have a cross-compiled installation of the Micro ROS Agent along with its dependencies, let's check we can run it.
+
+.. code-block:: bash
+
+    source ~/install/setup.bash
+    ros2 run micro_ros_agent micro_ros_agent serial -v4 -b 115200 -D /dev/ttyS0
+
+Starting the Micro ROS Agent automatically
+==========================================
+
+Rather than having to SSH into the companion computer and manually start
+all ROS 2 nodes in terminal, let's use systemd to start the service automatically on boot.
+For this tutorial, we will use systemd user services because they do not require root to run.
+
+First, create a script on the companion computer that sources the ROS 2 workspace and runs the Micro ROS Agent.
+
+.. code-block:: bash
+
+    mkdir -p ~/.config/systemd/user
+    nano ~/.config/systemd/user/micro-ros-agent.service
+
+Place the following contents inside:
+
+.. code-block:: text
+
+    [Unit]
+    Description=Micro-ROS Agent over serial /dev/ttyS0
+    After=network-online.target
+    Wants=network-online.target
+
+    [Service]
+    WorkingDirectory=/home/ubuntu
+    Type=simple
+    ExecStart=/home/ubuntu/.local/lib/start-micro-ros-agent.sh
+    Restart=on-failure
+
+    [Install]
+    WantedBy=default.target
+
+.. note::
+
+   If you are not using ``ubuntu`` as your username, be sure to change the ``WorkingDirectory`` and ``ExecStart`` fields above!
+
+Also, create the start script:
+
+.. code-block:: bash
+
+    mkdir -p ~/.local/lib/
+    nano ~/.local/lib/start-micro-ros-agent.sh
+
+And, place the following script inside:
+
+.. code-block:: bash
+
+    #!/bin/bash
+
+    source "$HOME/install/setup.bash"
+    exec ros2 run micro_ros_agent micro_ros_agent serial -v4 -b 115200 -D /dev/ttyS0
+
+Finally, make it executable, reload services, and start the new Micro ROS Agent systemd service.
+
+.. code-block:: bash
+
+    chmod +x ~/.local/lib/start-micro-ros-agent.sh
+    systemctl --user daemon-reload
+    systemctl --user enable micro-ros-agent.service
+    systemctl --user start micro-ros-agent.service
+    systemctl --user status micro-ros-agent.service
+
+The MicroROS agent should show it has started. It is now waiting on a connection from the autopilot.
+Once the autopilot is configured for the same baud rate as the Micro ROS Agent, it should connect.
+
+Because systemctl user services won't start until someone logs in, enable linger for login.
+Reference: 
+
+.. code-block:: bash
+
+    loginctl enable-linger $USER
+
+Once you start adding more service, you can check status like so:
+
+.. code-block:: bash
+
+    systemctl --user status
+
+Coming Soon
+===========
+
+* Building and installing your own nodes alongside the Micro ROS Agent
+* Using DroneBridge as an alternative DHCP Server
+
+References
+==========
+
+For more information on any of the above content, see the following references:
+
+* `Systemd user services <https://docs.oracle.com/en/operating-systems/oracle-linux/9/systemd/CreatingasystemdUserBasedService.html>`_
+* `Docker Create for Copying to Host <https://stackoverflow.com/a/51186557>`_
+* `Docker MultiPlatform Images <https://docs.docker.com/build/building/multi-platform/#build-multi-platform-images>`_
+* `Login Linger <https://www.baeldung.com/linux/systemd-session-dbus-headless-setup#1-enabling-systemd-user-lingering>`_

--- a/dev/source/docs/ros2-pi.rst
+++ b/dev/source/docs/ros2-pi.rst
@@ -123,7 +123,7 @@ First, create a dockerfile like so on your laptop called ``Dockerfile``
             git cmake build-essential
 
     WORKDIR /ws
-    RUN git clone --branch humble https://github.com/micro-ROS/micro-ROS-Agent.git
+    RUN git clone  --depth 1 --branch humble https://github.com/micro-ROS/micro-ROS-Agent.git
     WORKDIR /ws/micro-ROS-Agent
     RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
         --mount=target=/var/cache/apt,type=cache,sharing=locked \


### PR DESCRIPTION
# Purpose

Add a minimal example showing how to stand up a cross compile workflow for the Micro ROS Agent on a Raspberry Pi.
This does it without any custom scripts because it's more intended as instruction.

# Details

Companies using ROS 2 likely have their own mechanicsm for deployment (docker images, debian packages, etc), however this is a good minimal start to cross compile and launch an application on a headless computer. I start with just the MicroROS agent. We can add python and C++ nodes later.

# testing performed

Flew it on my plane, verified DDS connected via GCS messages each flight. 

# Follow up

Use PPP: https://discuss.ardupilot.org/t/guide-for-using-dds-over-ppp-with-a-raspberry-pi-4-companion-computer/126128/3
