### PR TITLE
Added wiki for Astra Battery Monitor

### DIFF
--- a/common/source/docs/common-smart-battery-astra.rst
+++ b/common/source/docs/common-smart-battery-astra.rst
@@ -1,0 +1,83 @@
+Astra Smart Battery
+====================
+
+.. _astra-smart-battery:
+
+The **Astra Smart Battery** is a smart battery based on the SBS (Smart Battery System) protocol over I2C. It is compatible with the Cube autopilot series and other ArduPilot-compatible boards with I2C connectivity.
+
+.. note::
+   ArduPilot’s `SMBUS_Generic <https://ardupilot.org/dev/docs/smart-battery.html>`__ backend is used as the basis for this battery monitor. Astra includes enhancements for reporting **State of Health (SOH)** and **Cycle Count**.
+
+Features
+--------
+
+- SBS/SMBus compliant
+- Provides:
+  - Voltage
+  - Current
+  - Remaining capacity
+  - Full charge capacity
+  - Temperature
+  - State of Health (SOH)
+  - Cycle count
+  - Serial number
+- Plug-and-play I2C interface
+- Compatible with Cube Orange / Cube Orange+ / Cube Blue and similar autopilots
+
+Wiring
+------
+
+Connect the battery’s I2C interface to the autopilot’s I2C port. Below is the standard Cube carrier board I2C port pinout:
+
+.. list-table:: I2C Pinout
+   :widths: 25 25 50
+   :header-rows: 1
+
+   * - Pin
+     - Signal
+     - Description
+   * - 1
+     - SDA
+     - I2C Data
+   * - 2
+     - SCL
+     - I2C Clock
+   * - 3
+     - VCC
+     - 3.3V or 5V (depending on design)
+   * - 4
+     - GND
+     - Ground
+
+ArduPilot Configuration
+-----------------------
+
+Use Mission Planner or your preferred GCS to configure the following parameters:
+
+.. list-table:: Battery Monitor Parameters
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Value / Description
+   * - `BATT_MONITOR`
+     - `32` (or `Astra` if you've created a separate backend)
+   * - `BATT_I2C_BUS`
+     - Set to the correct bus - 0
+   * - `BATT_I2C_ADDRESS`
+     - Set battery I2C Address - Default 11
+
+Additional Info
+---------------
+
+- **Cycle Count** and **SOH** values are shown in the Mission Planner’s status tab as `battery_cycle_count` and `battery_soh`, respectively.
+- Ensure SMBus protocol compatibility — not all batteries follow the standard strictly.
+- For custom implementations or forks of SMBUS_Generic (like `Astra`), see :ref:`battery-monitor-dev`.
+
+See Also
+--------
+
+- :ref:`battery-monitoring`
+- :ref:`smart-battery`
+- :ref:`smbus-battery-monitor`
+

--- a/common/source/docs/common-smart-battery-astra.rst
+++ b/common/source/docs/common-smart-battery-astra.rst
@@ -21,6 +21,7 @@ Features
   - State of Health (SOH)
   - Cycle count
   - Serial number
+    and lot more data
 - Plug-and-play I2C interface
 - Compatible with Cube Orange / Cube Orange+ / Cube Blue and similar autopilots
 
@@ -37,17 +38,17 @@ Connect the battery’s I2C interface to the autopilot’s I2C port. Below is th
      - Signal
      - Description
    * - 1
-     - SDA
-     - I2C Data
+     - GND
+     - Ground
    * - 2
      - SCL
      - I2C Clock
    * - 3
+     - SDA
+     - I2C Data
+   * - 4
      - VCC
      - 3.3V or 5V (depending on design)
-   * - 4
-     - GND
-     - Ground
 
 ArduPilot Configuration
 -----------------------

--- a/common/source/docs/common-smart-battery-astra.rst
+++ b/common/source/docs/common-smart-battery-astra.rst
@@ -48,7 +48,7 @@ Connect the battery’s I2C interface to the autopilot’s I2C port. Below is th
      - I2C Data
    * - 4
      - VCC
-     - 3.3V or 5V (depending on design)
+     - 3.3V or 5V (I/P for Isolator on the BMS)
 
 ArduPilot Configuration
 -----------------------
@@ -70,10 +70,7 @@ Use Mission Planner or your preferred GCS to configure the following parameters:
 
 Additional Info
 ---------------
-
-- **Cycle Count** and **SOH** values are shown in the Mission Planner’s status tab as `battery_cycle_count` and `battery_soh`, respectively.
-- Ensure SMBus protocol compatibility — not all batteries follow the standard strictly.
-- For custom implementations or forks of SMBUS_Generic (like `Astra`), see :ref:`battery-monitor-dev`.
+- **Cycle Count** and **SOH** values are not shown in the Mission Planner’s status tab or anywhere else. Work in progress. Can fetch the data using 0x17 for Cycle Count and 0x4f for SOH.
 
 See Also
 --------

--- a/common/source/docs/common-smart-battery-astra.rst
+++ b/common/source/docs/common-smart-battery-astra.rst
@@ -62,7 +62,7 @@ Use Mission Planner or your preferred GCS to configure the following parameters:
    * - Parameter
      - Value / Description
    * - `BATT_MONITOR`
-     - `32` (or `Astra` if you've created a separate backend)
+     - `32` (or `Astra`)
    * - `BATT_I2C_BUS`
      - Set to the correct bus - 0
    * - `BATT_I2C_ADDRESS`


### PR DESCRIPTION
Added a new document for Astra Battery Monitor to help the users understand more about the battery, successfully integrate with the FC and fetch important parameters.