### PR TITLE
add corotating frame diagrams

### DIFF
--- a/copter/source/docs/connect-escs-and-motors.rst
+++ b/copter/source/docs/connect-escs-and-motors.rst
@@ -210,6 +210,19 @@ OCTO QUAD FRAMES
     :scale: 40%
     :alt: OCTO QUAD X (BF REVERSED)
 
+.. image:: ../images/m_17_01_corotating_x.svg
+    :target: ../_images/m_17_01_corotating_x.svg
+    :scale: 40%
+    :alt: COROTATING X
+
+.. image:: ../images/m_17_14_corotating_x_cw.svg
+    :target: ../_images/m_17_14_corotating_x_cw.svg
+    :scale: 40%
+    :alt: COROTATING X (CW)
+
+.. note::
+    The Corotating X and X (CW) frames must be configured using FRAME_CLASS 17, and the autopilot must run the `X8-corotating.lua script <https://github.com/ArduPilot/ardupilot/libraries/AP_Scripting/examples/X8-corotating.lua>`__.
+
 Y6 FRAMES
 ---------
 

--- a/copter/source/images/m_17_01_corotating_x.svg
+++ b/copter/source/images/m_17_01_corotating_x.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="motor-diagram" width="733.0" height="733.0" viewBox="-366.5 -226.25 733.0 524.5">
+    <defs id="svg-defs">
+        <g id="frame-half-2d" fill="#ebebeb">
+            <path d="M 1 64 L -30 64 A 12 12 0 0 1 -42 52 L -42 -28 A 12 12 0 0 1 -38 -36 L -5 -62 A 12 12 0 0 1 0 -63 L 1 -63" stroke-width="12" />
+            <circle cx="-17" cy="-29" r="5" stroke-width="0" fill="#60507f" />
+            <line x1="-17" y1="-29" x2="1" y2="-29" stroke-width="10" />
+        </g>
+        <g id="frame-2d">
+            <use xlink:href="#frame-half-2d" />
+            <use xlink:href="#frame-half-2d" transform="scale(-1 1)" />
+        </g>
+        <path id="prop-half-arc" d="M -90 -6 A 91 91 0 0 1 89 -23 L 74 -21 L 101 4 A 101 101 0 0 0 -100 -14 Z" />
+        <g id="prop-arc">
+            <use xlink:href="#prop-half-arc" />
+            <use xlink:href="#prop-half-arc" transform="rotate(180)" />
+        </g>
+        <mask id="cw-arc-mask">
+            <circle cx="0" cy="0" r="101" fill="white" />
+            <rect x="-36" y="-102" width="72" height="20" fill="black" />
+        </mask>
+        <mask id="ccw-arc-mask">
+            <circle cx="0" cy="0" r="101" fill="white" />
+            <rect x="-50" y="-101" width="100" height="25" fill="black" />
+        </mask>
+        <g id="motor-center">
+            <circle cx="0" cy="0" r="75" fill="#c4c4c4" opacity="0.5" />
+            <circle cx="0" cy="0" r="35" />
+        </g>
+        <g id="CW" fill="#33cc33">
+            <use xlink:href="#motor-center" />
+            <use xlink:href="#prop-arc" mask="url(#cw-arc-mask)" />
+            <text x="0" y="-100">CW</text>
+        </g>
+        <g id="CW-normal">
+            <use xlink:href="#CW" />
+        </g>
+        <g id="CW-flipped" fill="#33cc33">
+            <use xlink:href="#CW" mask="url(#cw-arc-mask)" transform="scale(-1 -1)" />
+            <text x="0" y="100">CW</text>
+        </g>
+        <g id="CCW" fill="#00b8e6">
+            <use xlink:href="#motor-center" />
+            <use xlink:href="#prop-arc" mask="url(#ccw-arc-mask)" transform="scale(-1 1)" />
+            <text x="0" y="-100">CCW</text>
+        </g>
+        <g id="CCW-normal">
+            <use xlink:href="#CCW" />
+        </g>
+        <g id="CCW-flipped" fill="#00b8e6">
+            <use xlink:href="#CCW" mask="url(#ccw-arc-mask)" transform="scale(-1 -1)" />
+            <text x="0" y="100">CCW</text>
+        </g>
+        <g id="NYT" fill="#60507f" stroke="#60507f">
+            <use xlink:href="#motor-center" />
+            <circle cx="0" cy="0" r="101" stroke-width="10" fill-opacity="0" />
+        </g>
+        <g id="NYT-flipped">
+            <use xlink:href="#NYT" />
+        </g>
+        <g id="tail-servo" fill="black">
+            <rect x="-20" y="-30" width="40" height="60" />
+            <rect x="14" y="-45" width="6" height="90" />
+            <rect x="20" y="-10" width="5" height="20" />
+            <rect x="25" y="-20" width="5" height="40" />
+            <rect x="30" y="-3" width="4" height="6" />
+        </g>
+        <g id="tail-servo-flipped">
+            <use xlink:href="#tail-servo" />
+        </g>
+    </defs>
+    <g id="motor-diagram-layers" text-anchor="middle" dominant-baseline="central" font-family="sans-serif" font-size="48" font-weight="bold">
+        <g id="layer-background" fill="white" stroke="white"><rect x="-366.5" y="-226.25" width="733.0" height="524.5" fill="white" /></g>
+        <g id="layer-frame" stroke="#60507f" stroke-width="12" />
+        <g id="layer-motors" font-size="36">
+            <g id="layer-motors-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><use x="-192.5" y="-192.50000000000003" xlink:href="#CW-flipped" /><use x="192.50000000000003" y="-192.5" xlink:href="#CCW-flipped" /><use x="192.50000000000003" y="192.5" xlink:href="#CW-flipped" /><use x="-192.5" y="192.50000000000003" xlink:href="#CCW-flipped" /></g>
+            <g id="layer-frame-3d" stroke="#60507f" stroke-width="12" style="transform: rotate3d(1, 0, 0, -55deg)"><line x1="0" y1="0" x2="192.50000000000003" y2="-192.5" /><line x1="0" y1="0" x2="-192.5" y2="-192.50000000000003" /><line x1="0" y1="0" x2="-192.5" y2="192.50000000000003" /><line x1="0" y1="0" x2="192.50000000000003" y2="192.5" /><line x1="0" y1="0" x2="-192.5" y2="-192.50000000000003" /><line x1="0" y1="0" x2="192.50000000000003" y2="-192.5" /><line x1="0" y1="0" x2="192.50000000000003" y2="192.5" /><line x1="0" y1="0" x2="-192.5" y2="192.50000000000003" /><use x="0" y="-5" xlink:href="#frame-2d" /></g>
+            <g id="layer-motors-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-motors-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><use x="192.50000000000003" y="-192.5" xlink:href="#CCW" /><use x="-192.5" y="-192.50000000000003" xlink:href="#CW" /><use x="-192.5" y="192.50000000000003" xlink:href="#CCW" /><use x="192.50000000000003" y="192.5" xlink:href="#CW" /></g>
+        </g>
+        <g id="layer-motor-numbers" fill="white" font-weight="normal">
+            <g id="layer-numbers-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><text x="-192.5" y="-192.50000000000003">5</text><text x="192.50000000000003" y="-192.5">6</text><text x="192.50000000000003" y="192.5">7</text><text x="-192.5" y="192.50000000000003">8</text></g>
+            <g id="layer-numbers-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-numbers-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><text x="192.50000000000003" y="-192.5">1</text><text x="-192.5" y="-192.50000000000003">2</text><text x="-192.5" y="192.50000000000003">3</text><text x="192.50000000000003" y="192.5">4</text></g>
+        </g>
+        <g id="layer-motor-letters" fill="red">
+            <g id="layer-letters-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><text x="-322.5" y="-192.50000000000003">H</text><text x="322.5" y="-192.5">B</text><text x="322.5" y="192.5">D</text><text x="-322.5" y="192.50000000000003">F</text></g>
+            <g id="layer-letters-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-letters-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><text x="322.5" y="-192.5">A</text><text x="-322.5" y="-192.50000000000003">G</text><text x="-322.5" y="192.50000000000003">E</text><text x="322.5" y="192.5">C</text></g>
+        </g>
+        <g id="layer-frame-name" fill="black" font-style="italic"><text x="0" y="254.25">COROTATING X</text></g>
+        <g id="layer-frame-notes" font-size="36" font-weight="normal" font-style="italic" />
+    </g>
+</svg>

--- a/copter/source/images/m_17_14_corotating_x_cw.svg
+++ b/copter/source/images/m_17_14_corotating_x_cw.svg
@@ -1,0 +1,93 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" id="motor-diagram" width="733.0" height="733.0" viewBox="-366.5 -226.25 733.0 524.5">
+    <defs id="svg-defs">
+        <g id="frame-half-2d" fill="#ebebeb">
+            <path d="M 1 64 L -30 64 A 12 12 0 0 1 -42 52 L -42 -28 A 12 12 0 0 1 -38 -36 L -5 -62 A 12 12 0 0 1 0 -63 L 1 -63" stroke-width="12" />
+            <circle cx="-17" cy="-29" r="5" stroke-width="0" fill="#60507f" />
+            <line x1="-17" y1="-29" x2="1" y2="-29" stroke-width="10" />
+        </g>
+        <g id="frame-2d">
+            <use xlink:href="#frame-half-2d" />
+            <use xlink:href="#frame-half-2d" transform="scale(-1 1)" />
+        </g>
+        <path id="prop-half-arc" d="M -90 -6 A 91 91 0 0 1 89 -23 L 74 -21 L 101 4 A 101 101 0 0 0 -100 -14 Z" />
+        <g id="prop-arc">
+            <use xlink:href="#prop-half-arc" />
+            <use xlink:href="#prop-half-arc" transform="rotate(180)" />
+        </g>
+        <mask id="cw-arc-mask">
+            <circle cx="0" cy="0" r="101" fill="white" />
+            <rect x="-36" y="-102" width="72" height="20" fill="black" />
+        </mask>
+        <mask id="ccw-arc-mask">
+            <circle cx="0" cy="0" r="101" fill="white" />
+            <rect x="-50" y="-101" width="100" height="25" fill="black" />
+        </mask>
+        <g id="motor-center">
+            <circle cx="0" cy="0" r="75" fill="#c4c4c4" opacity="0.5" />
+            <circle cx="0" cy="0" r="35" />
+        </g>
+        <g id="CW" fill="#33cc33">
+            <use xlink:href="#motor-center" />
+            <use xlink:href="#prop-arc" mask="url(#cw-arc-mask)" />
+            <text x="0" y="-100">CW</text>
+        </g>
+        <g id="CW-normal">
+            <use xlink:href="#CW" />
+        </g>
+        <g id="CW-flipped" fill="#33cc33">
+            <use xlink:href="#CW" mask="url(#cw-arc-mask)" transform="scale(-1 -1)" />
+            <text x="0" y="100">CW</text>
+        </g>
+        <g id="CCW" fill="#00b8e6">
+            <use xlink:href="#motor-center" />
+            <use xlink:href="#prop-arc" mask="url(#ccw-arc-mask)" transform="scale(-1 1)" />
+            <text x="0" y="-100">CCW</text>
+        </g>
+        <g id="CCW-normal">
+            <use xlink:href="#CCW" />
+        </g>
+        <g id="CCW-flipped" fill="#00b8e6">
+            <use xlink:href="#CCW" mask="url(#ccw-arc-mask)" transform="scale(-1 -1)" />
+            <text x="0" y="100">CCW</text>
+        </g>
+        <g id="NYT" fill="#60507f" stroke="#60507f">
+            <use xlink:href="#motor-center" />
+            <circle cx="0" cy="0" r="101" stroke-width="10" fill-opacity="0" />
+        </g>
+        <g id="NYT-flipped">
+            <use xlink:href="#NYT" />
+        </g>
+        <g id="tail-servo" fill="black">
+            <rect x="-20" y="-30" width="40" height="60" />
+            <rect x="14" y="-45" width="6" height="90" />
+            <rect x="20" y="-10" width="5" height="20" />
+            <rect x="25" y="-20" width="5" height="40" />
+            <rect x="30" y="-3" width="4" height="6" />
+        </g>
+        <g id="tail-servo-flipped">
+            <use xlink:href="#tail-servo" />
+        </g>
+    </defs>
+    <g id="motor-diagram-layers" text-anchor="middle" dominant-baseline="central" font-family="sans-serif" font-size="48" font-weight="bold">
+        <g id="layer-background" fill="white" stroke="white"><rect x="-366.5" y="-226.25" width="733.0" height="524.5" fill="white" /></g>
+        <g id="layer-frame" stroke="#60507f" stroke-width="12" />
+        <g id="layer-motors" font-size="36">
+            <g id="layer-motors-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><use x="192.50000000000003" y="-192.5" xlink:href="#CCW-flipped" /><use x="192.50000000000003" y="192.5" xlink:href="#CW-flipped" /><use x="-192.5" y="192.50000000000003" xlink:href="#CCW-flipped" /><use x="-192.5" y="-192.50000000000003" xlink:href="#CW-flipped" /></g>
+            <g id="layer-frame-3d" stroke="#60507f" stroke-width="12" style="transform: rotate3d(1, 0, 0, -55deg)"><line x1="0" y1="0" x2="192.50000000000003" y2="-192.5" /><line x1="0" y1="0" x2="192.50000000000003" y2="-192.5" /><line x1="0" y1="0" x2="192.50000000000003" y2="192.5" /><line x1="0" y1="0" x2="192.50000000000003" y2="192.5" /><line x1="0" y1="0" x2="-192.5" y2="192.50000000000003" /><line x1="0" y1="0" x2="-192.5" y2="192.50000000000003" /><line x1="0" y1="0" x2="-192.5" y2="-192.50000000000003" /><line x1="0" y1="0" x2="-192.5" y2="-192.50000000000003" /><use x="0" y="-5" xlink:href="#frame-2d" /></g>
+            <g id="layer-motors-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-motors-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><use x="192.50000000000003" y="-192.5" xlink:href="#CCW" /><use x="192.50000000000003" y="192.5" xlink:href="#CW" /><use x="-192.5" y="192.50000000000003" xlink:href="#CCW" /><use x="-192.5" y="-192.50000000000003" xlink:href="#CW" /></g>
+        </g>
+        <g id="layer-motor-numbers" fill="white" font-weight="normal">
+            <g id="layer-numbers-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><text x="192.50000000000003" y="-192.5">2</text><text x="192.50000000000003" y="192.5">4</text><text x="-192.5" y="192.50000000000003">6</text><text x="-192.5" y="-192.50000000000003">8</text></g>
+            <g id="layer-numbers-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-numbers-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><text x="192.50000000000003" y="-192.5">1</text><text x="192.50000000000003" y="192.5">3</text><text x="-192.5" y="192.50000000000003">5</text><text x="-192.5" y="-192.50000000000003">7</text></g>
+        </g>
+        <g id="layer-motor-letters" fill="red">
+            <g id="layer-letters-bottom" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(30px)"><text x="322.5" y="-192.5">B</text><text x="322.5" y="192.5">D</text><text x="-322.5" y="192.50000000000003">F</text><text x="-322.5" y="-192.50000000000003">H</text></g>
+            <g id="layer-letters-middle" style="transform: rotate3d(1, 0, 0, -55deg)" />
+            <g id="layer-letters-top" style="transform: rotate3d(1, 0, 0, -55deg) translateZ(-30px)"><text x="322.5" y="-192.5">A</text><text x="322.5" y="192.5">C</text><text x="-322.5" y="192.50000000000003">E</text><text x="-322.5" y="-192.50000000000003">G</text></g>
+        </g>
+        <g id="layer-frame-name" fill="black" font-style="italic"><text x="0" y="254.25">COROTATING X (CW)</text></g>
+        <g id="layer-frame-notes" font-size="36" font-weight="normal" font-style="italic" />
+    </g>
+</svg>

--- a/scripts/motor_diagram_data/AP_Motors_display.json
+++ b/scripts/motor_diagram_data/AP_Motors_display.json
@@ -742,6 +742,136 @@
                     "Pitch": 0.0
                 }
             ]
+        },
+        {
+            "Class": 17,
+            "ClassName": "COROTATING",
+            "Type": 1,
+            "Comments": "Uses Tridge's X8-corotating.lua script",
+            "TypeName": "X",
+            "motors": [
+                {
+                    "Number": 1,
+                    "TestOrder": 1,
+                    "Rotation": "CCW",
+                    "Roll": -0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 2,
+                    "TestOrder": 7,
+                    "Rotation": "CW",
+                    "Roll": 0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 3,
+                    "TestOrder": 5,
+                    "Rotation": "CCW",
+                    "Roll": 0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 4,
+                    "TestOrder": 3,
+                    "Rotation": "CW",
+                    "Roll": -0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 5,
+                    "TestOrder": 8,
+                    "Rotation": "CW",
+                    "Roll": 0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 6,
+                    "TestOrder": 2,
+                    "Rotation": "CCW",
+                    "Roll": -0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 7,
+                    "TestOrder": 4,
+                    "Rotation": "CW",
+                    "Roll": -0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 8,
+                    "TestOrder": 6,
+                    "Rotation": "CCW",
+                    "Roll": 0.5,
+                    "Pitch": -0.5
+                }
+            ]
+        },
+        {
+            "Class": 17,
+            "ClassName": "COROTATING",
+            "Type": 14,
+            "Comments": "Uses Tridge's X8-corotating.lua script",
+            "TypeName": "X (CW)",
+            "motors": [
+                {
+                    "Number": 1,
+                    "TestOrder": 1,
+                    "Rotation": "CCW",
+                    "Roll": -0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 2,
+                    "TestOrder": 2,
+                    "Rotation": "CCW",
+                    "Roll": -0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 3,
+                    "TestOrder": 3,
+                    "Rotation": "CW",
+                    "Roll": -0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 4,
+                    "TestOrder": 4,
+                    "Rotation": "CW",
+                    "Roll": -0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 5,
+                    "TestOrder": 5,
+                    "Rotation": "CCW",
+                    "Roll": 0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 6,
+                    "TestOrder": 6,
+                    "Rotation": "CCW",
+                    "Roll": 0.5,
+                    "Pitch": -0.5
+                },
+                {
+                    "Number": 7,
+                    "TestOrder": 7,
+                    "Rotation": "CW",
+                    "Roll": 0.5,
+                    "Pitch": 0.5
+                },
+                {
+                    "Number": 8,
+                    "TestOrder": 8,
+                    "Rotation": "CW",
+                    "Roll": 0.5,
+                    "Pitch": 0.5
+                }
+            ]
         }
     ]
 }


### PR DESCRIPTION
Adds Corotating X8 diagrams per @tridge 's [recent blog post](https://discuss.ardupilot.org/t/co-rotating-x8-multicopters/135491). Script link and "X (CW)" diagram both put the cart slightly ahead of the horse, as the script currently only supports "X," and lives in a branch on Tridge's fork.

![{E285240B-CC02-485D-856C-E0D1A81184DA}](https://github.com/user-attachments/assets/2454d7c0-2992-495f-8ffd-2efbfc16ebe2)
