### PR TITLE
Common: XFRobot connection over ethernet should use TCP

### DIFF
--- a/common/source/docs/common-xfrobot-gimbal.rst
+++ b/common/source/docs/common-xfrobot-gimbal.rst
@@ -74,9 +74,9 @@ An example of the setup of the gimbal in a networked ArduPilot vehicle system is
   - Set the autopilot's IP address using :ref:`NET_IPADDR0<NET_IPADDR0>`, :ref:`NET_IPADDR1<NET_IPADDR1>`, :ref:`NET_IPADDR2<NET_IPADDR2>`, :ref:`NET_IPADDR3<NET_IPADDR3>` (e.g. 192.168.144.14)
 - Create a serial connection over ethernet
 
-  - Set :ref:`NET_P1_TYPE<NET_P1_TYPE>` = 1 (UDP Client) and reboot the autopilot
-  - Set :ref:`NET_P1_IP0<NET_P1_IP0>`, :ref:`NET_P1_IP1<NET_P1_IP1>`, :ref:`NET_P1_IP2<NET_P1_IP2>`, :ref:`NET_P1_IP3<NET_P1_IP3>` to the gimbal's IP address (e.g. 192.168.144.25)
-  - Set :ref:`NET_P1_PORT<NET_P1_PORT>` = 2338 (port that gimbals listens for commands on)
+  - Set :ref:`NET_P1_TYPE<NET_P1_TYPE>` = 3 (TCP Client) and reboot the autopilot
+  - Set :ref:`NET_P1_IP0<NET_P1_IP0>`, :ref:`NET_P1_IP1<NET_P1_IP1>`, :ref:`NET_P1_IP2<NET_P1_IP2>`, :ref:`NET_P1_IP3<NET_P1_IP3>` to the gimbal's IP address (e.g. 192.168.144.108)
+  - Set :ref:`NET_P1_PORT<NET_P1_PORT>` = 2332 (port that gimbals listens for commands on)
   - Set :ref:`NET_P1_PROTOCOL<NET_P1_PROTOCOL>` = 8 (Gimbal)
 
 The camera's live video is available at rtsp://192.168.144.108.  If connected to a PC, `VLC <https://www.videolan.org/>`__ can be used to test the feed


### PR DESCRIPTION
This updates ethernet connection recommendation for the XFRobot camera gimbals.  Upon further testing I found that the UDP connection was not completely working but TCP does work.  I've also corrected the gimbal's IP address (192.168.144.**108**)

I've built this locally and it looks OK to me