### PR TITLE
Cruise alf floor units fix

### DIFF
--- a/plane/source/docs/fly-by-wire-low-altitude-limit.rst
+++ b/plane/source/docs/fly-by-wire-low-altitude-limit.rst
@@ -31,7 +31,7 @@ How to setup Alt Limit
 ======================
 
 Using your APM Mission Planner you will have to set parameter
-:ref:`CRUISE_ALT_FLOOR<CRUISE_ALT_FLOOR>` to the desired alt **in centimeters!** If it
+:ref:`CRUISE_ALT_FLOOR<CRUISE_ALT_FLOOR>` to the desired alt **in meters!** If it
 is **0** then it is turned off.
 
 Choosing the right altitude


### PR DESCRIPTION
As per https://github.com/ArduPilot/ardupilot/commit/8151647e0465b5fe8b82b5f352f0f22b96025d33 the parameter is set in meters, I think that relates to 4.5.0 rescales of parameters away from centimeters. [The code](https://github.com/ArduPilot/ardupilot/blob/05dbacebd24e3354469a4c908fe8461d20ee1813/ArduPlane/altitude.cpp#L406) clearly expects meters in parameter too.