### PR TITLE
Update ros2-gazebo.rst to include sudo for directory write permissions

### DIFF
--- a/dev/source/docs/ros2-gazebo.rst
+++ b/dev/source/docs/ros2-gazebo.rst
@@ -41,14 +41,14 @@ Add Gazebo APT sources.
 
   sudo apt install wget
   wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
   sudo apt update
 
 Add Gazebo sources to `rosdep` for the non-default pairing of ROS 2 Humble and Gazebo Harmonic.
 
 .. code-block:: bash
 
-  wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
+  sudo wget https://raw.githubusercontent.com/osrf/osrf-rosdep/master/gz/00-gazebo.list -O /etc/ros/rosdep/sources.list.d/00-gazebo.list
   rosdep update
 
 Update ROS and Gazebo dependencies:


### PR DESCRIPTION
This pull request addresses write permission issues in the documentation by adding sudo to necessary commands in the ros2-gazebo.rst file. Specifically, it modifies commands related to adding Gazebo APT sources and updating Gazebo sources in rosdep to ensure they can be executed without permission errors. The changes include:

    Added sudo to tee command for writing to /etc/apt/sources.list.d/gazebo-stable.list.
    Added sudo to wget command for writing to /etc/ros/rosdep/sources.list.d/00-gazebo.list.

These changes ensure that users can follow the documentation without encountering write permission issues.