### PR TITLE
GitHub Actions: Lint Python code with ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,11 @@ jobs:
                   exit 1
               fi
           done
-      - name: Check python3 flake8 formatting
-        run : |
+      - name: Check python formatting
+        run: |
           set -eux -o pipefail
           flake8 .
+          pipx run ruff check
       - name: Test build
         run: |
           export AP_SPHINXOPTS=-W


### PR DESCRIPTION
https://github.com/astral-sh/ruff

Why ruff?
* https://github.com/mavlink/mavlink/pull/2303#issuecomment-3029944846

If ruff is a superset of flake8, why doesn't it complain about the rules in this repo's `.flake8`? https://github.com/ArduPilot/ardupilot_wiki/blob/703219ca36a9f8df9741f19810965aa7da2ea8f7/.flake8#L1-L16

Most of these are whitespace errors that are better handled by a code formatter like ruff format or psf/black, so ruff check ignores them.