### PR TITLE
Add missing SID_AXIS param settings to table

### DIFF
--- a/copter/source/docs/systemid-mode-operation.rst
+++ b/copter/source/docs/systemid-mode-operation.rst
@@ -72,16 +72,22 @@ Value    Description
 1        Input Roll Angle
 2        Input Pitch Angle
 3        Input Yaw Angle
-4        Recovery Roll Angle,
+4        Recovery Roll Angle
 5        Recovery Pitch Angle
 6        Recovery Yaw Angle
 7        Rate Roll
 8        Rate Pitch
 9        Rate Yaw
-10       Mixer Roll,
+10       Mixer Roll
 11       Mixer Pitch
 12       Mixer Yaw
 13       Mixer Thrust
+14       Measured Lateral Position
+15       Measured Longitudinal Position
+16       Measured Lateral Velocity
+17       Measured Longitudinal Velocity
+18       Input Lateral Velocity
+19       Input Longitudinal Velocity
 =====    ===========
 
 :ref:`SID_MAGNITUDE<SID_MAGNITUDE>`: System identification Chirp Magnitude. Depending on the injection point, units will be in either deg, deg/s, 0-1 for mixer outputs, m/s for velocity, and m for position. The magnitude can be changed in flight easily using the :ref:`tuning knob<TUNE>` using the 58 option.


### PR DESCRIPTION
The listing of the available options for the system ID SID_AXIS parameter was updated to be a table but not all of the axis settings were included.  This PR updates the table to include the missing position controller axis settings.