### PR TITLE
common_theme_override.css: fix anchor link positioning

### DIFF
--- a/common/source/_static/common_theme_override.css
+++ b/common/source/_static/common_theme_override.css
@@ -54,11 +54,8 @@ table.partners-table td {
     }
 }
 
-/* wiki top menu makes anchor links disappear under it, this hack fixes it */
-.section {
-    padding-top: 40px;
-    margin-top: -40px;
-}
+/* account for wiki top menu when jumping to anchor links */
+:target { scroll-margin-top: 40px; }
 
 /* make certain toc sidebar items red */
 .wy-menu .toctree-l1 a[href*="arduplane-setup.html"],


### PR DESCRIPTION
The existing "hack" wasn't working for me (anchor links were still ending up underneath the top menu when jumping to them), and there is [a dedicated feature for this](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top), which has been well-supported by browsers since 2021.