### PR TITLE
Common: fix CAN_D1_PROTOCOL label

### DIFF
--- a/common/source/docs/common-botblox-dronenet.rst
+++ b/common/source/docs/common-botblox-dronenet.rst
@@ -49,7 +49,7 @@ Autopilot Configuration
 See the ``PPP configuration`` and ``ArduPilot Port Configuration`` sections of :ref:`common-network` but in short set these parameters:
 
 - :ref:`CAN_P1_DRIVER <CAN_P1_DRIVER>` = 1 (First driver)
-- :ref:`CAN_D1_DRIVER <CAN_D1_PROTOCOL>` = 1 (DroneCAN)
+- :ref:`CAN_D1_PROTOCOL <CAN_D1_PROTOCOL>` = 1 (DroneCAN)
 - :ref:`NET_ENABLE <NET_ENABLE>` = 1
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 48 (PPP)
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 12500000 (12.5MBaud)

--- a/common/source/docs/common-cubepilot-cubenodeeth.rst
+++ b/common/source/docs/common-cubepilot-cubenodeeth.rst
@@ -60,7 +60,7 @@ Autopilot Configuration
 See the ``PPP configuration`` and ``ArduPilot Port Configuration`` sections of :ref:`common-network` but in short set these parameters:
 
 - :ref:`CAN_P1_DRIVER <CAN_P1_DRIVER>` = 1 (First driver)
-- :ref:`CAN_D1_DRIVER <CAN_D1_PROTOCOL>` = 1 (DroneCAN)
+- :ref:`CAN_D1_PROTOCOL <CAN_D1_PROTOCOL>` = 1 (DroneCAN)
 - :ref:`NET_ENABLE <NET_ENABLE>` = 1
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 48 (PPP)
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 12500000 (12.5MBaud)

--- a/common/source/docs/common-mro-uavcan-adapter-node.rst
+++ b/common/source/docs/common-mro-uavcan-adapter-node.rst
@@ -26,7 +26,7 @@ Setup
 Verify the following parameters are set on your autopilot via your ground station.
 
 - :ref:`CAN_P1_DRIVER<CAN_P1_DRIVER>` = 1 (assuming its on the first CAN bus of the autopilot and will be using the first driver)
-- :ref:`CAN_D1_DRIVER<CAN_D1_PROTOCOL>` = 1 (DroneCAN)(assuming its the first driver)
+- :ref:`CAN_D1_PROTOCOL<CAN_D1_PROTOCOL>` = 1 (DroneCAN)(assuming its the first driver)
 - :ref:`GPS1_TYPE<GPS1_TYPE>` = 9 (DroneCAN) or if it will be the secondary GPS, set instead
 - :ref:`GPS2_TYPE<GPS2_TYPE>` = 9 (DroneCAN)
 - Reboot


### PR DESCRIPTION
This fixes the CAN_D1_PROTOCOL parameter label on three pages.

I've built this locally and it looks OK to me