### PR TITLE
Add notes for PPP and DDS

### DIFF
--- a/common/source/docs/common-network.rst
+++ b/common/source/docs/common-network.rst
@@ -85,6 +85,14 @@ To enable this feature, it first must be present in the autopilot firmware. This
 
 Connect one of the H7 based autopilot's serial ports to the ethernet switch's or Ethernet-to-PPP-adapter's USART port. For optimum performance a serial port with flow control should be used (e.g. normally SERIAL1 or SERIAL2).  If a port without flow control if used, the baud rate may be set as high as 921000
 
+Alternatively, any Linux-based computer with a UART (or USB-UART) can be used with the "pppd" software. An example of the command to run this is:
+
+.. code-block:: bash
+
+    sudo pppd /dev/ttyAMA0 12500000 192.168.144.15:192.168.144.14 crtscts debug noauth nodetach local proxyarp ktune
+
+The above command will take the incoming stream from /dev/ttyAMA0 (at a 12.5M Baudrate) destined for 192.168.144.15 (the local IP of pppd) and defines the remote (the flight controller) as 192.168.144.14.
+
 To configure a serial port for PPP (Serial2 is used in this example):
 
 - set :ref:`SERIAL2_PROTOCOL<SERIAL2_PROTOCOL>` = 48 (PPP) requires a reboot to take effect.

--- a/dev/source/docs/ros2-over-ethernet.rst
+++ b/dev/source/docs/ros2-over-ethernet.rst
@@ -10,6 +10,7 @@ Ensure you have ROS 2 :ref:`installed <ros2>` and have run :ref:`SITL <ros2-sitl
 
 Additionally, make sure you understand the :ref:`basics of networking in ArduPilot. <common-network>`
 
+.. note:: ROS2 (via DDS) is not part of the standard ArduPilot build. Use the `Custom Build Server <https://custom.ardupilot.org/add_build>`__ and ensure "MicroXRCE DDS support for ROS 2" is checked.
 
 Motivation
 ==========

--- a/dev/source/docs/ros2-pi.rst
+++ b/dev/source/docs/ros2-pi.rst
@@ -4,6 +4,8 @@
 ROS 2 on Raspberry Pi
 =====================
 
+.. note:: ROS2 (via DDS) is not part of the standard ArduPilot build. Use the `Custom Build Server <https://custom.ardupilot.org/add_build>`__ and ensure "MicroXRCE DDS support for ROS 2" is checked.
+
 Purpose
 =======
 


### PR DESCRIPTION
This adds in 2 things:
* Method to run a ppp link from a Linux-based computer (thanks to https://discuss.ardupilot.org/t/guide-for-using-dds-over-ppp-with-a-raspberry-pi-4-companion-computer/126128)
* Add notes about DDS (ROS2) not being in standard ArduPilot builds (see https://github.com/ArduPilot/ardupilot/pull/30835 for background)