### PR TITLE
Update Sphinxsetup.sh to support MacOS

### DIFF
--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -7,12 +7,40 @@ if [ "$UID" -eq 0 ]; then
      exit 1
 fi
 
-DISTRIBUTION_ID=$(lsb_release -i -s)
+# Check for lsb_release and set distribution variables safely
+if command -v lsb_release &> /dev/null; then
+    DISTRIBUTION_ID=$(lsb_release -i -s)
+    DISTRIBUTION_CODENAME=$(lsb_release -c -s)
+else
+    DISTRIBUTION_ID=""
+    DISTRIBUTION_CODENAME=""
+fi
+
 if [ ${DISTRIBUTION_ID} = 'Ubuntu' ]; then
-  DISTRIBUTION_CODENAME=$(lsb_release -c -s)
   if [ ${DISTRIBUTION_CODENAME} = 'focal' ] || [ ${DISTRIBUTION_CODENAME} = 'bionic' ]; then
     sudo add-apt-repository universe
   fi
+fi
+
+# Check for macOS
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Detected macOS. Installing dependencies using Homebrew."
+    # Check for Homebrew and install if missing
+    if ! command -v brew &> /dev/null; then
+        echo "Homebrew not found. Installing Homebrew."
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"
+    fi
+    brew update
+    brew install git imagemagick curl wget make python3 unzip
+    # Ensure pip is available
+    if ! command -v pip3 &> /dev/null; then
+        python3 -m ensurepip --upgrade || true
+    fi
+    SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
+    python3 -m pip install --user --upgrade -r "$SCRIPT_DIR"/requirements.txt
+    echo "Setup completed successfully for macOS!"
+    exit 0
 fi
 
 sudo apt-get -y update


### PR DESCRIPTION
Adding update for script to run on MacOS. 

Changes done for countering errors raised especially running on MacOS

```
+ '[' 501 -eq 0 ']'
++ lsb_release -i -s
./Sphinxsetup.sh: line 10: lsb_release: command not found
+ DISTRIBUTION_ID=
```
additions added from Line 24 to Line 44. 

The code checks for MacOS and checks for homebrew and uses brew to install relevant scripts