### PR TITLE
Update common-stores.rst with VECROS Store link

### DIFF
--- a/common/source/docs/common-stores.rst
+++ b/common/source/docs/common-stores.rst
@@ -45,6 +45,7 @@ recommended for use with ArduPilot (in alphabetical order).  You may also want t
 * `UnmannedTech UK <https://www.unmannedtechshop.co.uk/>`__
 * `uAvionix <https://uavionix.com/>`__
 * `UAV Systems International <https://uavsystemsinternational.com/collections/all>`__
+* `VECROS <https://store.vecros.com>`_
 * `VimDrones <https://shop.vimdrones.com/>`__
 * `ZeroOne <https://www.01aero.com/>`__
 


### PR DESCRIPTION
VECROS is developing carrier boards for the jetson and CM4 modules along with PIXHAWK standard.

[https://store.vecros.com/products/jetcore-flight-controller-board](https://store.vecros.com/products/jetcore-flight-controller-board)