### PR TITLE
Add SBG support to external AHRS documentation

### DIFF
--- a/common/source/docs/common-external-ahrs.rst
+++ b/common/source/docs/common-external-ahrs.rst
@@ -14,6 +14,7 @@ Currently, ArduPilot supports these systems:
 - `MicroStrain 3DM® Series <https://www.microstrain.com/inertial-sensors/all-sensors>`_
 - `VectorNav <https://www.vectornav.com/products>`__
 - `Inertialabs INS-P <https://inertiallabs.com/wp-content/uploads/2023/09/INS-B-P-D-DL_Datasheet_rev-6.27_August_2023.pdf>`__
+- `SBG <https://www.sbg-systems.com/ins/>`__
 
 Setup and Configuration
 =======================
@@ -34,16 +35,16 @@ VectorNav
 ---------
 Refer to :ref:`common-external-ahrs-vectornav` for setup.
 
-MicroStrain
+
+MicroStrain or SBG
 -----------
 
     - :ref:`AHRS_EKF_TYPE<AHRS_EKF_TYPE>` = 11 (External AHRS)
 
-    - :ref:`EAHRS_TYPE<EAHRS_TYPE>` = 1 (VectorNAV), 2 (MicroStrain5), 5(InertialLabs), or 7(MicroStrain7)
+    - :ref:`EAHRS_TYPE<EAHRS_TYPE>` = 1 (VectorNAV), 2 (MicroStrain5), 5(InertialLabs), or 7(MicroStrain7), or 8(SBG)
 
 This will replace ArduPilot’s internally generated INS/AHRS subsystems with the external system.
-The MicroStrain system must be configured via `Sensor Connect <https://www.microstrain.com/software/sensorconnect>`__ before use.
-See the below section on data rates.
+The MicroStrain system must be configured via `Sensor Connect <https://www.microstrain.com/software/sensorconnect>`__, or the SBG configured via `sbgCenter <https://www.sbg-systems.com/softwares/sbgcenter>`__, before use. See the below section on data rates.
 
 
 MicroStrain7


### PR DESCRIPTION
Updated the external AHRS documentation to include SBG as an option and added configuration instructions.