### PR TITLE
Update common-aedroxh7.rst

### DIFF
--- a/common/source/docs/common-aedroxh7.rst
+++ b/common/source/docs/common-aedroxh7.rst
@@ -50,7 +50,7 @@ The default RC input is configured on the UART3 (RX3/SBUS). Non SBUS,  single wi
 
 OSD Support
 ===========
-Onboard OSD using OSD_TYPE 1 (MAX7456 driver) is supported by default. Simultaneously, DisplayPort OSD is available by default on the HD VTX connector.
+DisplayPort OSD is available by default on the HD VTX connector.
 
 VTX Support
 ===========


### PR DESCRIPTION
There is no analog OSD on the board only HD through SERIAL8, so we removed the MAX7456 mention