### PR TITLE
common-uavcan-escs: Add link to Velocity ESC

### DIFF
--- a/common/source/docs/common-uavcan-escs.rst
+++ b/common/source/docs/common-uavcan-escs.rst
@@ -17,6 +17,7 @@ List of DroneCAN ESCs
 
 
 - :ref:`AM32 DroneCAN ESCs <common-am32-escs>`
+- :ref:`Currawong Enginering Velocity ESCs <common-velocity-can-escs>`
 - :ref:`Hargrave Technologies DroneCAN ESCs <common-hargrave-dronecan-escs>`
 - :ref:`Hobbywing CAN ESCs <common-hobbywing-dronecan-esc>`
 - `Holybro Kotleta20 <https://holybro.com/products/kotleta20>`__

--- a/common/source/docs/common-velocity-can-escs.rst
+++ b/common/source/docs/common-velocity-can-escs.rst
@@ -31,7 +31,7 @@ PiccoloCAN Setup
 
 .. note::
 
-    The Velocity ESC uses the PiccoloCAN protocol. Originally developed for the Piccolo autopilot, the protocol is now natively supported by ArduPilot 
+    The Velocity ESC supports the PiccoloCAN protocol. Originally developed for the Piccolo autopilot, the protocol is now natively supported by ArduPilot 
 
 ArduPilot Configuration
 =======================


### PR DESCRIPTION
This PR adds a link from the "Drone CAN ESCs" page to the (already existing) page for the Currawong Engineering Velocity DroneCAN ESCs:

Ref: https://currawong.aero/velocity

