### PR TITLE
Update guide for uploading firmware from Windows with WSL

### DIFF
--- a/dev/source/docs/building-setup-windows11.rst
+++ b/dev/source/docs/building-setup-windows11.rst
@@ -37,7 +37,7 @@ Windows files can be from within WSL2 using a file explorer such as ``nautilus``
 Uploading to a board using WSL2
 ===============================
 
-Uploading to boards (e.g. ``./waf plane --upload``) in WSL2 is possible using `usbipd <https://learn.microsoft.com/es-es/windows/wsl/connect-usb>`__. You need to run the usbipd attach command with the flag ``-a``, beacuase the board will connect and disconnect several times during the upload process. The ``-a`` flag ensures the board automatically reconnects.
+Uploading to boards (e.g. ``./waf plane --upload``) in WSL2 is possible using `usbipd <https://learn.microsoft.com/en-us/windows/wsl/connect-usb>`__. You need to run the usbipd attach command with the flag ``-a``, beacuase the board will connect and disconnect several times during the upload process. The ``-a`` flag ensures the board automatically reconnects.
 
 ::
 


### PR DESCRIPTION
The older guide mentioned that it was not possible to upload firmware through the USBIPD tool using WSL2 on windows. I just tried it and it worked fine. The only weird thing is that you have to add the -a flag to the usbipd attach command because that ensures that the board reconnects automatically into WSL.

I changed the description of the guide on the section Uploading to a board using WSL2