### PR TITLE
4.7/29843/roll limits option

### DIFF
--- a/plane/source/docs/flight-options.rst
+++ b/plane/source/docs/flight-options.rst
@@ -25,7 +25,8 @@ Flight Options
 11                                      Disable suppression of fixed wing rate gains in ground mode.
 12                                      Enable FBWB style loiter altitude control if STICK_MIXING is enabled.
 14                                      In AUTO, climb to next waypoint altitude immediately instead of linear climb.
-15                                      Use minimum of target and actual speed for flap setting
+15                                      Use minimum of target and actual speed for flap setting.
+16                                      Enable full aerodynamic load factor-based roll limits. This should be enabled when an accurate and well calibrated airspeed sensor is used to impose the correct FBW roll limits when the aircraft is turning. Requires an enabled airspeed sensor and AIRSPEED_STALL set. WARNING: If your airspeed sensor is very inaccurate or fails, having this enabled may result in almost no roll maneuverability in FBW modes.
 =====================================   ======================
 
 Default is no options enabled ("0"). Setting the bit will enable that function. For example, if forcing target airspeed in FBWB and CRUISE modes is desired, a value of "8" (bit 3 = 1) would be set.


### PR DESCRIPTION
Fixed minor punctuation and consistency issues, and updated the contents to include bits 15 and 16. The addition of bit 16 is the wiki change needed for ArduPilot/ardupilot#29843.