### PR TITLE
Copter: zigzag mode supports takeoff

### DIFF
--- a/copter/source/docs/zigzag-mode.rst
+++ b/copter/source/docs/zigzag-mode.rst
@@ -11,9 +11,9 @@ ZigZag mode is a semi-autonomous mode designed to make it easier for a pilot to 
 
 The way it works is:
 
-- A two or preferably three position :ref:`auxiliary switch <channel-7-and-8-options>` is set to "ZigZag SaveWP" (i.e. :ref:`RC7_OPTION <RC7_OPTION>` = 61)
-- The pilot arms the vehicle in :ref:`Loiter <loiter-mode>` mode, takes off and then changes to ZigZag mode (in the future we may make it possible to arm and take-off in ZigZag mode)
-- The vehicle is flown manually (it flies like :ref:`Loiter <loiter-mode>`) to one side of the field and then the auxiliary switch is moved to the highest or lowest position (it doesn't matter which) to record that side
+- A two or three position :ref:`auxiliary switch <channel-7-and-8-options>` is set to 61 / "ZigZag SaveWP" (i.e. :ref:`RC7_OPTION <RC7_OPTION>` = 61)
+- The pilot arms the vehicle and takes off.  The vehicle will fly just like :ref:`Loiter <loiter-mode>`
+- The vehicle is flown manually to one side of the field and then the auxiliary switch is moved to the highest or lowest position (it doesn't matter which) to record that side
 - The vehicle is flown to the other side of the field and the switch is moved to the opposite position
 - The switch can now be used to start the vehicle flying autonomously (at the current height) to either side of the field.  Once the vehicle reaches the other side it will revert to manual control.  The pilot can also regain manual control by moving the auxiliary switch to the middle position or by changing the flight mode.
 - If a downward facing :ref:`range finder <common-rangefinder-landingpage>` is used, the vehicle will follow the terrain when flying.  If the range finder becomes unhealthy while traversing from one side to the other, the vehicle will revert to manual control and come to a stop.


### PR DESCRIPTION
This corrects the description of how ZigZag works to reflect that we now support arming and taking off in ZigZag (and have for some time).

I've built this locally and it looks OK to me