### PR TITLE
Reform ros2 launch in ROS2-SITL

### DIFF
--- a/dev/source/docs/ros2-sitl.rst
+++ b/dev/source/docs/ros2-sitl.rst
@@ -18,7 +18,19 @@ You will need to run this command on every new shell you open to have access to 
         cd ~/ardu_ws/
         colcon build --packages-up-to ardupilot_sitl
         source install/setup.bash
-        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
+        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py \
+        transport:=udp4 \
+        refs:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/dds_xrce_profile.xml \
+        synthetic_clock:=True \
+        wipe:=False \
+        model:=quad \
+        speedup:=1 \
+        slave:=0 \
+        instance:=0 \
+        defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm \
+        sim_address:=127.0.0.1 \
+        master:=tcp:127.0.0.1:5760 \
+        sitl:=127.0.0.1:5501
 
 
    .. group-tab:: ArduPilot 4.6 and later
@@ -29,7 +41,18 @@ You will need to run this command on every new shell you open to have access to 
         cd ~/ardu_ws/
         colcon build --packages-up-to ardupilot_sitl
         source install/setup.bash
-        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py transport:=udp4 synthetic_clock:=True wipe:=False model:=quad speedup:=1 slave:=0 instance:=0 defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm sim_address:=127.0.0.1 master:=tcp:127.0.0.1:5760 sitl:=127.0.0.1:5501
+        ros2 launch ardupilot_sitl sitl_dds_udp.launch.py \
+        transport:=udp4 \
+        synthetic_clock:=True \
+        wipe:=False \
+        model:=quad \
+        speedup:=1 \
+        slave:=0 \
+        instance:=0 \
+        defaults:=$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/copter.parm,$(ros2 pkg prefix ardupilot_sitl)/share/ardupilot_sitl/config/default_params/dds_udp.parm \
+        sim_address:=127.0.0.1 \
+        master:=tcp:127.0.0.1:5760 \
+        sitl:=127.0.0.1:5501
 
 
 


### PR DESCRIPTION
split up ros2 launch commands into multiple lines, as it is originated from [ZhongmouLi:ROS2_SITL](https://github.com/ArduPilot/ardupilot_wiki/pull/7183#issue-3523511036)