### PR TITLE
Common: watchdog reporting clarified

### DIFF
--- a/common/source/docs/common-watchdog.rst
+++ b/common/source/docs/common-watchdog.rst
@@ -4,18 +4,40 @@
 Independent Watchdog and Crash Dump
 ===================================
 
-In ArduPilot 4.0 and later firmware revisions, the autopilot cpu's internal independent watchdog has been enabled. It can be disabled (NOT recommended!) by setting :ref:`BRD_OPTIONS<BRD_OPTIONS>` = 0. The cpu will be reset if a peripheral or code takes too long to complete its scheduled software thread or "hangs" the cpu, and will restart the cpu. This may or may not save the vehicle if in flight or motion.
+ArduPilot enables the autopilot CPU's internal independent watchdog which causes the CPU to be reset and restarted if a peripheral or some piece of code takes too long to complete or "hangs" the CPU.  This may or may not save the vehicle if in flight or motion.
 
-.. warning:: In the case of a "HARD FAULT" (illegal instruction, out of bounds memory access,etc.) instead of a delay in completing a thread in timely manner, before resetting, the code will attempt to write a file called crash_dump.bin in the flash capturing the cpu state and registers for later analysis (See section below for more details). A "HARD FAULT" is extremely serious and should be reported to ArduPilot. The vehicle is probably not safe to fly until the cause is resolved.
+While not recommended, this feature can be disabled by setting :ref:`BRD_OPTIONS<BRD_OPTIONS>` = 0.
 
+In the case of a "HARD FAULT" (e.g an illegal instruction, out of bounds memory access, etc.) before resetting, the watchdog handler code will log a "WDG" message to the onboard log, send a "WDG" text message to the GCS and attempt to write a crash_dump.bin file to the "@SYS" flash area.  This crash_dump.bin file contains the cpu state and registers for later analysis (See section below for more details). A "HARD FAULT" is extremely serious and should be reported to ArduPilot. The vehicle is probably not safe to fly until the cause is resolved.
+
+In ArduPilot-4.5.1 (and higher), if a crash_dump.bin file has been created, a pre-arm failure will warn the user and prevent arming.  The crash_dump.bin file can be erased by re-flashing the ArduPilot firmware to the autopilot or it can be ignored by setting the :ref:`ARMING_CRSDP_IGN<ARMING_CRSDP_IGN>` param to 1 (not recommended).
 
 .. youtube:: ZGuTIPLI_e0
+
+.. _crash_dump:
+
+Reporting a Watchdog / Crash Dump
+=================================
+
+Use Mission Planner or another GCS to download the crash_dump.bin file from the "@SYS" flash area.
+
+.. image:: ../../../images/crash_dump.png
+    :target: ../_images/crash+dump.png
+
+Download the dataflash log from the flight or operation that caused the crash dump to be created.  Information on downloading logs can be found :ref:`here <common-downloading-and-analyzing-data-logs-in-mission-planner>`.
+
+If the dataflash log cannot be found, find the git-hash of the firmware.  This appears in the GCS's messages tab soon after startup.
+
+.. image:: ../../../images/git-hash.png
+   :target: ../_images/git-hash.png
+
+Open `ArduPilot's support forum <https://discuss.ardupilot.org/>`__, find the category for your vehicle and software version (e.g. `Copter-4.6 <https://discuss.ardupilot.org/c/arducopter/copter-46/179>`__, `Plane-4.6 <https://discuss.ardupilot.org/c/arduplane/plane-4-6/182>`__, `Rover-4.6 <https://discuss.ardupilot.org/c/ardurover/rover-46/180>`__),
+create a "New Topic", include "watchdog" in the title and attach the crash_dump.bin file, log file and/or git-hash as described above.  If the files cannot be uploaded directly, please include a link to where they can be downloaded from.
 
 Determining that a Watchdog Reset Occurred
 ==========================================
 
 One way is by looking at the dataflash logs. If the log is filtered to show only the "MSG" messages it can be seen that some include the word, "watchdog". This is a clear indication that the previous log or flight ended with a watchdog reset.
-
 
 .. image:: ../../../images/watchdog.png
      :target: ../_images/watchdog.png
@@ -46,20 +68,3 @@ A WDOG log message should also appear with the following columns that may be use
 - FA : Fault Address (in memory).  For example this would be 0 in case an attempt was made to read a byte using a nullptr
 - FP : Thread Priority (see list of priorities starting with APM_MONITOR_PRIORITY in `AP_HAL_ChibiOS/Scheduler.h <https://github.com/ardupilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/Scheduler.h#L25>`__)
 - ICSR : Interrupt Control and State Register (see "ICSR bit assignments" in ST datasheets)
-
-.. _crash_dump:
-
-CRASH DUMP
-==========
-
-On a "HARD FAULT", a file will be attempted to be written to the "@SYS" flash area as "crash_dump.bin" containing needed system state information for later diagnosis. This file can be downloaded using Misssion Planner or other GCS for forwarding to ArduPilot, either by `forum <https://discuss.ardupilot.org/>`__ or :ref:`Discord <ardupilot-discord-server>` post.
-
-.. image:: ../../../images/crash_dump.png
-    :target: ../_images/crash+dump.png
-
-In addition to the crash_dump.bin file, the preceding dataflash log or the git-hash of the firmware that caused the crash dump should be included in the post of the file.
-
-.. image:: ../../../images/git-hash.png
-   :target: ../_images/git-hash.png
-
-As of version 4.5.1, if a crash_dump.bin file has been created, a pre-arm failure will be activated to warn the user of the crash dump so that it may be reported. The pre-arm may be cleared by either re-flashing firmware to the autopilot or by setting the :ref:`ARMING_CRSDP_IGN<ARMING_CRSDP_IGN>` param to 1 (not recommended).


### PR DESCRIPTION
This attempts to resolve issue https://github.com/ArduPilot/ardupilot/issues/31404 by making it more clear to users how to to report, erase or ignore the crash dump file

This has been tested locally and it looks OK to me.  I've also done some drive-by changes to wording on the page to fix grammatical errors and make it more succinct.

I've built this locally and it looks OK to me