### PR TITLE
Common: rplidar recommends loop rate of 400 for rovers

### DIFF
--- a/common/source/docs/common-rplidar-a2.rst
+++ b/common/source/docs/common-rplidar-a2.rst
@@ -52,4 +52,8 @@ It may be necessary to turn off flow control if using Telem1 (aka Serial1) or Te
 - :ref:`BRD_SER1_RTSCTS <BRD_SER1_RTSCTS>` =  "0" if using Serial1
 - :ref:`BRD_SER2_RTSCTS <BRD_SER2_RTSCTS>` =  "0" if using Serial2
 
+On rovers and boats it may be necessary to increase the main loop rate to 400 in order to reliably consume all the data from the sensor
+
+- :ref:`SCHED_LOOP_RATE <SCHED_LOOP_RATE>` =  "400"
+
 More details on using this sensor for object avoidance on Copter can be found :ref:`here <common-object-avoidance-landing-page>`.


### PR DESCRIPTION
This adds a recommendation that the main loop rate be increased to 400 on rovers and boats in order to consume all the data from the sensor.

This is the result of [this support discussion](https://discuss.ardupilot.org/t/object-avoidance-bug/140929)

We don't need to recommend this for Plane because it doesn't support proximity sensors as far as I know

I've tested this locally and it looks OK to me