### PR TITLE
sub: leak-failsafe: clarify GPIO requirement

### DIFF
--- a/common/source/docs/common-flight-controller-io.rst
+++ b/common/source/docs/common-flight-controller-io.rst
@@ -135,6 +135,8 @@ Input from the radio control receiver is input on this pin. Most serial RC proto
 
 As of firmware versions 4.0 and later, ArduPilot also allows an RC receiver to be attached to any UART port.
 
+.. _main-aux-out:
+
 MAIN/AUX/OUT
 ------------
 

--- a/sub/source/docs/internal-leak-failsafe.rst
+++ b/sub/source/docs/internal-leak-failsafe.rst
@@ -10,11 +10,13 @@ For the remainder of this article, the first leak detector's parameters will use
 
 When the failsafe will trigger
 ==============================
-If :ref:`FS_LEAK_ENABLE<FS_LEAK_ENABLE>` is non-zero, and a detector is attached to either an analog input or GPIO pin on the autopilot, set by the :ref:`LEAK1_PIN<LEAK1_PIN>`. Then if the detector is analog , it's considered active ("1") if its voltage is > 2.0V. Digital sensors present a normal digital logic level.
+If :ref:`FS_LEAK_ENABLE<FS_LEAK_ENABLE>` is non-zero, and a detector is attached to either an analog input or GPIO pin on the autopilot, set by the :ref:`LEAK1_PIN<LEAK1_PIN>`. Then if the detector is analog, it's considered active ("1") if its voltage is > 2.0V. Digital sensors present a normal digital logic level.
 
 Whether the active level of an analog sensor or the logic level from a digital sensor is taken as "dry" is determined by the :ref:`LEAK1_LOGIC<LEAK1_LOGIC>` parameter.
 
 .. note:: In ArduSub firmware prior or equal to 4.5, the input pin must be declared to be analog or digital with the ``LEAKx_TYPE`` parameter.
+
+.. note:: Digital leak detectors should be connected to digital input pins. Some flight controllers support that on :ref:`servo channel ports <main-aux-out>`, in which case the relevant channel(s) must be configured as :ref:`common-gpios`.
 
 What will happen
 ================
@@ -22,4 +24,4 @@ When the failsafe occurs, the action taken is determined by the value of :ref:`F
 
 -  **Disabled** (Value 0) will disable the failsafe entirely.
 -  **Warn Only** (Value 1) will send a GCS warning message.
--  **Enter SURFACE Mode** (Value 2).
+-  **Enter SURFACE Mode** (Value 2) will send a warning and return the vehicle to the surface.


### PR DESCRIPTION
Ran into some user confusion, because `AUX6` on Pixhawk used to be the default leak sensor port for ArduSub, but when they updated to 4.5 it wasn't working anymore because the output wasn't assigned as a GPIO (thanks to the removal of `BRD_PWM_COUNT`). We're going to be working on ArduSub detecting and dealing with this, but it also seems relevant to document how users are supposed to configure it in the first place.

This approach was the most straightforward way I could think of linking these things without going into detail about specific flight controller boards, or `SERVO_GPIO_MASK` shenanigans...

## Change Preview:
<img width="705" height="109" alt="Screenshot 2025-12-02 at 5 01 14 pm" src="https://github.com/user-attachments/assets/d8d6351d-8473-4ee8-bf4b-14dad7cb83dc" />