### PR TITLE
Sub: modes: fix motordetect requirements

### DIFF
--- a/sub/source/docs/modes.rst
+++ b/sub/source/docs/modes.rst
@@ -19,7 +19,7 @@ GUIDED          Swim to location or velocity/direction using GCS    P/D
 CIRCLE          Circle swim with depth control                      P/D
 SURFACE         Return to surface, pilot directional control        \-
 POSHOLD         Loiter with depth control and pilot overrides       P/D
-MOTOR_DETECT    Automatically determine motor rotation and adjust   D
+MOTOR_DETECT    Automatically determine motor rotation and adjust   \-
 SURFTRAK        Hold distance above seafloor while stabilizing      R
 =============   =================================================  =========
 


### PR DESCRIPTION
I was reading [the implementation](https://github.com/ArduPilot/ardupilot/blob/master/ArduSub/mode_motordetect.cpp#L88-L131) and saw it only actually uses the gyroscope, so no depth sensor is required.