### PR TITLE
reference-frames-hexsoon: fix URL typo

### DIFF
--- a/copter/source/docs/reference-frames-hexsoon-edu450.rst
+++ b/copter/source/docs/reference-frames-hexsoon-edu450.rst
@@ -36,7 +36,7 @@ Connection and Setup
 
 Connect the four ESC wires to the back of the autopilot as shown in the :ref:`QuadX configuration <connect-escs-and-motors>`
 
-Parameter file: `hexsoon-edu450.param <https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/hexsoon-edu450.param>`__
+Parameter file: `hexsoon-edu450.param <https://github.com/ArduPilot/ardupilot/blob/master/Tools/Frame_params/Hexsoon-edu450.param>`__
 
 This parameter file can also be loaded using the Mission Planner's Config/Tuning >> Full Parameter Tree page by selecting "hexsoon-edu450" from the drop down on the middle right and then push the "Load Presaved" button.
 


### PR DESCRIPTION
URL without proper capitalization leads to 404 error.