### PR TITLE
Dev: add video to BlueOS setup page

### DIFF
--- a/dev/source/docs/companion-computer-blueos.rst
+++ b/dev/source/docs/companion-computer-blueos.rst
@@ -34,3 +34,9 @@ Please follow the links below for detailed setup instructions.
     BlueOS Installation <companion-computer-blueos-install>
     BlueOS 4G/LTE Telemetry Setup <companion-computer-blueos-lte-telem>
     BlueOS Live Video Setup <companion-computer-blueos-live-video>
+
+Videos
+------
+
+..  youtube:: 3ZNHjfyfxRY
+    :width: 100%


### PR DESCRIPTION
This adds a BlueOS & ArduPilot setup video to the developer wiki's page which I hope will make it easier for people who like videos over wiki pages to setup BlueOS with ArduPilot

I've tested this locally and it looks OK to me.