### PR TITLE
Copter: Fix reference

### DIFF
--- a/common/source/docs/common-tbs-rc.rst
+++ b/common/source/docs/common-tbs-rc.rst
@@ -43,7 +43,7 @@ ELRS MAVLink Configuration
 Instead of CRSF protocol, MAVLink protocol can be used. In this case, using SERIAL 4 for example:
 
 - Set :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 2
-- Set :ref:SERIAL4_BBAUD <SERIAL4_BAUDL>` = 460
+- Set :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 460
 - Set :ref:`RSSI_TYPE <RSSI_TYPE>` = 5
 
 If the ELRS transmitter module has WIFI capability, then the telemetry data can be forwarded wirelessly to a PC or phone based GCS close to the transmitter.


### PR DESCRIPTION
While fixing, also noticed 
```
ELRS MAVLink Configuration
--------------------------

Instead of CRSF protocol, MAVLink protocol can be used. In this case, using SERIAL 4 for example:

- Set :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 2
- Set :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 460
- Set :ref:`RSSI_TYPE <RSSI_TYPE>` = 5

If the ELRS transmitter module has WIFI capability, then the telemetry data can be forwarded wirelessly to a PC or phone based GCS close to the transmitter.

MAVLink Option
--------------

In addition to SBUS and CRSF protocols, ELRS can be configured to use MAVLink protocol for telemetry and embedded RC control. To utilize this attach to SERIAL port 4(as an example) and configure:

- Set :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 2
- Set :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 460
- Set :ref:`RSSI_TYPE <RSSI_TYPE>` =  5

If the ELRS transmitter module has WIFI, the MAVLink telemetry can be wirelessly forwarded to a phone or PC GCS.
```

this seems duplicated, can top one be removed?