### PR TITLE
dev: events: update with latest conference info

### DIFF
--- a/dev/source/docs/events.rst
+++ b/dev/source/docs/events.rst
@@ -1,7 +1,7 @@
 .. _events:
     
 ===============
-Events for 2025
+Events for 2026
 ===============
 
 This is a list of events where ArduPilot developers and/or their `Partners <https://ardupilot.org/about/Partners>`__ can be found
@@ -9,11 +9,12 @@ This is a list of events where ArduPilot developers and/or their `Partners <http
 Planned Events
 --------------
 
-- Sep 5th ~ 7th 2025: Developer conference in Yorkshire, UK (`blog <https://discuss.ardupilot.org/t/ardupilot-developer-conference-2025-september-5th-7th-in-yorkshire-uk/128501>`__)
+- Oct (Early ~ Mid), 2026: Developer conference in Ottawa, Canada (`blog <https://discuss.ardupilot.org/t/ardupilot-developer-conference-2026-in-ottawa-canada-october/140736>`__)
 
 Past Events
 -----------
 
+- Sep 5th ~ 7th 2025: Developer conference in Yorkshire, UK (`blog <https://discuss.ardupilot.org/t/ardupilot-developer-conference-2025-september-5th-7th-in-yorkshire-uk/128501>`__, `YouTube playlist <https://www.youtube.com/playlist?list=PLC8WVaJJhN4w40Wj7yI_a5uAwLoPFYskA>`__)
 - Oct 25th ~ Oct 27th 2024: Developer Un-conference in Kaga, Japan (`blog <https://discuss.ardupilot.org/t/ardupilot-developer-conference-oct-25th-27-2024-in-kaga-japan/119429>`__, `YouTube playlist <https://www.youtube.com/watch?v=sHcuWj9yVlI&list=PLC8WVaJJhN4xkTfPRU9zf7VmhkbbezzSd>`__)
 - Mar 31st ~ Apr 2nd 2023: Developer Un-conference in Canberra, Australia (`discussion <https://discuss.ardupilot.org/t/ardupilot-developer-conference-2023/91558>`__)
 - Apr 8th ~ 10th 2022: Developer Un-conference in Canberra, Australia (`blog <https://discuss.ardupilot.org/t/ardupilot-developer-conference-2022>`__)


### PR DESCRIPTION
Saw this was outdated, so:
1. Moved the 2025 dev conference to "past events"
2. Added the YouTube playlist link for it
3. Added the latest info we have about the 2026 dev conference
4. Updated the page title from 2025 -> 2026