### PR TITLE
Add missing Optitrack parameters to MAVProxy documentation

### DIFF
--- a/mavproxy/source/docs/modules/optitrack.rst
+++ b/mavproxy/source/docs/modules/optitrack.rst
@@ -14,11 +14,13 @@ It is assumed that the server is using the default ports of 1510 and 1511.
 
 Use ``optitrack start`` to start sending position data.
 
-==================   ===============================================  ===============================
-Setting              Description                                      Default
-==================   ===============================================  ===============================
-server               IP address of server                             127.0.0.1
-client               IP address of client                             127.0.0.1
-msg_intvl_ms         How often to send position updates (ms)          75
-obj_id               Mocap object ID                                  1
-==================   ===============================================  ===============================
+==================   =========================================================  ===============================
+Setting              Description                                                Default
+==================   =========================================================  ===============================
+server               IP address of server                                       127.0.0.1
+client               IP address of client                                       127.0.0.1
+msg_intvl_ms         How often to send position updates (ms)                    75
+obj_id               Mocap object ID                                            1
+print_lv             Print level (0=off, 1=on, >1=print every nth mocap frame)  0
+multicast            Use multicast                                              True
+==================   =========================================================  ===============================


### PR DESCRIPTION
This PR updates the MAVProxy Optitrack documentation to include two missing parameters:

* `print_lv`: controls debug output verbosity
* `multicast`: enables/disables multicast reception