### PR TITLE
Dev: Add missing GStreamer plugins for Gazebo video streaming

### DIFF
--- a/dev/source/docs/sitl-with-gazebo.rst
+++ b/dev/source/docs/sitl-with-gazebo.rst
@@ -97,7 +97,7 @@ is hosted on GitHub at: `https://github.com/ArduPilot/ardupilot_gazebo <https://
 
         sudo apt update
         sudo apt install libgz-sim8-dev rapidjson-dev
-        sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
+        sudo apt install libopencv-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-tools
 
     macOS
 


### PR DESCRIPTION
Added missing GStreamer plugins to installation instructions.