### PR TITLE
Update DDFP tail thrust expo directions

### DIFF
--- a/copter/source/docs/traditional-helicopter-tailrotor-setup.rst
+++ b/copter/source/docs/traditional-helicopter-tailrotor-setup.rst
@@ -42,11 +42,11 @@ The range of the motor ESC is controlled by its output's ``SERVOx_MIN/MAX`` para
 Direct Drive Fixed Pitch :ref:`H_TAIL_TYPE <H_TAIL_TYPE>` = 3 or 4
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The Direct Drive Fixed Pitch (DDFP) tail type uses a fixed pitch tail rotor and separate motor. The stabilization and yaw is controlled by the speed of this motor. It has two options: one where the main rotor rotates clockwise when viewed from above and the other where the main rotor rotates counter-clockwise when viewed from above.  Be sure to select the DDFP tail type for the main rotor rotation.  In this case, the control of tailrotor thrust is accomplished through tailrotor speed since it is a fixed pitch propeller. The ``SERVOx_FUNCTION`` of "36" (Motor4) should be assigned to the servo channel to which the tailrotor ESC is physically connected.
+The Direct Drive Fixed Pitch (DDFP) tail type uses a fixed pitch tail rotor and separate motor. The stabilization and yaw is controlled by the speed of this motor. It has two options: one where the main rotor rotates clockwise when viewed from above and the other where the main rotor rotates counter-clockwise when viewed from above.  Be sure to select the DDFP tail type for the main rotor rotation.  In this case, the control of tailrotor thrust is accomplished through tailrotor speed since it is a fixed pitch propeller. The ``SERVOx_FUNCTION`` of "36" (Motor4) should be assigned to the servo channel to which the tailrotor ESC is physically connected.  On new DDFP setups it is suggested to set ``H_DDFP_THST_EXPO`` to .65 as a starting point.  This will be a good enough thrust expo for most aircraft.
 
 There are several parameters that provide the ability to linearize the thrust produced by the tail rotor motor and therefore provide better control:
 
-- :ref:`H_DDFP_THST_EXPO<H_DDFP_THST_EXPO>` - Tail rotor DDFP motor thrust curve exponent (0.0 for linear to 1.0 for second order curve). Default = 0
+- :ref:`H_DDFP_THST_EXPO<H_DDFP_THST_EXPO>` - Tail rotor DDFP motor thrust curve exponent (0.0 for linear to 1.0 for second order curve). A suggested starting point for tuning this parameter is .65 and will often give better better results than the default. Default = 0 (for legacy compatability reason)
 - :ref:`H_DDFP_SPIN_MIN<H_DDFP_SPIN_MIN>` - Point at which the DDFP motor thrust starts expressed as a number from 0 to 1 in the entire output range.  Default = 0
 - :ref:`H_DDFP_SPIN_MAX<H_DDFP_SPIN_MAX>` - Point at which the DDFP motor thrust saturates expressed as a number from 0 to 1 in the entire output range. Default = 1
 - :ref:`H_DDFP_BAT_IDX<H_DDFP_BAT_IDX>` - Index of battery to be used for voltage compensation. Default = 0.


### PR DESCRIPTION
Added some more detailed guidance on thrust expo settings along with a starting point setting that will be much more affective that default for most new configurations.