### PR TITLE
common: fix link to set-origin lua script

### DIFF
--- a/common/source/docs/common-non-gps-navigation-landing-page.rst
+++ b/common/source/docs/common-non-gps-navigation-landing-page.rst
@@ -37,7 +37,7 @@ These are the available options that allow a vehicle to estimate its position wi
 [/site]
     GPS/Non-GPS Transitions <common-non-gps-to-gps>
 
-.. note:: Most of the above systems (except Beacons) require that the ORIGIN be set manually, except if a GPS is present. In order to do this the user must either use the GCS to set Origin, as shown below using Mission Planner, or use a lua script like this `one <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/examples/ahrs-set-origin.lua>`__
+.. note:: Most of the above systems (except Beacons) require that the ORIGIN be set manually, except if a GPS is present. In order to do this the user must either use the GCS to set Origin, as shown below using Mission Planner, or use a lua script like this `one <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/ahrs-set-origin.lua>`__
 
 .. image:: ../../../images/setorigin.jpg
 


### PR DESCRIPTION
This fixes a link to the set-origin.lua script and resolves issue https://github.com/ArduPilot/ardupilot_wiki/issues/7413

I've tested this locally and it seems OK to me