### PR TITLE
Fix measurement units and update connection instructions

### DIFF
--- a/common/source/docs/common-benewake-tf02-lidar.rst
+++ b/common/source/docs/common-benewake-tf02-lidar.rst
@@ -13,72 +13,72 @@ Benewake provides a range of lidar sensors that use proprietary serial and/or CA
    :widths: 15 15 10 12 10 15
 
    * - Model
-     - Range (Indoor/Outdoor)
+     - Range (Min/Max)
      - Weight
      - Voltage
      - FOV
      - Interface
    * - TF02 (discontinued)
-     - 22m / 10m
+     - 0.22m / 10m
      - 52g
      - 5V
      - 3 deg
      - UART
    * - `TF02-Pro <https://en.benewake.com/TF02Pro/index.html>`__
-     - 40m / 13.5m
+     - 0.40m / 13.5m
      - 50g
      - 5V~12V
      - 3 deg
      - UART
    * - `TF02-i <https://en.benewake.com/TF02i/index.html>`__
-     - 40m / 13.5m
+     - 0.40m / 13.5m
      - 60g
      - 7V~30V
      - 3 deg
      - CAN
    * - `TF03 <https://en.benewake.com/TF03/index.html>`__
-     - 100m / 50m
+     - 1m / 50m
      - 89g
      - 5V~24V
      - 0.5 deg
      - UART, CAN
    * - `TFS20-L <https://en.benewake.com/TFS20L/index.html>`__
-     - 20m / 15m
+     - 0.20m / 15m
      - 2g
      - 3.3V
      - 2 deg
      - UART
    * - `TF-Luna <https://en.benewake.com/TFLuna/index.html>`__
-     - 8m / 3m
+     - 0.80m / 3m
      - 5g
      - 3.7V~5.2V
      - 2 deg
      - UART
    * - `TF-Nova <https://en.benewake.com/tf-nova>`__
-     - 14m / 7m
+     - 0.14m / 7m
      - 5g
      - 5V
      - 14 deg
      - UART
    * - `TF350 <https://en.benewake.com/TF350/index.html>`__
-     - 350m / 150m
+     - 3.5m / 150m
      - 224g
      - 5V~24V
      - 0.35 deg
      - UART, CAN
 
-More details on these lidar can be found in the `benewake.com's downloads area <https://en.benewake.com/DataDownload>`__
+More details on these lidar can be found in the `benewake.com's downloads section <https://en.benewake.com/DataDownload>`__
 
 Where to Buy
 ------------
 
 - `Benewake.com Distributors <https://en.benewake.com/Agent/index.html>`__ including `3DXR <https://www.3dxr.co.uk/sensors-c5/lidar-range-and-flow-sensors-c4>`__ and `Unmanned Tech UK <https://www.unmannedtechshop.co.uk/benewake-tf02-lidar-rangefinder-ip65-22m/>`__
-- `Benewake's store on Alibaba.com <https://beixingguangzi.en.alibaba.com>`__
+- `Benewake's store on Alibaba <https://beixingguangzi.en.alibaba.com>`__
 
 Connecting via Serial
 ---------------------
 
-For a serial connection you can use any spare Serial/UART port.  The diagram below shows how to connect a TF02 to Serial2.  Please note that wire colours may vary by model so please check the datasheet
+For a serial connection you can use any spare Serial/UART port.  The diagram below shows how to connect a TF02 to Serial2.  Please note that wire colours may vary by model so please check the datasheet.
 
 .. image:: ../../../images/benewake-tf02-autopilot-serial.png
     :target: ../_images/benewake-tf02-autopilot-serial.png
@@ -96,19 +96,20 @@ The diagram below shows how to connect a TF-Nova to Serial2
     :target: ../_images/benewake-tfnova-autopilot-serial.png
     :height: 400px
 
-If SERIAL2 is being used then the following parameters should be set for the first rangefinder:
+If SERIAL2 is being used, then use the following parameters to set the first rangefinder:
 
 -  :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` = 9 (Lidar)
 -  :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` = 115 (115200 baud)
--  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (Benewake TF02) for TF02, 27 (Benewake TF03) for TF02-Pro, TF03, TFS20-L, TF-Luna, TF-Nova, TF350
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.1
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>`: for TF02 use **20** for indoor, **10** for outdoor.  For TF03 use **100** for indoor, **50** for outdoor.  Please see table at top of this page for other sensors. *This is the distance in meters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 19 (BenewakeTF02) for TF02, 27 (BenewakeTF03) for TF02-Pro, TF03, TFS20-L, TF-Luna, TF-Nova, TF350.
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = *Use a distance the rangefinder could reliably read in [metres].*  For TF02: **0.22**, for TF03: **1**, or look up the top table of this page for other sensors.
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = *Use a distance the rangefinder could reliably read in [metres].*  For TF02: **10**, for TF03: **50**, or look up the top table of this page for other sensors.
+-  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (Down) *Indicates the position the rangefinder is set to read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *An accurate distance in [metres] from the rangefinder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
 
 Connecting via CAN
 ------------------
 
-The TF02-i, TF03, TFmini-i and TF350 can be connected to the autopilot via CAN1.  The diagram below shows how to connect a TF03 to CAN1.  Please note that wire colours may vary by model so please check the datasheet.
+The TF02-i, TF03, TFmini-i and TF350 can be connected to the autopilot via CAN.  The diagram below shows how to connect a TF03 to CAN1.  Please note that wire colours may vary by model so please check the datasheet.
 
 .. image:: ../../../images/benewake-tf03-autopilot-can.png
     :target: ../_images/benewake-tf03-autopilot-can.png
@@ -118,10 +119,13 @@ If CAN1 is used then set the following parameters:
 
 -  :ref:`CAN_P1_DRIVER <CAN_P1_DRIVER>` = 1 (First driver)
 -  :ref:`CAN_D1_PROTOCOL <CAN_D1_PROTOCOL>` = 11 (Benewake)
--  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 34 (Benewake CAN)
--  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = 0.1
--  :ref:`RNGFND1_MAX <RNGFND1_MAX>`: for TF02-i use **40** for indoor, **13** for outdoor.  For TF03 use **100** for indoor, **50** for outdoor.  Please see table at top of this page for other sensors. *This is the distance in meters that the rangefinder can reliably read.*
--  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *or more accurately the distance in metres from the range finder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+-  :ref:`RNGFND1_TYPE <RNGFND1_TYPE>` = 34 (Benewake_CAN)
+-  :ref:`RNGFND1_MIN <RNGFND1_MIN>` = *Use a distance the rangefinder could reliably read in [metres].*  For TF02-i: **0.4**, for TF03: **1**, or look up the top table of this page for other sensors.
+-  :ref:`RNGFND1_MAX <RNGFND1_MAX>` = *Use a distance the rangefinder could reliably read in [metres].*  For TF02-i: **13.5**, for TF03: **50**, or look up the top table of this page for other sensors.
+-  :ref:`RNGFND1_ORIENT <RNGFND1_ORIENT>` = 25 (Down) *Indicates the position the rangefinder is set to read.*
+-  :ref:`RNGFND1_GNDCLR <RNGFND1_GNDCLR>` = 0.1 *An accurate distance in [metres] from the rangefinder to the ground when the vehicle is landed.  This value depends on how you have mounted the rangefinder.*
+
+.. note:: Check the information at :ref:`common-sensor-offset-compensation` in order to configure the position where the range finder is installed.
 
 Testing the sensor
 ==================


### PR DESCRIPTION
Corrected measurement units from meters to centimeters for various Benewake Lidar models. Updated connection instructions for serial and CAN interfaces.