### PR TITLE
Upgrade Python code linting tool flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
 beautifulsoup4
 
 # Install flake8
-flake8==3.7.9
+flake8==7.3.0

--- a/update.py
+++ b/update.py
@@ -130,7 +130,7 @@ def progress(message, file=sys.stdout, end="\n"):
 
 def error(str_to_print):
     """Show and count the errors."""
-    global error_log
+    global error_log  # noqa: F824
     error_log.append(str_to_print)
     print(f"[update.py][error]: {str_to_print}", file=sys.stderr)
 


### PR DESCRIPTION
```diff
- flake8==3.7.9
+ flake8==7.3.0
```
https://pypi.org/project/flake8

`./update.py:133:5: F824 `global error_log` is unused: name is never assigned in scope`

Add the linter directive `# noqa: F824` because `error_log.append()` modifies the global.
* https://flake8.pycqa.org/en/latest/user/error-codes.html