### PR TITLE
Remove obsolete Python Unicode literal strings

### DIFF
--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'AntennaTracker'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'AntennaTracker'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -247,8 +247,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -277,7 +277,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -291,7 +291,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -48,9 +48,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'ArduPilot'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'ArduPilot'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -240,8 +240,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -270,7 +270,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -284,7 +284,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/blimp/source/conf.py
+++ b/blimp/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Blimp'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Blimp'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -250,8 +250,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -280,7 +280,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -294,7 +294,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Copter'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Copter'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -250,8 +250,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -280,7 +280,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -294,7 +294,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -46,9 +46,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Dev'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Dev'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -240,8 +240,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -270,7 +270,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -284,7 +284,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -46,9 +46,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'MAVProxy'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'MAVProxy'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -243,8 +243,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -273,7 +273,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -287,7 +287,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Plane'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Plane'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -249,8 +249,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -279,7 +279,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -293,7 +293,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -46,9 +46,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Mission Planner'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Mission Planner'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -242,8 +242,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -272,7 +272,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -286,7 +286,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -46,9 +46,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'APM Planner 2'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'APM Planner 2'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -242,8 +242,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -272,7 +272,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -286,7 +286,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Rover'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Rover'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -245,8 +245,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -275,7 +275,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -289,7 +289,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/sub/source/conf.py
+++ b/sub/source/conf.py
@@ -50,9 +50,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'Sub'
-copyright = u'2024, ArduPilot Dev Team'
-author = u'ArduPilot Dev Team'
+project = 'Sub'
+copyright = '2024, ArduPilot Dev Team'
+author = 'ArduPilot Dev Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -247,8 +247,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'ArduPilot.tex', u'ArduPilot Documentation',
-     u'ArduPilot Dev Team', 'manual'),
+    (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
+     'ArduPilot Dev Team', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -277,7 +277,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'ardupilot', u'ArduPilot Documentation',
+    (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
 
@@ -291,7 +291,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'ArduPilot', u'ArduPilot Documentation',
+    (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]


### PR DESCRIPTION
In Python 3, all strings are Unicode by default. The Unicode kind prefix is unnecessary and should be removed to avoid confusion.

% `python3 -c "print(u'ArduPilot Documentation' == 'ArduPilot Documentation')"`
```
True
```
% [`ruff check --select=UP025 --fix`](https://docs.astral.sh/ruff/rules/unicode-kind-prefix)
```
Found 77 errors (77 fixed, 0 remaining).
```
