### PR TITLE
workflows: add spell checker for PR changes

### DIFF
--- a/.github/workflows/extra-pr-checks.yml
+++ b/.github/workflows/extra-pr-checks.yml
@@ -1,0 +1,31 @@
+name: Test Pull Request
+
+on: 
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check-spelling:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install dependencies
+        run: python -m pip install codespell
+      - name: Checkout source
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2  # Fetch the latest state + the PR changes
+      - name: Get modified files
+        id: changed-files
+        run: |
+          echo "changed_files=$(git diff --name-only HEAD^1 HEAD | xargs)" >> $GITHUB_OUTPUT
+      - name: Check spelling of added content
+        run: |
+          # Process additions to each file, and count files that have new lines with errors
+          set +e  # Don't fail early
+          errors=0
+          for file in ${{ steps.changed-files.outputs.changed_files }}; do
+            git diff HEAD^1 HEAD $file | sed -n 's/^\+//p' > addition
+            echo -e "\nChecking $file"
+            codespell addition || ((errors++))
+          done
+          exit $errors


### PR DESCRIPTION
Following on from discussion in #7426, this PR adds a workflow for codespell checking to the lines added[^1] in a PR.

[^1]: "added" can be completely new lines, or modified lines (which diff considers as a deleted line and a new line to replace it). It does not check any removed content.

The idea is that contributors and reviewers/maintainers can evaluate whether errors need fixing on a case-by-case basis, and choose to ignore them if they want to. It does still check the unchanged words in a line that was changed, but that seems unlikely to cause substantial issues or overhead.

Example output can be found [here](https://github.com/ES-Alexander/ardupilot_wiki/actions/runs/22336487140/job/64630075770).

---
As a somewhat related note, it seems [my assumption that codespell works like other spell checkers](https://github.com/ArduPilot/ardupilot_wiki/pull/7426#issuecomment-3944417593) is incorrect, and [in fact](https://github.com/codespell-project/codespell/tree/main?tab=readme-ov-file#codespell:~:text=It%20does%20not%20check%20for%20word%20membership,%20a%20niche%20term%20it%20doesn%27t%20know%20about.):

> It does not check for word membership in a complete dictionary, but instead looks for a set of common misspellings. Therefore it should catch errors like "adn", but it will not catch "adnasdfasdf". This also means it shouldn't generate false-positives when you use a niche term it doesn't know about.

Given that, I agree we should consider @cclauss's idea of re-running it on all/most files at some kind of regular interval, but ideally that should be just when the library version gets updated (when there are likely to be new words in the dictionary). I haven't added it in this workflow, because I don't think PR contributors should need to be flagged for errors unrelated to their changes - if we add that it can be in a dedicated workflow that's independent of the PR process.