### PR TITLE
common: user-alerts: fix broken database link

### DIFF
--- a/common/source/docs/common-user-alerts.rst
+++ b/common/source/docs/common-user-alerts.rst
@@ -15,7 +15,7 @@ User Alerts will only be for ArduPilot software issues. Manufacturer hardware wi
 The User Alert documentation is available on the :ref:`developer wiki <dev:user-alerts-developer>`.
 
 For more information about a specific User Alert, see the `User Alert
-Database <https://firmware.ardupilot.org/userAlerts/alerts.html>`_.
+Database <https://firmware.ardupilot.org/useralerts/alerts.html>`_.
 
 
 .. note::


### PR DESCRIPTION
The original link doesn't work. I'm not sure whether it never worked, or if the source URL has changed since it was first documented.