### PR TITLE
Create README: link to relevant information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# ArduPilot Documentation Source Files
+
+1. See [the wiki site](https://ardupilot.org/ardupilot/index.html) for the human-friendly view
+2. See [the Issues](https://github.com/ArduPilot/ardupilot_wiki/issues) for known missing, incorrect, or outdated content
+    - Submit a new issue if you've found a problem that isn't already listed
+    - DO NOT use the wiki issues for support questions - they will be immediately closed
+        - Instead, chat on [Discord](https://ardupilot.org/dev/docs/ardupilot-discord-server.html) or post on the [Discuss](https://discuss.ardupilot.org/) forum
+3. See [the Pull Requests](https://github.com/ArduPilot/ardupilot_wiki/pulls) for in-progress improvements
+    - See in-progress improvements
+        - Review existing pull requests if you're familiar with the topic(s) being documented
+    - Submit new pull requests for [quick fixes](https://ardupilot.org/dev/docs/common-wiki-editing-quick-edit.html) and/or to resolve Issues
+        - See [the wiki editing guide](https://ardupilot.org/dev/docs/common-wiki_editing_guide.html) for how to make changes, including environment setup
+        - Include `Resolves #ISSUE_NUMBER` in the pull request description if you're fixing a listed Issue
+            - This automatically closes the issue if/when your pull request gets merged
+            - If not fully resolving an issue, include `Relevant to #ISSUE_NUMBER` instead
+        - Pull requests get reviewed by wiki maintainers before they can be accepted - be prepared to discuss and make updates
+    - The wiki site is updated every ~24 hours, and updated parameter tables are generated every 2-3 days


### PR DESCRIPTION
In case someone gets to the repo without knowing their way around the wiki itself, it seems worth having some relevant links and info.

I've currently got two visual approaches for the same info - not sure whether the sections or the numbered list is preferred. [Preview here](https://github.com/ES-Alexander/ardupilot_wiki/tree/add-README?tab=readme-ov-file#ardupilot-documentation-source-files).

Not sure if there's a public link I should add for where/how the wiki site actually gets built.