### PR TITLE
Remove deprecated dependency python-future

### DIFF
--- a/dev/source/docs/building-for-navio2-on-rpi3.rst
+++ b/dev/source/docs/building-for-navio2-on-rpi3.rst
@@ -23,14 +23,6 @@ Setup
 Use an ssh terminal program such as `Putty <http://www.putty.org/>`__ to
 log into the Navio2 board's RPI3.
 
-.. note::
-    
-    On Raspbian Stretch, one of the Python requirements might be missing, so please install future by
-
-::
-
-    pip install future
-
 .. include:: building-setup-linux.rst
     :start-after: Setup on Ubuntu
     :end-before: Setup for other Distributions

--- a/dev/source/docs/building-setup-mac.rst
+++ b/dev/source/docs/building-setup-mac.rst
@@ -39,8 +39,7 @@ Setup steps
    ::
 
        brew update
-       brew install genromfs
-       brew install gcc-arm-none-eabi
+       brew install gcc-arm-none-eabi genromfs python3
 
 #. Install the latest version of awk using brew (make sure
    **/usr/local/bin** takes precedence in your path):
@@ -49,12 +48,11 @@ Setup steps
 
        brew install gawk
 
-#. Install *pip* and *pyserial* using the following commands:
+#. Install *empy* and *pyserial* using the following commands:
 
    ::
 
-       sudo easy_install pip
-       sudo pip install pyserial future empy
+       python3 -m pip install empy pyserial
        
    ::
    


### PR DESCRIPTION
[`python-future`](https://pypi.org/project/future) was deprecated two years ago.
* https://python-future.org/whatsnew.html#what-s-new-in-version-1-0-0-2024-02-21

Remove mention of an end-of-life version of Raspbian.

Use https://docs.python.org/3/library/venv.html as recommended in https://peps.python.org/pep-0668

Upgrade to a non-EOL version of Python as discussed at https://devguide.python.org/versions

Apply [`ruff rule UP010`](https://docs.astral.sh/ruff/rules/unnecessary-future-import)