### PR TITLE
Fix unnecessary future import

### DIFF
--- a/update.py
+++ b/update.py
@@ -31,7 +31,6 @@ Build notes:
 Parameters files are fetched from autotest using requests
 
 """
-from __future__ import print_function, unicode_literals
 
 import argparse
 import distutils


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/unnecessary-future-import

% `ruff check --select=UP010`
```
UP010 [*] Unnecessary `__future__` imports `print_function`, `unicode_literals` for target Python version
  --> update.py:34:1
   |
33 | """
34 | from __future__ import print_function, unicode_literals
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
35 |
36 | import argparse
   |
help: Remove unnecessary `__future__` import

Found 1 error.
[*] 1 fixable with the `--fix` option.
```
% `ruff check --select=UP010 --fix`
```
Found 1 error (1 fixed, 0 remaining).
```