### PR TITLE
Remove unnecessary Python file encoding declarations

### DIFF
--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/blimp/source/conf.py
+++ b/blimp/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     This script aims to provide multiple parameters source files for each vehicle based on the versions available at
     https://firmware.ardupilot.org

--- a/common_conf.py
+++ b/common_conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This contains common configuration information for the ardupilot wikis.
 # This information is imported by the conf.py files in each of the sub wikis
 

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Script to get last blog entries on Discourse (https://discuss.ardupilot.org/)
 """

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #

--- a/sub/source/conf.py
+++ b/sub/source/conf.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # ArduPilot documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 02:44:23 2016.
 #


### PR DESCRIPTION
% `ruff check --select=UP009 --fix ` # https://docs.astral.sh/ruff/rules/utf8-encoding-declaration
```
Found 15 errors (15 fixed, 0 remaining).
```
% `ruff rule UP009`
# utf8-encoding-declaration (UP009)

Derived from the **pyupgrade** linter.

Fix is always available.

## What it does
Checks for unnecessary UTF-8 encoding declarations.

## Why is this bad?
[PEP 3120] makes UTF-8 the default encoding, so a UTF-8 encoding declaration is unnecessary.

## Example
```python
# -*- coding: utf-8 -*-
print("Hello, world!")
```

Use instead:
```python
print("Hello, world!")
```

[PEP 3120]: https://peps.python.org/pep-3120/