### PR TITLE
Format Python code with ruff format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,8 +8,8 @@ ignore =
     E226,
     # E261 at least two spaces before inline comment
     E261,
-    # W504 line break after binary operator
-    W504,
+    # W503 line break before binary operator
+    W503,
     # E203 whitespace before ':'
     E203,
     # E221 multiple spaces before operator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,8 @@ repos:
   - repo: https://github.com/pycqa/flake8
     rev: 7.3.0
     hooks:
-    - id: flake8
+      - id: flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.5
+    hooks:
+      - id: ruff-format

--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -148,10 +148,12 @@ html_favicon = '../../images/favicon_default.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -230,13 +232,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -244,10 +246,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -274,10 +278,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -288,11 +294,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -222,13 +222,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -236,10 +236,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -266,10 +268,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -280,11 +284,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []
@@ -368,9 +374,11 @@ epub_exclude_files = ['search.html']
 # If false, no index is generated.
 # epub_use_index = True
 
+# fmt: off
 html_js_files = [
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping

--- a/blimp/source/conf.py
+++ b/blimp/source/conf.py
@@ -151,10 +151,12 @@ html_favicon = '../../images/favicon_blimp.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -233,13 +235,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -247,10 +249,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -277,10 +281,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -291,11 +297,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python
 """
-    This script aims to provide multiple parameters source files for each vehicle based on the versions available at
-    https://firmware.ardupilot.org
+This script aims to provide multiple parameters source files for each vehicle based on the versions available at
+https://firmware.ardupilot.org
 
-    It is intended to be run on the main wiki server. TO-DO: run locally within the project's Vagrant environment.
+It is intended to be run on the main wiki server. TO-DO: run locally within the project's Vagrant environment.
 
-    Build notes:
+Build notes:
 
-    * Before start:
-        * Folder and file management tested only in linux;
-        * It is supposed to have the wiki repo in a same level of an ArduPilot repo and two other folders
-        named new_params_mvesion/ and old_params_mversion/
+* Before start:
+    * Folder and file management tested only in linux;
+    * It is supposed to have the wiki repo in a same level of an ArduPilot repo and two other folders
+    named new_params_mvesion/ and old_params_mversion/
 
-    * First step is go to each vehicle on firmware.ardupilot.org and get all available versions namely as stable/beta/latest.
-        * For each version it gets a board and get git_version.txt file;
-        * It parsers that to get the version and commit hash;
-        * It creates a dictionary with vehicles, versions and commit hashes.
+* First step is go to each vehicle on firmware.ardupilot.org and get all available versions namely as stable/beta/latest.
+    * For each version it gets a board and get git_version.txt file;
+    * It parsers that to get the version and commit hash;
+    * It creates a dictionary with vehicles, versions and commit hashes.
 
-    * Second step is use the dict to navigates on a ArduPilot Repo, changing checkouts to desidered hashes.
-        * Relies on ArduPilotRepoFolder/Tools/autotest/param_metadata/param_parse.py to generate the parameters files;
-        * It renames the anchors for all files, except for latest versions.
+* Second step is use the dict to navigates on a ArduPilot Repo, changing checkouts to desidered hashes.
+    * Relies on ArduPilotRepoFolder/Tools/autotest/param_metadata/param_parse.py to generate the parameters files;
+    * It renames the anchors for all files, except for latest versions.
 
-    * Third step: create the json files and move all generated files.
+* Third step: create the json files and move all generated files.
 
 """
 
@@ -36,10 +36,33 @@ import glob
 import argparse
 
 parser = argparse.ArgumentParser(description="python3 build_parameters.py [options]")
-parser.add_argument("--verbose", dest='verbose', action='store_false', default=True, help="show debugging output")
-parser.add_argument("--ardupilotRepoFolder", dest='gitFolder', default="../ardupilot", help="Ardupilot git folder. ")
-parser.add_argument("--destination", dest='destFolder', default="../../../../new_params_mversion", help="Parameters*.rst destination folder.")  # noqa: E501
-parser.add_argument('--vehicle', dest='single_vehicle', help="If you just want to copy to one vehicle, you can do this. Otherwise it will work for all vehicles (Copter, Plane, Rover, AntennaTracker, Sub, Blimp)")  # noqa: E501
+parser.add_argument(
+    "--verbose",
+    dest='verbose',
+    action='store_false',
+    default=True,
+    help="show debugging output",
+)
+parser.add_argument(
+    "--ardupilotRepoFolder",
+    dest='gitFolder',
+    default="../ardupilot",
+    help="Ardupilot git folder. ",
+)
+parser.add_argument(
+    "--destination",
+    dest='destFolder',
+    default="../../../../new_params_mversion",
+    help="Parameters*.rst destination folder.",
+)
+parser.add_argument(
+    '--vehicle',
+    dest='single_vehicle',
+    help=(
+        "If you just want to copy to one vehicle, you can do this. Otherwise it will "
+        "work for all vehicles (Copter, Plane, Rover, AntennaTracker, Sub, Blimp)"
+    ),
+)
 args = parser.parse_args()
 
 error_count = 0
@@ -47,13 +70,13 @@ error_count = 0
 # Parameters
 COMMITFILE = "git-version.txt"
 BASEURL = "https://firmware.ardupilot.org/"
-ALLVEHICLES = ["AntennaTracker", "Copter" , "Plane", "Rover", "Sub", "Blimp"]
+ALLVEHICLES = ["AntennaTracker", "Copter", "Plane", "Rover", "Sub", "Blimp"]
 VEHICLES = ALLVEHICLES
 
 BASEPATH = ""
 
 # Dicts for name replacing
-vehicle_new_to_old_name = { # Used because "param_parse.py" args expect old names
+vehicle_new_to_old_name = {  # Used because "param_parse.py" args expect old names
     "Rover": "APMrover2",
     "Sub": "ArduSub",
     "Copter": "ArduCopter",
@@ -62,7 +85,7 @@ vehicle_new_to_old_name = { # Used because "param_parse.py" args expect old name
     "Blimp": "Blimp",
 }
 
-vehicle_old_to_new_name = { # Used because git-version.txt use APMVersion with old names
+vehicle_old_to_new_name = {  # Used because git-version.txt use APMVersion with old names
     "APMrover2": "Rover",
     "ArduRover": "Rover",
     "ArduSub": "Sub",
@@ -91,7 +114,7 @@ def error(str_to_print):
 
 
 def check_temp_folders():
-    """Creates temporaty subfolders IFF not exists  """
+    """Creates temporaty subfolders IFF not exists"""
 
     os.chdir("../")
     if not os.path.exists("new_params_mversion"):
@@ -121,7 +144,10 @@ def setup():
         VEHICLES = [args.single_vehicle]
         progress("Running only for " + str(args.single_vehicle))
     else:
-        progress("Vehicle %s not recognized, running for all vehicles." % str(args.single_vehicle))
+        progress(
+            "Vehicle %s not recognized, running for all vehicles."
+            % str(args.single_vehicle)
+        )
 
     try:
         # Goes to ardupilot folder and clean it and update to make sure that is the most recent one.
@@ -165,6 +191,7 @@ def fetch_releases(firmware_url, vehicles):
                     return
                 attr = dict(attrs)
                 links.append(attr)
+
         # Create instance of HTML parser
         lParser = parseText()
         # Feed HTML file into parsers
@@ -178,6 +205,7 @@ def fetch_releases(firmware_url, vehicles):
             lParser.links = []
             lParser.close()
             return links
+
     ######################################################################################
 
     debug("Cleaning fetched links for wanted folders")
@@ -186,14 +214,16 @@ def fetch_releases(firmware_url, vehicles):
         page_links = fetch_vehicle_subfolders(firmware_url + f)
         for folder in page_links:  # Non clever way to filter the strings insert by makehtml.py, unwanted folders, and so.
             version_folder = str(folder)
-            if version_folder.find("stable") > 0 and not version_folder.endswith("stable"): # If finish with
+            if version_folder.find("stable") > 0 and not version_folder.endswith(
+                "stable"
+            ):  # If finish with
                 stableFirmwares.append(firmware_url[:-1] + version_folder[10:-2])
-            elif version_folder.find("latest") > 0 :
+            elif version_folder.find("latest") > 0:
                 stableFirmwares.append(firmware_url[:-1] + version_folder[10:-2])
             elif version_folder.find("beta") > 0:
                 stableFirmwares.append(firmware_url[:-1] + version_folder[10:-2])
 
-    return stableFirmwares # links for the firmwares folders
+    return stableFirmwares  # links for the firmwares folders
 
 
 def get_commit_dict(releases_parsed):
@@ -201,6 +231,7 @@ def get_commit_dict(releases_parsed):
     For informed releases, return a dict git hashes of its build.
 
     """
+
     def get_last_board_folder(url):
         """
         For given URL returns the last folder which should be a board name.
@@ -215,6 +246,7 @@ def get_commit_dict(releases_parsed):
                     return
                 attr = dict(attrs)
                 links.append(attr)
+
         # Create instance of HTML parser
         lParser = parseText()
         # Feed HTML file into parsers
@@ -228,8 +260,13 @@ def get_commit_dict(releases_parsed):
             lParser.close()
             last_item = links.pop()
             last_folder = last_item['href']
-            debug("Returning link of the last board folder (" + last_folder[last_folder.rindex('/')+1:] + ")")
-            return last_folder[last_folder.rindex('/')+1:]  # clean the partial link
+            debug(
+                "Returning link of the last board folder ("
+                + last_folder[last_folder.rindex('/') + 1 :]
+                + ")"
+            )
+            return last_folder[last_folder.rindex('/') + 1 :]  # clean the partial link
+
     ####################################################################################################
 
     def fetch_commit_hash(version_link, board, file):
@@ -256,8 +293,10 @@ def get_commit_dict(releases_parsed):
 
             regex = re.compile(r'[@_!#$%^&*()<>?/\|}{~:]')
 
-            if (regex.search(vehicle) is None):  # there are some non standard names
-                vehicle = vehicle_old_to_new_name[vehicle.strip()]   # Names may not be standard as expected
+            if regex.search(vehicle) is None:  # there are some non standard names
+                vehicle = vehicle_old_to_new_name[
+                    vehicle.strip()
+                ]  # Names may not be standard as expected
             else:
                 # tries to fix automatically
                 if re.search('copter', vehicle, re.IGNORECASE):
@@ -283,7 +322,12 @@ def get_commit_dict(releases_parsed):
                     vehicle = "Blimp"
                     debug("Bad vehicle name auto fixed to BLIMP on:\t" + fetch_link)
                 else:
-                    error("Nomenclature exception found in a vehicle name:\t" + vehicle + "\tLink with the exception:\t" + fetch_link)  # noqa: E501
+                    error(
+                        "Nomenclature exception found in a vehicle name:\t"
+                        + vehicle
+                        + "\tLink with the exception:\t"
+                        + fetch_link
+                    )  # noqa: E501
 
             if "beta" in fetch_link:
                 version_number = "beta-" + version_number
@@ -293,17 +337,22 @@ def get_commit_dict(releases_parsed):
 
             return vehicle, version_number, commit_hash
         except Exception as e:
-            error("An exception occurred: " + file + " DECODE ERROR. Link: " + fetch_link)
+            error(
+                "An exception occurred: " + file + " DECODE ERROR. Link: " + fetch_link
+            )
             error(e)
             # sys.exit(1) #comment to make easier debug
             return "error", "error", "error"
+
     ####################################################################################################
 
     commits_and_codes = {}
     commite_and_codes_cleanned = {}
 
     for j in range(0, len(releases_parsed)):
-        commits_and_codes[j] = fetch_commit_hash(releases_parsed[j], get_last_board_folder(releases_parsed[j]), COMMITFILE)
+        commits_and_codes[j] = fetch_commit_hash(
+            releases_parsed[j], get_last_board_folder(releases_parsed[j]), COMMITFILE
+        )
 
     for i in commits_and_codes:
         if commits_and_codes[i][0] != 'error':
@@ -331,19 +380,27 @@ def generate_rst_files(commits_to_checkout_and_parse):
 
         for line in file_in:
             if (re.match("(^.. _)(.*):$", line)) and ("latest" not in version_tag):
-                file_out.write(line[0:-2] + version_tag + ":\n")  # renames the anchors, but leave latest anchors "as-is" to maintaim compatibility with all links across the wiki  # noqa: E501
+                file_out.write(
+                    line[0:-2] + version_tag + ":\n"
+                )  # renames the anchors, but leave latest anchors "as-is" to maintaim compatibility with all links across the wiki  # noqa: E501
 
             elif "Complete Parameter List" in line:
                 # Adjusting the page title
                 out_line = "Complete Parameter List\n=======================\n\n"
                 out_line += "\n.. raw:: html\n\n"
-                out_line += "   <h2>Full Parameter List of " + version_tag[1:].replace("-", " ") + "</h2>\n\n"  # rename the page identifier to insert the version  # noqa: E501
+                out_line += (
+                    "   <h2>Full Parameter List of "
+                    + version_tag[1:].replace("-", " ")
+                    + "</h2>\n\n"
+                )  # rename the page identifier to insert the version  # noqa: E501
 
                 # Pigbacking and inserting the javascript selector
                 out_line += "\n.. raw:: html\n   :file: ../_static/parameters_versioning_script.inc\n\n"
                 file_out.write(out_line)
 
-            elif ("=======================" in line) and (not found_original_title): # Ignores the original mark
+            elif ("=======================" in line) and (
+                not found_original_title
+            ):  # Ignores the original mark
                 found_original_title = True
 
             else:
@@ -357,19 +414,26 @@ def generate_rst_files(commits_to_checkout_and_parse):
         # Not elegant workaround:
         # These versions present errors when parsing using param_parser.py. Needs more investigation?
         if (
-            "3.2.1" in version or # last stable APM Copte
-            "3.4.0" in version or # last stable APM Plane
-            "3.4.6" in version or # Copter
-            "2.42" in version or  # last stable APM Rover?
-            "2.51" in version or  # last beta APM Rover?
-            "0.7.2" in version    # Antennatracker
+            "3.2.1" in version  # last stable APM Copte
+            or "3.4.0" in version  # last stable APM Plane
+            or "3.4.6" in version  # Copter
+            or "2.42" in version  # last stable APM Rover?
+            or "2.51" in version  # last beta APM Rover?
+            or "0.7.2" in version  # Antennatracker
         ):
             debug("Ignoring APM version:\t" + vehicle + "\t" + version)
             continue
 
         # Checkout an Commit ID in order to get its parameters
         try:
-            debug("Git checkout on " + vehicle + " version " + version + " id " + commit_id)
+            debug(
+                "Git checkout on "
+                + vehicle
+                + " version "
+                + version
+                + " id "
+                + commit_id
+            )
             os.system("git checkout --force " + commit_id)
 
         except Exception as e:
@@ -380,16 +444,25 @@ def generate_rst_files(commits_to_checkout_and_parse):
         # Run param_parse.py tool from Autotest set in the desidered commit id
         try:
             os.chdir(BASEPATH + "/Tools/autotest/param_metadata")
-            if ('rover' in vehicle.lower()) and ('v3.' not in version.lower()) and ('v4.0' not in version.lower()): # Workaround the vehicle renaming (Rover, APMRover2 ArduRover...)  # noqa: E501
+            if (
+                ('rover' in vehicle.lower())
+                and ('v3.' not in version.lower())
+                and ('v4.0' not in version.lower())
+            ):  # Workaround the vehicle renaming (Rover, APMRover2 ArduRover...)  # noqa: E501
                 os.system("python3 ./param_parse.py --vehicle " + 'Rover')
-            else: # regular case
-                os.system("python3 ./param_parse.py --vehicle " + vehicle_new_to_old_name[vehicle])  # option "param_parse.py --format rst" is not available in all commits where param_parse.py is found  # noqa: E501
+            else:  # regular case
+                os.system(
+                    "python3 ./param_parse.py --vehicle "
+                    + vehicle_new_to_old_name[vehicle]
+                )  # option "param_parse.py --format rst" is not available in all commits where param_parse.py is found  # noqa: E501
 
             # create a filename for new parameters file
             filename = "parameters-" + vehicle
-            if ("beta" in version or "rc" in version): # Plane uses BETA, Copter and Rover uses RCn
-                filename += "-" + version  + ".rst"
-            elif ("latest" in version):
+            if (
+                "beta" in version or "rc" in version
+            ):  # Plane uses BETA, Copter and Rover uses RCn
+                filename += "-" + version + ".rst"
+            elif "latest" in version:
                 filename += "-" + version + ".rst"
             else:
                 filename += "-stable-" + version + ".rst"
@@ -407,7 +480,14 @@ def generate_rst_files(commits_to_checkout_and_parse):
 
             os.chdir(BASEPATH)
         except Exception as e:
-            error("Error while parsing \"Parameters.rst\" | details:\t" + vehicle + "\t" + version  + "\t" + commit_id)
+            error(
+                "Error while parsing \"Parameters.rst\" | details:\t"
+                + vehicle
+                + "\t"
+                + version
+                + "\t"
+                + commit_id
+            )
             error(e)
             # sys.exit(1)
         debug("")
@@ -417,13 +497,12 @@ def generate_rst_files(commits_to_checkout_and_parse):
 
 def generate_json(vehicles):
     """
-        Generates a JSON with all parameters page to be live consumed by a javascript
+    Generates a JSON with all parameters page to be live consumed by a javascript
     """
 
     os.chdir(BASEPATH + "/Tools/autotest/param_metadata")
 
     for vehicle in vehicles:
-
         debug("Creating JSON files for " + vehicle)
 
         # Creates the JSON lines from available rst files
@@ -435,14 +514,39 @@ def generate_json(vehicles):
         json_lines.append("\"Click here to change\" : \"\"")
 
         for filename in parameters_files:
-            if ("beta" in filename or "rc" in filename): # Plane uses BETA, Copter and Rover uses RCn
-                json_lines.append(",\"" + vehicle + " beta " + filename[(len("parameters-" + vehicle + "-beta")+1):-4] + "\" : \"" + filename[:-3] + "html\"")  # noqa: E501
-            elif ("latest" in filename):
+            if (
+                "beta" in filename or "rc" in filename
+            ):  # Plane uses BETA, Copter and Rover uses RCn
+                json_lines.append(
+                    ",\""
+                    + vehicle
+                    + " beta "
+                    + filename[(len("parameters-" + vehicle + "-beta") + 1) : -4]
+                    + "\" : \""
+                    + filename[:-3]
+                    + "html\""
+                )  # noqa: E501
+            elif "latest" in filename:
                 # json_lines.append(",\"" +  vehicle + " latest " + filename[(len("parameters-" + vehicle + "-latest")+1):-4] + "\" : \"" + filename[:-3] + "html\"")  # noqa: E501
-                json_lines.append(",\"" + vehicle + " latest " + filename[(len("parameters-" + vehicle + "-latest")+1):-4] + "\" : \"" + ("parameters.html\""))  # Trying to re-enable toc list on the left bar on the wiki by forcing latest file name.  # noqa: E501
+                json_lines.append(
+                    ",\""
+                    + vehicle
+                    + " latest "
+                    + filename[(len("parameters-" + vehicle + "-latest") + 1) : -4]
+                    + "\" : \""
+                    + ("parameters.html\"")
+                )  # Trying to re-enable toc list on the left bar on the wiki by forcing latest file name.  # noqa: E501
 
             else:
-                json_lines.append(",\"" + vehicle + " stable " + filename[(len("parameters-" + vehicle + "-stable")+1):-4] + "\" : \"" + filename[:-3] + "html\"")  # noqa: E501
+                json_lines.append(
+                    ",\""
+                    + vehicle
+                    + " stable "
+                    + filename[(len("parameters-" + vehicle + "-stable") + 1) : -4]
+                    + "\" : \""
+                    + filename[:-3]
+                    + "html\""
+                )  # noqa: E501
 
         json_lines.append("}")
 
@@ -453,7 +557,12 @@ def generate_json(vehicles):
                 for lines in json_lines:
                     f.write("%s\n" % lines)
         except Exception as e:
-            error("Error while creating the JSON file " + vehicle + " in folder " + str(os.getcwd()))  # noqa: E501
+            error(
+                "Error while creating the JSON file "
+                + vehicle
+                + " in folder "
+                + str(os.getcwd())
+            )  # noqa: E501
             error(e)
             # sys.exit(1)
         debug("")
@@ -461,7 +570,7 @@ def generate_json(vehicles):
 
 def move_results(vehicles):
     """
-        Once all parameters files are created, moves for "new_params_mversion" as the last execution result
+    Once all parameters files are created, moves for "new_params_mversion" as the last execution result
     """
 
     os.chdir(BASEPATH + "/Tools/autotest/param_metadata")
@@ -485,30 +594,45 @@ def move_results(vehicles):
             # Moving files.
             files_to_move = [f for f in glob.glob("parameters-" + vehicle + "*")]
             for file in files_to_move:
-                if ("latest" not in file):  # Trying to re-enable toc list on the left bar on the wiki by forcing latest file name.  # noqa: E501
+                if (
+                    "latest" not in file
+                ):  # Trying to re-enable toc list on the left bar on the wiki by forcing latest file name.  # noqa: E501
                     os.rename(file, folder + file)
                 else:
                     os.rename(file, str((folder + "parameters.rst")))
 
         except Exception as e:
-            error("Error while moving result files of vehicle " + vehicle + " pwd: " + str(os.getcwd()))
+            error(
+                "Error while moving result files of vehicle "
+                + vehicle
+                + " pwd: "
+                + str(os.getcwd())
+            )
             error(e)
             # sys.exit(1)
 
 
 def print_versions(commits_to_checkout_and_parse):
-    """ Partial results: present all vechicles, versions and commits selected to generate parameters """
+    """Partial results: present all vechicles, versions and commits selected to generate parameters"""
     debug("\n\tList of parameters files to generate:\n")
     for i in commits_to_checkout_and_parse:
-        debug(commits_to_checkout_and_parse[i][0] + ' - ' + commits_to_checkout_and_parse[i][1] + ' - ' + commits_to_checkout_and_parse[i][2])  # noqa: E501
+        debug(
+            commits_to_checkout_and_parse[i][0]
+            + ' - '
+            + commits_to_checkout_and_parse[i][1]
+            + ' - '
+            + commits_to_checkout_and_parse[i][2]
+        )  # noqa: E501
     debug("")
 
 
 # Step 1 - Select the versions for generate parameters
-setup()                                                             # Reset the ArduPilot folder/repo
-feteched_releases = fetch_releases(BASEURL, VEHICLES)               # All folders/releases.
-commits_to_checkout_and_parse = get_commit_dict(feteched_releases)  # Parse names, and git hashes.
-print_versions(commits_to_checkout_and_parse)                       # Present work dict.
+setup()  # Reset the ArduPilot folder/repo
+feteched_releases = fetch_releases(BASEURL, VEHICLES)  # All folders/releases.
+commits_to_checkout_and_parse = get_commit_dict(
+    feteched_releases
+)  # Parse names, and git hashes.
+print_versions(commits_to_checkout_and_parse)  # Present work dict.
 
 # Step 2 - Generates them in ArdupilotRepoFolder/Tools/autotest/param_metadata
 generate_rst_files(commits_to_checkout_and_parse)

--- a/common_conf.py
+++ b/common_conf.py
@@ -9,11 +9,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
-    'sphinx.ext.mathjax',     # For :math: element rendering
+    'sphinx.ext.mathjax',  # For :math: element rendering
     'sphinx.ext.ifconfig',
     'sphinxcontrib.youtube',  # For youtube embedding
     'sphinxcontrib.jquery',
-    'sphinx_tabs.tabs'        # For clickable tabs
+    'sphinx_tabs.tabs',  # For clickable tabs
 ]
 
 # Set False to re-enable warnings for non-local images.
@@ -32,29 +32,19 @@ html_context = {'target': '/'}
 # This needs to change to the actual URL root once the theme updated.
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'copter': (intersphinx_base_url % 'copter',
-                                  None),
-                       'plane': (intersphinx_base_url % 'plane',
-                                  None),  # noqa: E127
-                       'rover': (intersphinx_base_url % 'rover',
-                                  None),  # noqa: E127
-                       'sub': (intersphinx_base_url % 'sub',
-                                  None),  # noqa: E127
-                       'planner': (intersphinx_base_url % 'planner',
-                                  None),  # noqa: E128
-                       'planner2': (intersphinx_base_url % 'planner2',
-                                  None),  # noqa: E128
-                       'dev': (intersphinx_base_url % 'dev',
-                                  None),  # noqa: E127
-                       'antennatracker': (intersphinx_base_url % 'antennatracker',
-                                  None),  # noqa: E128
-                       'ardupilot': (intersphinx_base_url % 'ardupilot',
-                                  None),  # noqa: E128
-                       'mavproxy': (intersphinx_base_url % 'mavproxy',
-                                  None),  # noqa: E128
-                       'blimp': (intersphinx_base_url % 'blimp',
-                                  None),  # noqa: E127
-                      }  # noqa: E124
+intersphinx_mapping = {
+    'copter': (intersphinx_base_url % 'copter', None),
+    'plane': (intersphinx_base_url % 'plane', None),  # noqa: E127
+    'rover': (intersphinx_base_url % 'rover', None),  # noqa: E127
+    'sub': (intersphinx_base_url % 'sub', None),  # noqa: E127
+    'planner': (intersphinx_base_url % 'planner', None),  # noqa: E128
+    'planner2': (intersphinx_base_url % 'planner2', None),  # noqa: E128
+    'dev': (intersphinx_base_url % 'dev', None),  # noqa: E127
+    'antennatracker': (intersphinx_base_url % 'antennatracker', None),  # noqa: E128
+    'ardupilot': (intersphinx_base_url % 'ardupilot', None),  # noqa: E128
+    'mavproxy': (intersphinx_base_url % 'mavproxy', None),  # noqa: E128
+    'blimp': (intersphinx_base_url % 'blimp', None),  # noqa: E127
+}  # noqa: E124
 
 # PATCH REMOVE NON-LOCAL IMAGE WARNINGS
 # From:

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -151,10 +151,12 @@ html_favicon = '../../images/favicon_copter.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -233,13 +235,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -247,10 +249,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -277,10 +281,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -291,11 +297,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -223,13 +223,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -237,10 +237,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -267,10 +269,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -281,11 +285,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []
@@ -368,9 +374,11 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 # epub_use_index = True
+# fmt: off
 html_js_files = [
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Intersphinx mapping config (done globally)
 intersphinx_mapping = common_conf.intersphinx_mapping

--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -2,6 +2,7 @@
 """
 Script to get last blog entries on Discourse (https://discuss.ardupilot.org/)
 """
+
 import argparse
 import json
 import re
@@ -41,25 +42,28 @@ class BlogPostsFetcher:
         self.news_url = news_url
         base_dir = Path.cwd()
         if str(base_dir).endswith('frontend'):
-            base_dir = base_dir.parent  # move one level up in the directory tree if needed
+            # move one level up in the directory tree if needed
+            base_dir = base_dir.parent
 
         self.files_names = {
             self.blog_url: (base_dir / "./frontend/blog_posts.json").resolve(),
-            self.news_url: (base_dir / "./frontend/news_posts.json").resolve()
+            self.news_url: (base_dir / "./frontend/news_posts.json").resolve(),
         }
         # Configure session with proper cookie handling
         self.session = requests.Session()
-        self.session.headers.update({
-            'User-Agent': 'Mozilla/5.0 (compatible; ArduPilotPostGrabber/1.0)',
-            'Accept': 'application/json',
-            "Connection": "keep-alive",
-        })
+        self.session.headers.update(
+            {
+                'User-Agent': 'Mozilla/5.0 (compatible; ArduPilotPostGrabber/1.0)',
+                'Accept': 'application/json',
+                "Connection": "keep-alive",
+            }
+        )
         # Add retry logic for 429 and other errors
         retries = Retry(
             total=5,
             backoff_factor=2,
             status_forcelist=[429, 500, 502, 503, 504],
-            allowed_methods=["HEAD", "GET", "OPTIONS"]
+            allowed_methods=["HEAD", "GET", "OPTIONS"],
         )
         adapter = HTTPAdapter(max_retries=retries)
         self.session.mount("https://", adapter)
@@ -68,8 +72,16 @@ class BlogPostsFetcher:
     @staticmethod
     def get_arguments() -> Any:
         parser = argparse.ArgumentParser(description="python3 get_discourse_posts.py")
-        parser.add_argument("--n_posts", dest='n_posts', default="9", help="Number of posts to retrieve")
-        parser.add_argument("--verbose", dest='verbose', action='store_false', default=True, help="show debugging output")
+        parser.add_argument(
+            "--n_posts", dest='n_posts', default="9", help="Number of posts to retrieve"
+        )
+        parser.add_argument(
+            "--verbose",
+            dest='verbose',
+            action='store_false',
+            default=True,
+            help="show debugging output",
+        )
         args, unknown = parser.parse_known_args()
         return args
 
@@ -119,27 +131,40 @@ class BlogPostsFetcher:
 
     @staticmethod
     def get_first_youtube_or_img_link(request: str) -> Tuple[str, bool]:
-        """ Returns the first YouTube link or image link in the request, if any.
-            True if the link is a Youtube link."""
+        """Returns the first YouTube link or image link in the request, if any.
+        True if the link is a Youtube link."""
         request_lines = request.splitlines()
         # Join the first 5 lines back together
         first_five_lines = '\n'.join(request_lines[:5])
 
         # Regular expression to find URLs that contain 'YouTube' or image links
         url_pattern = re.compile(r'href=[\'"]?(https?://www\.youtube[^\'" >]+)')
-        img_pattern = re.compile(r'(?i)(?:href|src)=[\'"]?(https?://[^\'" >]+\.(?:jpg|jpeg|png|gif|svg|bmp|webp))')
-        img_pattern2 = re.compile(r'img src=[\'"]?(https?://[^\'" >]+)')  # catch google link and such
+        img_pattern = re.compile(
+            r'(?i)(?:href|src)=[\'"]?(https?://[^\'" >]+\.(?:jpg|jpeg|png|gif|svg|bmp|webp))'
+        )
+        # catch google link and such
+        img_pattern2 = re.compile(r'img src=[\'"]?(https?://[^\'" >]+)')
 
         # Find all matches
         youtube_links = url_pattern.findall(first_five_lines)
-        img_links = img_pattern.findall(first_five_lines)[0] if img_pattern.findall(first_five_lines) else None
+        img_links = (
+            img_pattern.findall(first_five_lines)[0]
+            if img_pattern.findall(first_five_lines)
+            else None
+        )
         if img_links is None:
-            img_links = img_pattern2.findall(first_five_lines)[0] if img_pattern2.findall(
-                first_five_lines) else None
+            img_links = (
+                img_pattern2.findall(first_five_lines)[0]
+                if img_pattern2.findall(first_five_lines)
+                else None
+            )
 
         # If there are image links before YouTube links, return empty string
-        if img_links and (not youtube_links or
-                          first_five_lines.index(img_links) < first_five_lines.index(youtube_links[0])):
+        if img_links and (
+            not youtube_links
+            or first_five_lines.index(img_links)
+            < first_five_lines.index(youtube_links[0])
+        ):
             if 'github.com' in img_links:
                 img_links = img_links + "?raw=true"
             return img_links, False
@@ -155,18 +180,32 @@ class BlogPostsFetcher:
 
     @staticmethod
     def youtube_link_to_embed_link(url: str) -> str:
-        return url.replace('https://www.youtube.com/watch?v=', 'https://www.youtube-nocookie.com/embed/')
+        return url.replace(
+            'https://www.youtube.com/watch?v=',
+            'https://www.youtube-nocookie.com/embed/',
+        )
 
     def get_post_data(self, content: Any, i: int, verbose: bool) -> Post:
         item = content['topic_list']['topics'][i]
-        single_post_link = str('https://discuss.ardupilot.org/t/' + str(item['slug']) + '/' + str(item['id'])) + '.json'
+        single_post_link = (
+            str(
+                'https://discuss.ardupilot.org/t/'
+                + str(item['slug'])
+                + '/'
+                + str(item['id'])
+            )
+            + '.json'
+        )
         self.debug(f"Requesting post text {single_post_link} ... ", verbose)
         post_content_raw = self.execute_http_request_json(single_post_link)
         post_content = str(post_content_raw['post_stream']['posts'][0]['cooked'])
         single_post_text = self.get_single_post_text(post_content)
 
         has_image = False
-        self.debug(f"Requesting post text {single_post_link} to look for youtube link... ", verbose)
+        self.debug(
+            f"Requesting post text {single_post_link} to look for youtube link... ",
+            verbose,
+        )
         thing_link, isyoutube = self.get_first_youtube_or_img_link(post_content)
         youtube_link = self.youtube_link_to_embed_link(thing_link) if isyoutube else ''
         if youtube_link == '':
@@ -178,8 +217,14 @@ class BlogPostsFetcher:
                 youtube_link = 'nops'
                 item['image_url'] = thing_link
 
-        return Post(item['title'], item['image_url'], has_image, youtube_link, single_post_link.rsplit('.', 1)[0],
-                    single_post_text.strip())
+        return Post(
+            item['title'],
+            item['image_url'],
+            has_image,
+            youtube_link,
+            single_post_link.rsplit('.', 1)[0],
+            single_post_text.strip(),
+        )
 
     def save_posts_to_json(self, url: str, n_posts: int, verbose: bool) -> None:
         content = self.execute_http_request_json(url)
@@ -194,7 +239,9 @@ class BlogPostsFetcher:
             with open(self.files_names[url], 'w', encoding='utf-8') as f:
                 json.dump(post_data, f, ensure_ascii=False, indent=4)
         except Exception as e:
-            raise WriteToFileError(f"Exception occurred while writing to file with message {e}")
+            raise WriteToFileError(
+                f"Exception occurred while writing to file with message {e}"
+            )
 
     def fetch(self, args: Any) -> None:
         try:

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -218,21 +218,23 @@ htmlhelp_basename = 'ArduPilotdoc'
 html_context = common_conf.html_context
 
 
+# fmt: off
 html_js_files = [
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -240,10 +242,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -270,10 +274,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -284,11 +290,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -150,10 +150,12 @@ html_favicon = '../../images/favicon_plane.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -232,13 +234,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -246,10 +248,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -276,10 +280,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -290,11 +296,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -217,21 +217,20 @@ htmlhelp_basename = 'ArduPilotdoc'
 # Where to point the base of the build for the main site menu
 html_context = common_conf.html_context
 
+# fmt: off
 html_js_files = [
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -239,10 +238,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -269,10 +270,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -283,11 +286,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -217,21 +217,24 @@ htmlhelp_basename = 'ArduPilotdoc'
 # Where to point the base of the build for the main site menu
 html_context = common_conf.html_context
 
+# fmt: off
 html_js_files = [
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
+
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -239,10 +242,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -269,10 +274,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -283,11 +290,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.ruff]
+format.quote-style="preserve"
+

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -149,10 +149,12 @@ html_favicon = '../../images/favicon_rover.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -228,13 +230,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -242,10 +244,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -272,10 +276,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -286,11 +292,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/rst_table.py
+++ b/rst_table.py
@@ -17,7 +17,12 @@ def tablify_row(rowheading, row, widths, height):
         out_line = ""
         if rowheading is not None:
             rowheading_line = rowheading_lines[i]
-            out_line += joiner + " " + rowheading_line + " " * (widths[0] - len(rowheading_line) - 1)
+            out_line += (
+                joiner
+                + " "
+                + rowheading_line
+                + " " * (widths[0] - len(rowheading_line) - 1)
+            )
             joiner = "#"
         j = 0
         for item in row_lines:

--- a/scripts/build_motor_diagrams.py
+++ b/scripts/build_motor_diagrams.py
@@ -140,7 +140,9 @@ def get_motors_json():
     if not motors_json or not display_json:
         return {}
 
-    existing_layouts = {(layout["Class"], layout["Type"]) for layout in motors_json["layouts"]}
+    existing_layouts = {
+        (layout["Class"], layout["Type"]) for layout in motors_json["layouts"]
+    }
 
     # append additional layouts from display json
     for layout in display_json["layouts"]:
@@ -222,7 +224,7 @@ def get_translated_coordinates(x, y, radius):
     scale motor vector (Roll/Pitch) output to svg coordinates
     """
     θ = math.atan2(-y, -x)
-    r = math.sqrt(y ** 2 + x ** 2) * radius
+    r = math.sqrt(y**2 + x**2) * radius
     x_translated = r * math.cos(θ)
     y_translated = r * math.sin(θ)
     return x_translated, y_translated, r, θ
@@ -912,8 +914,8 @@ if __name__ == "__main__":
         generate_all_diagrams()
         exit(0)
 
-    # TODO: future use for inserting wiki text automatically
-    # if args.build or args.preview:
+        # TODO: future use for inserting wiki text automatically
+        # if args.build or args.preview:
         build_all(preview=args.preview)
         exit(0)
     if args.preview:

--- a/scripts/cap_params.py
+++ b/scripts/cap_params.py
@@ -6,8 +6,11 @@ script to find and optionally replace param refs in rst files
 import re
 
 from argparse import ArgumentParser
+
 parser = ArgumentParser('find and optionally replace parameters')
-parser.add_argument("--change", action='store_true', help="change matches to use param markup")
+parser.add_argument(
+    "--change", action='store_true', help="change matches to use param markup"
+)
 parser.add_argument("files", nargs='+')
 
 args = parser.parse_args()

--- a/scripts/generate_motor_json.py
+++ b/scripts/generate_motor_json.py
@@ -16,6 +16,7 @@
 *   in an Ardupilot/ardupilot environment to update JSON data.
 *
 ****************************************************************************"""
+
 import argparse
 import json
 import math
@@ -167,7 +168,7 @@ def truncate(number, decimal_places):
     """
     truncate a float decimal_places digits after the decimal point
     """
-    str = f"{number:.{decimal_places+1}f}"
+    str = f"{number:.{decimal_places + 1}f}"
     truncated = str[: str.find(".") + decimal_places + 1]
     return float(truncated)
 
@@ -449,7 +450,8 @@ if __name__ == "__main__":
     if run with '-h' or '--help', print help
     """
     parser = argparse.ArgumentParser(
-        description="Generate motor matrices (JSON) from 'AP_Motors/AP_MotorsMatrix.cpp'.")
+        description="Generate motor matrices (JSON) from 'AP_Motors/AP_MotorsMatrix.cpp'."
+    )
     parser.add_argument(
         "-o",
         "--output",
@@ -460,7 +462,8 @@ if __name__ == "__main__":
         help=(
             "Output to file (default is stdout; '-o' or '--output' with no argument writes to "
             f"'{DEFAULT_OUTPUT_FILE.relative_to(THIS_SCRIPT.parent)}')."
-        ))
+        ),
+    )
     parser.add_argument(
         "-f",
         "--force",

--- a/scripts/rename_params.py
+++ b/scripts/rename_params.py
@@ -15,9 +15,15 @@ from argparse import ArgumentParser
 
 parser = ArgumentParser(description="parameter conversion tool")
 
-parser.add_argument("--recurse", default=False, action='store_true', help="recurse into subdirectories")
-parser.add_argument("--nonref", default=False, action='store_true', help="include non-ref instances")
-parser.add_argument("--verbose", default=False, action='store_true', help="verbose messages")
+parser.add_argument(
+    "--recurse", default=False, action='store_true', help="recurse into subdirectories"
+)
+parser.add_argument(
+    "--nonref", default=False, action='store_true', help="include non-ref instances"
+)
+parser.add_argument(
+    "--verbose", default=False, action='store_true', help="verbose messages"
+)
 parser.add_argument("param_map", default=None, help="parameter map file")
 parser.add_argument("files", nargs="+", default=None, help="directories or files")
 
@@ -49,8 +55,7 @@ def process_file(fname, param_map):
     needs_write = False
     txt = open(fname, "r").read()
 
-    replacements = [":ref:`PARAMNAME <PARAMNAME>`",
-                    ":ref:`PARAMNAME<PARAMNAME>`"]
+    replacements = [":ref:`PARAMNAME <PARAMNAME>`", ":ref:`PARAMNAME<PARAMNAME>`"]
     if args.nonref:
         replacements.extend(["PARAMNAME"])
 

--- a/sub/source/conf.py
+++ b/sub/source/conf.py
@@ -151,10 +151,12 @@ html_favicon = '../../images/favicon_sub.ico'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# fmt: off
 html_js_files = [
     './useralerts.js',
     ('https://plausible.ardupilot.org/js/script.outbound-links.js', {"data-domain": "ardupilot.org", "defer": "defer"}),
 ]
+# fmt: on
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -230,13 +232,13 @@ html_context = common_conf.html_context
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     # 'papersize': 'letterpaper',
-
+    #
     # The font size ('10pt', '11pt' or '12pt').
     # 'pointsize': '10pt',
-
+    #
     # Additional stuff for the LaTeX preamble.
     # 'preamble': '',
-
+    #
     # Latex figure (float) alignment
     # 'figure_align': 'htbp',
 }
@@ -244,10 +246,12 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
+# fmt: off
 latex_documents = [
     (master_doc, 'ArduPilot.tex', 'ArduPilot Documentation',
      'ArduPilot Dev Team', 'manual'),
 ]
+# fmt: on
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
@@ -274,10 +278,12 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
+# fmt: off
 man_pages = [
     (master_doc, 'ardupilot', 'ArduPilot Documentation',
      [author], 1)
 ]
+# fmt: on
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -288,11 +294,13 @@ man_pages = [
 # Grouping the document tree into Texinfo files. List of tuples
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
+# fmt: off
 texinfo_documents = [
     (master_doc, 'ArduPilot', 'ArduPilot Documentation',
      author, 'ArduPilot', 'One line description of project.',
      'Miscellaneous'),
 ]
+# fmt: on
 
 # Documents to append as an appendix to all manuals.
 # texinfo_appendices = []

--- a/update.py
+++ b/update.py
@@ -57,6 +57,7 @@ from typing import Optional, Dict, List
 from sphinx.application import Sphinx
 import rst_table
 from datetime import datetime
+
 # while flake8 says this is unused, distutils.dir_util.mkpath fails
 # without the following import on old versions of Python:
 from distutils import dir_util  # noqa: F401
@@ -188,7 +189,9 @@ def fetch_url(fetchurl: str, fpath: Optional[str] = None, verbose: bool = True) 
 
 
 def get_request_file_size(url: str) -> int:
-    headers = {'Accept-Encoding': 'identity'}  # needed as request use compression by default
+    headers = {
+        'Accept-Encoding': 'identity'
+    }  # needed as request use compression by default
     hresponse = requests.head(url, headers=headers)
 
     if 'Content-Length' in hresponse.headers:
@@ -201,7 +204,7 @@ def fetchparameters(site: Optional[str] = None, cache: Optional[str] = None) -> 
     dataname = "Parameters"
     fetch_ardupilot_generated_data(
         PARAMETER_SITE,
-        f"https://autotest.ardupilot.org/{dataname}", # noqa: E231
+        f"https://autotest.ardupilot.org/{dataname}",  # noqa: E231
         f"{dataname}.rst",
         f"{dataname.lower()}.rst",
         site,
@@ -221,8 +224,14 @@ def fetchlogmessages(site: Optional[str] = None, cache: Optional[str] = None) ->
     )
 
 
-def fetch_ardupilot_generated_data(site_mapping: Dict, base_url: str, sub_url: str, document_name: str,
-                                   site: Optional[str] = None, cache: Optional[str] = None) -> None:
+def fetch_ardupilot_generated_data(
+    site_mapping: Dict,
+    base_url: str,
+    sub_url: str,
+    document_name: str,
+    site: Optional[str] = None,
+    cache: Optional[str] = None,
+) -> None:
     """Fetches the data for all the sites from the test server and
     copies them to the correct location.
 
@@ -241,7 +250,9 @@ def fetch_ardupilot_generated_data(site_mapping: Dict, base_url: str, sub_url: s
             targetfile = f'./dev/source/docs/AP_Periph-{sub_url}'
         if cache:
             if not os.path.exists(targetfile):
-                raise Exception(f"Asked to use cached files, but {targetfile} does not exist")
+                raise Exception(
+                    f"Asked to use cached files, but {targetfile} does not exist"
+                )
             continue
         if site == key or site is None or (site == 'dev' and key == 'AP_Periph'):
             urls.append(fetchurl)
@@ -249,7 +260,7 @@ def fetch_ardupilot_generated_data(site_mapping: Dict, base_url: str, sub_url: s
             names.append(f"{value}_{document_name}")
 
     with ThreadPoolExecutor() as executor:
-        executor.map(fetch_and_rename, urls, targetfiles, names, timeout=5*60)
+        executor.map(fetch_and_rename, urls, targetfiles, names, timeout=5 * 60)
 
 
 def build_one(wiki, fast):
@@ -418,8 +429,10 @@ def delete_old_wiki_backups(folder, n_to_keep):
                     debug('Deleting folder %s' % str(backup_folders[i]))
                     shutil.rmtree(str(backup_folders[i]))
                 else:
-                    debug('Ignoring folder %s because it does not look like a auto generated wiki backup folder' %
-                          str(backup_folders[i]))
+                    debug(
+                        'Ignoring folder %s because it does not look like a auto generated wiki backup folder'
+                        % str(backup_folders[i])
+                    )
         else:
             debug('No old backups to delete in %s' % folder)
     except Exception as e:
@@ -509,7 +522,9 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                                 files_skipped += 1
                                 continue
                         except Exception as e:
-                            debug(f"filecmp failed for {source_file_path} vs {targetfile}: {e}")
+                            debug(
+                                f"filecmp failed for {source_file_path} vs {targetfile}: {e}"
+                            )
                             # treat as different and fall through to write
 
                     debug(targetfile)
@@ -521,7 +536,11 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                     src = os.path.join(root, file)
                     dst = '%s/source/_static/%s' % (wiki, file)
                     # Only copy if different
-                    if not clean_common and os.path.exists(dst) and filecmp.cmp(src, dst, shallow=False):
+                    if (
+                        not clean_common
+                        and os.path.exists(dst)
+                        and filecmp.cmp(src, dst, shallow=False)
+                    ):
                         continue
                     shutil.copy2(src, dst)
             elif file.endswith(".js"):
@@ -540,14 +559,18 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                             if filecmp.cmp(source_file_path, targetfile, shallow=False):
                                 continue
                         except Exception as e:
-                            debug(f"filecmp failed for {source_file_path} vs {targetfile}: {e}")
+                            debug(
+                                f"filecmp failed for {source_file_path} vs {targetfile}: {e}"
+                            )
                             # treat as different and fall through to write
 
                     debug(targetfile)
                     with open(targetfile, 'w', encoding='utf-8') as destination_file:
                         destination_file.write(content)
 
-    progress(f"Common files: {files_copied} copied, {files_skipped} unchanged, {files_removed} removed")
+    progress(
+        f"Common files: {files_copied} copied, {files_skipped} unchanged, {files_removed} removed"
+    )
 
 
 def get_copy_targets(content):
@@ -579,10 +602,7 @@ def strip_content(content, site):
         return ''
 
     # Remove the copywiki from content
-    newText = re.sub(r'\[copywiki.*?\]',
-                     fix_copywiki_shortcode,
-                     content,
-                     flags=re.M)
+    newText = re.sub(r'\[copywiki.*?\]', fix_copywiki_shortcode, content, flags=re.M)
 
     def fix_site_shortcode(matchobj):
         # logmatch_code(matchobj, 'SITESC_')
@@ -594,11 +614,14 @@ def strip_content(content, site):
         else:
             # progress("YES")
             return matchobj.group(2)
+
     # Remove the site shortcode from content
-    newText = re.sub(r'\[site\s.*?wiki\=\"(.*?)\".*?\](.*?)\[\/site\]',
-                     fix_site_shortcode,
-                     newText,
-                     flags=re.S)
+    newText = re.sub(
+        r'\[site\s.*?wiki\=\"(.*?)\".*?\](.*?)\[\/site\]',
+        fix_site_shortcode,
+        newText,
+        flags=re.S,
+    )
 
     return newText
 
@@ -613,7 +636,8 @@ def logmatch_code(matchobj, prefix):
 
 
 def is_the_same_file(file1, file2):
-    """ Compare two files using their SHA256 hashes"""
+    """Compare two files using their SHA256 hashes"""
+
     def file_hash(path, algo="sha256", chunk_size=8192):
         h = hashlib.new(algo)
         with open(path, "rb") as f:
@@ -622,6 +646,7 @@ def is_the_same_file(file1, file2):
                 h.update(chunk)
                 chunk = f.read(chunk_size)
         return h.hexdigest()
+
     return file_hash(file1) == file_hash(file2)
 
 
@@ -634,14 +659,16 @@ def fetch_versioned_parameters(site=None):
     """
 
     for key, value in PARAMETER_SITE.items():
-
-        if key == 'AP_Periph': # workaround until create a versioning for AP_Periph in firmware server
-            fetchurl = 'https://autotest.ardupilot.org/Parameters/%s/Parameters.rst' % value
+        if (
+            key == 'AP_Periph'
+        ):  # workaround until create a versioning for AP_Periph in firmware server
+            fetchurl = (
+                'https://autotest.ardupilot.org/Parameters/%s/Parameters.rst' % value
+            )
             targetfile = './dev/source/docs/AP_Periph-Parameters.rst'
             fetch_and_rename(fetchurl, targetfile, 'Parameters.rst')
 
-        else: # regular versioning
-
+        else:  # regular versioning
             if site == key or site is None:
                 # Remove old param single file
                 single_param_file = './%s/source/docs/parameters.rst' % key
@@ -649,17 +676,23 @@ def fetch_versioned_parameters(site=None):
                 remove_if_exists(single_param_file)
 
                 # Remove old versioned param files
-                if 'antennatracker' in key.lower():  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
-                    old_parameters_mask = (os.getcwd() +
-                                           '/%s/source/docs/parameters-%s-' %
-                                           ("AntennaTracker", "AntennaTracker"))
+                if (
+                    'antennatracker' in key.lower()
+                ):  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
+                    old_parameters_mask = (
+                        os.getcwd()
+                        + '/%s/source/docs/parameters-%s-'
+                        % ("AntennaTracker", "AntennaTracker")
+                    )
                 else:
-                    old_parameters_mask = (os.getcwd() +
-                                           '/%s/source/docs/parameters-%s-' %
-                                           (key, key.title()))
+                    old_parameters_mask = (
+                        os.getcwd()
+                        + '/%s/source/docs/parameters-%s-' % (key, key.title())
+                    )
                 try:
                     old_parameters_files = [
-                        f for f in glob.glob(old_parameters_mask + "*.rst")]
+                        f for f in glob.glob(old_parameters_mask + "*.rst")
+                    ]
                     for filename in old_parameters_files:
                         debug("Erasing rst " + filename)
                         os.remove(filename)
@@ -668,24 +701,41 @@ def fetch_versioned_parameters(site=None):
                     pass
 
                 # Remove old json file
-                if 'antennatracker' in key.lower():  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
-                    target_json_file = ('./%s/source/_static/parameters-%s.json' %
-                                        ("AntennaTracker", "AntennaTracker"))
+                if (
+                    'antennatracker' in key.lower()
+                ):  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
+                    target_json_file = './%s/source/_static/parameters-%s.json' % (
+                        "AntennaTracker",
+                        "AntennaTracker",
+                    )
                 else:
-                    target_json_file = ('./%s/source/_static/parameters-%s.json' %
-                                        (value, key.title()))
+                    target_json_file = './%s/source/_static/parameters-%s.json' % (
+                        value,
+                        key.title(),
+                    )
                 debug("Erasing json " + target_json_file)
                 remove_if_exists(target_json_file)
 
                 # Moves the updated JSON file
-                if 'antennatracker' in key.lower():  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
-                    vehicle_json_file = os.getcwd() + '/../new_params_mversion/%s/parameters-%s.json' % ("AntennaTracker", "AntennaTracker")  # noqa: E501
+                if (
+                    'antennatracker' in key.lower()
+                ):  # To main the original script approach instead of the build_parameters.py approach.  # noqa: E501
+                    vehicle_json_file = (
+                        os.getcwd()
+                        + '/../new_params_mversion/%s/parameters-%s.json'
+                        % ("AntennaTracker", "AntennaTracker")
+                    )  # noqa: E501
                 else:
-                    vehicle_json_file = os.getcwd() + '/../new_params_mversion/%s/parameters-%s.json' % (value, key.title())
+                    vehicle_json_file = (
+                        os.getcwd()
+                        + '/../new_params_mversion/%s/parameters-%s.json'
+                        % (value, key.title())
+                    )
                 new_file = (
-                    key +
-                    "/source/_static/" +
-                    vehicle_json_file[str(vehicle_json_file).rfind("/")+1:])
+                    key
+                    + "/source/_static/"
+                    + vehicle_json_file[str(vehicle_json_file).rfind("/") + 1 :]
+                )
                 try:
                     debug("Moving " + vehicle_json_file)
                     # os.rename(vehicle_json_file, new_file)
@@ -696,8 +746,9 @@ def fetch_versioned_parameters(site=None):
 
                 # Copy all parameter files to vehicle folder IFF it is new
                 try:
-                    new_parameters_folder = (os.getcwd() +
-                                             '/../new_params_mversion/%s/' % value)
+                    new_parameters_folder = (
+                        os.getcwd() + '/../new_params_mversion/%s/' % value
+                    )
                     new_parameters_files = [
                         f for f in glob.glob(new_parameters_folder + "*.rst")
                     ]
@@ -707,25 +758,67 @@ def fetch_versioned_parameters(site=None):
                 for filename in new_parameters_files:
                     # Check possible cached version
                     try:
-                        new_file = (key +
-                                    "/source/docs/" +
-                                    filename[str(filename).rfind("/")+1:])
+                        new_file = (
+                            key
+                            + "/source/docs/"
+                            + filename[str(filename).rfind("/") + 1 :]
+                        )
                         if not os.path.isfile(new_file):
-                            debug("Copying %s to %s (target file does not exist)" % (filename, new_file))
+                            debug(
+                                "Copying %s to %s (target file does not exist)"
+                                % (filename, new_file)
+                            )
                             shutil.copy2(filename, new_file)
-                        elif os.path.isfile(filename.replace("new_params_mversion", "old_params_mversion")): # The cached file exists?  # noqa: E501
-
+                        elif os.path.isfile(
+                            filename.replace(
+                                "new_params_mversion", "old_params_mversion"
+                            )
+                        ):  # The cached file exists?  # noqa: E501
                             # Temporary debug messages to help with cache tasks.
-                            debug("Check cache: %s against %s" % (filename, filename.replace("new_params_mversion", "old_params_mversion")))  # noqa: E501
-                            debug("Check cache with filecmp.cmp: %s" % filecmp.cmp(filename, filename.replace("new_params_mversion", "old_params_mversion")))  # noqa: E501
-                            debug("Check cache with sha256: %s" % is_the_same_file(filename, filename.replace("new_params_mversion", "old_params_mversion")))  # noqa: E501
+                            debug(
+                                "Check cache: %s against %s"
+                                % (
+                                    filename,
+                                    filename.replace(
+                                        "new_params_mversion", "old_params_mversion"
+                                    ),
+                                )
+                            )  # noqa: E501
+                            debug(
+                                "Check cache with filecmp.cmp: %s"
+                                % filecmp.cmp(
+                                    filename,
+                                    filename.replace(
+                                        "new_params_mversion", "old_params_mversion"
+                                    ),
+                                )
+                            )  # noqa: E501
+                            debug(
+                                "Check cache with sha256: %s"
+                                % is_the_same_file(
+                                    filename,
+                                    filename.replace(
+                                        "new_params_mversion", "old_params_mversion"
+                                    ),
+                                )
+                            )  # noqa: E501
 
-                            if ("parameters.rst" in filename) or (not filecmp.cmp(filename, filename.replace("new_params_mversion", "old_params_mversion"))):    # It is different?  OR is this one the latest. | Latest file must be built every time in order to enable Sphinx create the correct references across the wiki.  # noqa: E501
+                            if (
+                                ("parameters.rst" in filename)
+                                or (
+                                    not filecmp.cmp(
+                                        filename,
+                                        filename.replace(
+                                            "new_params_mversion", "old_params_mversion"
+                                        ),
+                                    )
+                                )
+                            ):  # It is different?  OR is this one the latest. | Latest file must be built every time in order to enable Sphinx create the correct references across the wiki.  # noqa: E501
                                 debug("Overwriting %s to %s" % (filename, new_file))
                                 shutil.copy2(filename, new_file)
                             else:
                                 debug("It will reuse the last build of " + new_file)
-                        else:   # If not cached, copy it anyway.
+                        else:  # If not cached, copy it anyway.
                             debug("Copying %s to %s" % (filename, new_file))
                             shutil.copy2(filename, new_file)
 
@@ -740,17 +833,26 @@ def create_latest_parameter_redirect(default_param_file, vehicle):
     redirects to the latest parameters file.(Create to maintaim retro
     compatibility.)
     """
-    out_line = "======================\nParameters List (Full)(\n======================\n"
+    out_line = (
+        "======================\nParameters List (Full)(\n======================\n"
+    )
     out_line += "\n.. raw:: html\n\n"
-    out_line += "   <script>location.replace(\"" + default_param_file[:-3] + "html" + "\")</script>"
+    out_line += (
+        "   <script>location.replace(\""
+        + default_param_file[:-3]
+        + "html"
+        + "\")</script>"
+    )
     out_line += "\n\n"
 
     filename = vehicle + "/source/docs/parameters.rst"
     with open(filename, "w") as text_file:
         text_file.write(out_line)
 
-    debug("Created html automatic redirection from parameters.html to %shtml" %
-          default_param_file[:-3])
+    debug(
+        "Created html automatic redirection from parameters.html to %shtml"
+        % default_param_file[:-3]
+    )
 
 
 def cache_parameters_files(site=None):
@@ -759,10 +861,13 @@ def cache_parameters_files(site=None):
     old_params_mversion/ folders and .html built files as well.
     """
     for key, value in PARAMETER_SITE.items():
-        if (site == key or site is None) and (key != 'AP_Periph'):  # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
+        if (
+            (site == key or site is None) and (key != 'AP_Periph')
+        ):  # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
             try:
-                old_parameters_folder = (os.getcwd() +
-                                         '/../old_params_mversion/%s/' % value)
+                old_parameters_folder = (
+                    os.getcwd() + '/../old_params_mversion/%s/' % value
+                )
                 old_parameters_files = [
                     f for f in glob.glob(old_parameters_folder + "*.*")
                 ]
@@ -770,15 +875,14 @@ def cache_parameters_files(site=None):
                     debug("Removing %s" % file)
                     os.remove(file)
 
-                new_parameters_folder = (os.getcwd() +
-                                         '/../new_params_mversion/%s/' % value)
+                new_parameters_folder = (
+                    os.getcwd() + '/../new_params_mversion/%s/' % value
+                )
                 new_parameters_files = [
-                    f for f in glob.glob(new_parameters_folder +
-                                         "parameters-*.rst")
+                    f for f in glob.glob(new_parameters_folder + "parameters-*.rst")
                 ]
                 for filename in new_parameters_files:
-                    debug("Copying %s to %s" %
-                          (filename, old_parameters_folder))
+                    debug("Copying %s to %s" % (filename, old_parameters_folder))
                     shutil.copy2(filename, old_parameters_folder)
 
                 built_folder = os.getcwd() + "/" + key + "/build/html/docs/"
@@ -786,8 +890,7 @@ def cache_parameters_files(site=None):
                     f for f in glob.glob(built_folder + "parameters-*.html")
                 ]
                 for built in built_parameters_files:
-                    debug("Copying %s to %s" %
-                          (built, old_parameters_folder))
+                    debug("Copying %s to %s" % (built, old_parameters_folder))
                     shutil.copy2(built, old_parameters_folder)
 
             except Exception as e:
@@ -801,20 +904,24 @@ def put_cached_parameters_files_in_sites(site=None):
 
     """
     for key, value in PARAMETER_SITE.items():
-        if (site == key or site is None) and (key != 'AP_Periph'): # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
+        if (
+            (site == key or site is None) and (key != 'AP_Periph')
+        ):  # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
             try:
-                built_folder = (os.getcwd() +
-                                '/../old_params_mversion/%s/' % value)
+                built_folder = os.getcwd() + '/../old_params_mversion/%s/' % value
                 built_parameters_files = [
                     f for f in glob.glob(built_folder + "parameters-*.html")
                 ]
                 vehicle_folder = os.getcwd() + "/" + key + "/build/html/docs/"
-                debug("Site %s getting previously built files from %s" %
-                      (site, built_folder))
+                debug(
+                    "Site %s getting previously built files from %s"
+                    % (site, built_folder)
+                )
                 for built in built_parameters_files:
-                    if ("latest" not in built):  # latest parameters files must be built every time
-                        debug("Reusing built %s in %s " %
-                              (built, vehicle_folder))
+                    if (
+                        "latest" not in built
+                    ):  # latest parameters files must be built every time
+                        debug("Reusing built %s in %s " % (built, vehicle_folder))
                         shutil.copy(built, vehicle_folder)
             except Exception as e:
                 error(e)
@@ -854,15 +961,24 @@ def copy_static_html_sites(site, destdir):
 def check_imports():
     '''check key imports work'''
     import importlib.metadata
+
     # package names to check the versions of. Note that these can be different than the string used to import the package
-    required_packages = ["sphinx_rtd_theme>=1.3.0", "sphinxcontrib.youtube>=1.2.0", "sphinx>=7.1.2", "docutils<0.19"]
+    required_packages = [
+        "sphinx_rtd_theme>=1.3.0",
+        "sphinxcontrib.youtube>=1.2.0",
+        "sphinx>=7.1.2",
+        "docutils<0.19",
+    ]
     for package in required_packages:
         debug("Checking for %s" % package)
         try:
             importlib.metadata.version(package.split("<")[0].split(">=")[0])
         except importlib.metadata.PackageNotFoundError as ex:
             progress(ex)
-            fatal("Require %s\nPlease run the wiki build setup script \"Sphinxsetup\"" % package)
+            fatal(
+                "Require %s\nPlease run the wiki build setup script \"Sphinxsetup\""
+                % package
+            )
     debug("Imports OK")
 
 
@@ -882,9 +998,13 @@ def check_ref_directives():
             try:
                 for i, line in enumerate(file.readlines()):
                     if character_before_ref_tag.search(line):
-                        error(f"Remove character before ref directive in \"{f}\" on line number {i+1}")
+                        error(
+                            f"Remove character before ref directive in \"{f}\" on line number {i + 1}"
+                        )
                     if character_after_ref_tag.search(line):
-                        error(f"Remove character after ref directive in \"{f}\" on line number {i+1}")
+                        error(
+                            f"Remove character after ref directive in \"{f}\" on line number {i + 1}"
+                        )
             except UnicodeDecodeError as ex:
                 print("UnicodeError in %s: " % f, ex)
                 sys.exit(1)
@@ -899,8 +1019,11 @@ def create_features_pages(site):
     # grab build_options which allows us to map from define to name
     # and description.  Create a convenience hash for it
     remove_if_exists("build_options.py")
-    fetch_url("https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/scripts/build_options.py")
+    fetch_url(
+        "https://raw.githubusercontent.com/ArduPilot/ardupilot/master/Tools/scripts/build_options.py"
+    )
     import build_options
+
     build_options_by_define = {}
     for f in build_options.BUILD_OPTIONS:
         build_options_by_define[f.define] = f
@@ -949,7 +1072,7 @@ def create_features_page(features, build_options_by_define, vehicletype):
     rows = []
     column_headings = ["Category", "Feature", "Included", "Description"]
     all_tables = ""
-    for platform_key in sorted(features_by_platform.keys(), key=lambda x : x.lower()):
+    for platform_key in sorted(features_by_platform.keys(), key=lambda x: x.lower()):
         rows = []
         platform_features = features_by_platform[platform_key]
         sorted_platform_features_in = []
@@ -964,8 +1087,10 @@ def create_features_page(features, build_options_by_define, vehicletype):
                 build_options = build_options_by_define[feature]
             except KeyError:
                 # mismatch between build_options.py and features.json
-                progress("feature %s (%s,%s) not in build_options.py" %
-                         (feature, platform_key, vehicletype))
+                progress(
+                    "feature %s (%s,%s) not in build_options.py"
+                    % (feature, platform_key, vehicletype)
+                )
                 continue
             if feature_in:
                 some_list = sorted_platform_features_in
@@ -973,11 +1098,11 @@ def create_features_page(features, build_options_by_define, vehicletype):
                 some_list = sorted_platform_features_not_in
             some_list.append((build_options.category, feature))
 
-        sorted_platform_features = (
-            sorted(sorted_platform_features_not_in, key=lambda x : x[0] + x[1]) +
-            sorted(sorted_platform_features_in, key=lambda x : x[0] + x[1]))
+        sorted_platform_features = sorted(
+            sorted_platform_features_not_in, key=lambda x: x[0] + x[1]
+        ) + sorted(sorted_platform_features_in, key=lambda x: x[0] + x[1])
 
-        for (category, feature) in sorted_platform_features:
+        for category, feature in sorted_platform_features:
             build_options = build_options_by_define[feature]
             row = [category, build_options.label]
             if features_in[feature]:
@@ -994,23 +1119,27 @@ def create_features_page(features, build_options_by_define, vehicletype):
         else:
             t = rst_table.tablify(rows, headings=column_headings)
         underline = "-" * len(platform_key)
-        all_tables += ('''
+        all_tables += '''
 .. _%s:
 
 %s
 %s
 
 %s
-''' % (reference_for_board(platform_key), platform_key, underline, t))
+''' % (reference_for_board(platform_key), platform_key, underline, t)
 
     index = ""
-    for board in sorted(features_by_platform.keys(), key=lambda x : x.lower()):
+    for board in sorted(features_by_platform.keys(), key=lambda x: x.lower()):
         index += '- :ref:`%s<%s>`\n\n' % (board, reference_for_board(board))
 
     all_features_rows = []
-    for feature in sorted(build_options_by_define.values(), key=lambda x : (x.category + x.label).lower()):
+    for feature in sorted(
+        build_options_by_define.values(), key=lambda x: (x.category + x.label).lower()
+    ):
         all_features_rows.append([feature.category, feature.label, feature.description])
-    all_features = rst_table.tablify(all_features_rows, headings=["Category", "Feature", "Description"])
+    all_features = rst_table.tablify(
+        all_features_rows, headings=["Category", "Feature", "Description"]
+    )
 
     return '''
 .. _binary-features:
@@ -1042,11 +1171,11 @@ Boards
 %s
 ''' % (vehicletype, index, all_features, all_tables)
 
+
 #######################################################################
 
 
 if __name__ == "__main__":
-
     if platform.system() == "Windows":
         multiprocessing.freeze_support()
 
@@ -1108,8 +1237,10 @@ if __name__ == "__main__":
         dest='fast',
         action='store_true',
         default=False,
-        help=("Incremental build using already downloaded parameters, log messages, and video thumbnails rather than cleaning "
-              "before build."),
+        help=(
+            "Incremental build using already downloaded parameters, log messages, and video thumbnails rather than cleaning "
+            "before build."
+        ),
     )
 
     args = parser.parse_args()
@@ -1161,7 +1292,7 @@ if __name__ == "__main__":
     if error_count > 0:
         progress("Reprinting error messages:", file=sys.stderr)
         for msg in error_log:
-            print(f"\033[1;31m[update.py][error]: {msg}\033[0m", file=sys.stderr) # noqa: E702,E231
+            print(f"\033[1;31m[update.py][error]: {msg}\033[0m", file=sys.stderr)  # noqa: E702,E231
         fatal(f"{error_count} errors during Wiki build")
     else:
         print("Build completed without errors")


### PR DESCRIPTION
Blocked by: #7458 or #7467
* #7458
* #7467 

https://docs.astral.sh/ruff/formatter

% `ruff format --config="format.quote-style='preserve'" ` # as discussed in
* #6996 

The goal of this pull request is explained in the first paragraph of the [`psf/black` docs](https://black.readthedocs.io):
> By using `Black`, you agree to cede control over minutiae of hand-formatting. In return, `Black` gives you speed, determinism, and freedom from `pycodestyle` nagging about formatting. You will save time and mental energy for more important matters.