### PR TITLE
Fix capitalization in analog pins documentation

### DIFF
--- a/common/source/docs/common-analog-pins.rst
+++ b/common/source/docs/common-analog-pins.rst
@@ -12,7 +12,7 @@ In addition to digital input and output pins, autopilots have analog input pins 
 - Analog Sonar/Rangefinder Input
 - Analog Temperature Sensor Input
 
-.. note:: all pins can accept 0-3.3v inputs. Unless the documentation (OEM or Wiki) specifically specifies 6.6V input range, only apply 3.3 maximum!
+.. Note:: All pins can accept 0-3.3v inputs. Unless the documentation (OEM or Wiki) specifically specifies 6.6V input range, only apply 3.3 maximum!
 
 When any of these inputs are enabled by the appropriate sensor type selection, a ``_PIN`` parameter will need to be entered to designate which "pin" on the autopilot is to be used. Often, the correct pin number for the autopilot's analog inputs will be documented either on its Wiki page here, or the OEM's documentation.
 


### PR DESCRIPTION
Correct capitalization in note about input voltage range.