### PR TITLE
Fixed link to flight mode numbers in log download documentation page

### DIFF
--- a/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
+++ b/common/source/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.rst
@@ -534,7 +534,7 @@ SubSystem and Error codes listed below
 
 Vehicle was unable to enter the desired flight mode normally because of a bad position estimate
 
-See `flight mode numbers here <https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/defines.h#L34>`__
+See `flight mode numbers here <https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode.h#L77>`__
 
 .. raw:: html
 


### PR DESCRIPTION
Changed the link in
/copter/docs/common-downloading-and-analyzing-data-logs-in-mission-planner.html at the error list to point at mode.h instead of defines.h. The link is supposed to lead to "flight mode numbers" yet defines.h doesn't have them.