### PR TITLE
docker: allow to build the paramversionning into docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM python:3.11-slim-bookworm
 
-
-
 ARG DEBIAN_FRONTEND=noninteractive
 ARG USER_NAME=ardupilot_wiki
 ARG USER_UID=1000
@@ -14,9 +12,13 @@ RUN groupadd ${USER_NAME} --gid ${USER_GID}\
 
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
+    bash-completion \
+    git \
     software-properties-common \
     lsb-release \
-    sudo
+    sudo \
+    && sudo apt-get clean \
+    && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ENV USER=${USER_NAME}
 
@@ -32,5 +34,20 @@ RUN --mount=type=cache,target=/var/cache/apt \
     bash -c "./Sphinxsetup.sh"
 
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ARG PARAMVERSIONING=0
+ENV PARAMVERSIONING=$PARAMVERSIONING
+WORKDIR /
+RUN if [ "$PARAMVERSIONING" -ne 1 ]; then echo "Not building paramversionning"; \
+     else echo 'Building paramversionning' \
+    && sudo git clone https://github.com/ArduPilot/ardupilot.git --depth 1 \
+    && sudo mkdir -p old_params_mversion \
+    && sudo chown -R ${USER_NAME}:${USER_NAME} /ardupilot \
+    && mkdir -p /${USER_NAME}/new_params_mversion /${USER_NAME}/old_params_mversion \
+    && sudo chown -R ${USER_NAME}:${USER_NAME} /${USER_NAME}/new_params_mversion /${USER_NAME}/old_params_mversion \
+    && sudo ln -s /${USER_NAME}/new_params_mversion /new_params_mversion \
+    && sudo ln -s /${USER_NAME}/old_params_mversion /old_params_mversion; fi
+
+WORKDIR ${WORKDIRECTORY}
 
 ENV PATH="/home/${USER_NAME}/.local/bin:${PATH}"


### PR DESCRIPTION
Allow to build the wiki with param versionning using docker.
The ardupilot cloned repo stay on the container, so that won't mess with the local filesystem.
bash-completion isn't strictly necessary but usefull for those like me that use docker.

Docker Build command : 

`docker build . -t ardupilot_wiki --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) --build-arg PARAMVERSIONING=1`

example Wiki build (don't do this if you don't have 12Go RAM free and lot of time) : 

`docker run --rm -it -v "$(pwd):/ardupilot_wiki" -u "$(id -u):$(id -g)" ardupilot_wiki python3 build_parameters.py --destination /ardupilot_wiki/new_params_mversion
`
`docker run --rm -it -v "$(pwd):/ardupilot_wiki"  -u "$(id -u):$(id -g)" ardupilot_wiki python3 update.py --site copter --paramversioning`