### PR TITLE
pre-commit: run in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,15 @@ env:
   TEST: "1"
 jobs:
 
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.10"
+    - uses: pre-commit/action@v3.0.1
+
   build-linux:
 
     runs-on: ubuntu-22.04
@@ -39,10 +48,6 @@ jobs:
                   exit 1
               fi
           done
-      - name: Check python3 flake8 formatting
-        run : |
-          set -eux -o pipefail
-          flake8 .
       - name: Test build
         run: |
           export AP_SPHINXOPTS=-W

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,3 @@ git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
 
 # and a parser to use getting posts from Discourse (forum) and insert in FrontEnd
 beautifulsoup4
-
-# Install flake8
-flake8==7.3.0


### PR DESCRIPTION
In a GitHub Action, run `pre-commit run --all-files` on all pull requests.  While some developers will `pre-commit install` locally, this will ensure that `pre-commit` passes even for those who have not done so.

Like:
* https://github.com/ArduPilot/ardupilot/pull/30270

