### PR TITLE
Docker build: There is no matrix so `fail-fast` is useless

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -7,8 +7,6 @@ jobs:
   build-docker:
 
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false  # don't cancel if a job from the matrix fails
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Also, why not build using [`ubuntu-latest`](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images) instead of 4 year old `ubuntu-22.04`?