### PR TITLE
Python Style Guide PEP8: line breaks and binary operators

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,8 +8,8 @@ ignore =
     E226,
     # E261 at least two spaces before inline comment
     E261,
-    # W504 line break after binary operator
-    W504,
+    # W503 line break before binary operator
+    W503,
     # E203 whitespace before ':'
     E203,
     # E221 multiple spaces before operator

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -386,12 +386,12 @@ def generate_rst_files(commits_to_checkout_and_parse):
         # Not elegant workaround:
         # These versions present errors when parsing using param_parser.py. Needs more investigation?
         if (
-            "3.2.1" in version or # last stable APM Copte
-            "3.4.0" in version or # last stable APM Plane
-            "3.4.6" in version or # Copter
-            "2.42" in version or  # last stable APM Rover?
-            "2.51" in version or  # last beta APM Rover?
-            "0.7.2" in version    # Antennatracker
+            "3.2.1" in version # last stable APM Copte
+            or "3.4.0" in version # last stable APM Plane
+            or "3.4.6" in version # Copter
+            or "2.42" in version  # last stable APM Rover?
+            or "2.51" in version  # last beta APM Rover?
+            or "0.7.2" in version    # Antennatracker
         ):
             debug(f"Ignoring APM version:\t{vehicle}\t{version}")
             continue

--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -138,8 +138,8 @@ class BlogPostsFetcher:
                 first_five_lines) else None
 
         # If there are image links before YouTube links, return empty string
-        if img_links and (not youtube_links or
-                          first_five_lines.index(img_links) < first_five_lines.index(youtube_links[0])):
+        if img_links and (not youtube_links
+                          or first_five_lines.index(img_links) < first_five_lines.index(youtube_links[0])):
             if 'github.com' in img_links:
                 img_links = img_links + "?raw=true"
             return img_links, False

--- a/update.py
+++ b/update.py
@@ -937,8 +937,8 @@ def create_features_page(features, build_options_by_define, vehicletype):
             some_list.append((build_options.category, feature))
 
         sorted_platform_features = (
-            sorted(sorted_platform_features_not_in, key=lambda x : x[0] + x[1]) +
-            sorted(sorted_platform_features_in, key=lambda x : x[0] + x[1]))
+            sorted(sorted_platform_features_not_in, key=lambda x : x[0] + x[1])
+            + sorted(sorted_platform_features_in, key=lambda x : x[0] + x[1]))
 
         for (category, feature) in sorted_platform_features:
             build_options = build_options_by_define[feature]


### PR DESCRIPTION
### `.flake8`
```diff
-    # W504 line break after binary operator
-    W504,
+    # W503 line break before binary operator
+    W503,
```
The change to `.flake8` is to be compliant with the Python Style Guide PEP8 as recommended at:
* https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#w503

---
* [x] #7494 removed many changes to `update.py`.
* [ ] #7561 will remove many more.