### PR TITLE
Clarify EKF3 Affinity

### DIFF
--- a/common/source/docs/common-ek3-affinity-lane-switching.rst
+++ b/common/source/docs/common-ek3-affinity-lane-switching.rst
@@ -6,30 +6,41 @@ EKF3 Affinity and Lane Switching
 ================================
 
 The :ref:`EKF <dev:extended-kalman-filter>` instantiates multiple instances of the filter called 'lanes'.
-The primary lane is the one that provides state estimates, rest are updated in the background and available for switching to.
-The number of possible lanes is exactly equal to the number of IMUs enabled for use.
-Conventionally, each lane uses the primary instance of the Airspeed, Barometer, GPS and Magnetometer sensors.
-The primary sensor can be set as a user-modifiable parameter, but can be later changed by the system, even in-flight, in case of a driver-level fault.
-However, modern-day vehicles are known to have multiple sensors installed of good quality.
-Affinity is a way for the EKF lanes to use non-primary sensors within any running lane.
-This provides a statistically consistent way to make use of multiple high quality sensors and use lane-switching to select the lane which has best performing combination of sensors.
-The lane error score takes into account innovations from all sensors used by a lane.
-This way, the vehicle can be saved from mishaps using noisy non-IMU sensors as well.
+The "primary" lane is the one currently providing state estimates, other lanes are updated in the background and available for switching to.
 
+.. note::
 
-**A simple example of an affinity configuration for a vehicle which has 2 Barometers, 2 GPS, 2 Airspeeds, 3 Magnetometers and 3 IMUs -**
+    This page describes an advanced configuration topic. The source code is the truth. This page hopefully provides conceptual clarity, but it *is not perfect* on the details.
+
+The number of possible lanes is the number of IMUs enabled for use (see :ref:`EK3_IMU_MASK <EK3_IMU_MASK>`).
+Furthermore, the lanes are 1-1 bound to the (used) IMUs: lane 1 for IMU 1, lane 2 for IMU 2, etc.
+
+For each of the other sensor-types {Airspeed, Barometer, GPS, and Magnetometer (aka Compass)}:
+If affinity for that sensor-type is disabled, each lane uses the system's "primary" instance of the sensor.
+(Affinity being disabled for every sensor-type is the conventional/default choice.)
+The initial primary sensor instance is selected by a user-modifiable parameter.
+The system may change which sensor instance is its primary, even in-flight, for example in case of a sensor fault.
+
+Because modern-day vehicles may have redundant good quality sensors installed, "affinity" provides a way to have some EKF lanes prefer sensor instances which are not the system-wide primary.
+For sensors with affinity enabled, lane-switching should be thought of as sensor-switching.
+The lane error score (used to make a switching decision) takes into account innovations from all sensors used by a lane.
+Thus in the case of noisy-but-not-broken non-IMU sensors, affinity might avoid a mishap by simply EKF lane-switching to a less-noisy IMU+sensor combination.
+
+**Example: Vehicle uses 4 IMUs, 2 Airspeeds, 3 Barometers, 2 GPS, and 3 Magnetometers.
+Affinity is disabled for airspeed & barometers, enabled for GPS & magnetometers.**
 
 .. raw:: html
 
    <table border="1" class="docutils">
-   <tr><th>LANE</th><th>1</th><th>2</th><th>3</th></tr>
-   <tr><td>AIRSPEED</td><td>1</td><td>2</td><td>1</td></tr>
-   <tr><td>BAROMETER</td><td>1</td><td>2</td><td>1</td></tr>
-   <tr><td>GPS</td><td>1</td><td>2</td><td>1</td></tr>
-   <tr><td>MAGNETOMETER</td><td>1</td><td>2</td><td>3</td></tr>
+   <tr><th>LANE</th><th>1</th><th>2</th><th>3</th><th>4</th></tr>
+   <tr><td>IMU</td><td>1</td><td>2</td><td>3</td><td>4</td></tr>
+   <tr><td>AIRSPEED</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+   <tr><td>BAROMETER</td><td>1</td><td>1</td><td>1</td><td>1</td></tr>
+   <tr><td>GPS</td><td>1</td><td>2</td><td>1</td><td>1</td></tr>
+   <tr><td>MAGNETOMETER</td><td>1</td><td>2</td><td>3</td><td>1</td></tr>
    </table>
 
-*Numbers are the respective sensor instances*
+*Numbers indicate the lane's initial primary sensor instance.*
 
 Configuration Parameters
 ------------------------
@@ -39,7 +50,8 @@ Configuration Parameters
     Affinity is only available with EKF3, so make sure you are using it by ensuring :ref:`EK3_ENABLE <EK3_ENABLE>` is set to "1" and :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` is set to "3"
 
 The :ref:`EK3_AFFINITY <EK3_AFFINITY>` parameter is a bitmask which gives you the option to choose the sensors you want to enable affinity for.
-Non-enabled will follow the default primary sensor allotment.
+In every EKF lane, sensors for which affinity is not enabled will follow the system's "primary" selection logic.
+For a sensor-type with affinity enabled, lane 1's primary sensor is 1, lane 2's primary sensor is 2, etc.
 
 The :ref:`EK3_ERR_THRESH <EK3_ERR_THRESH>` parameter controls the sensitivity of lane switching. Lane errors are accumulated over time relative to the active primary lane. This threshold controls how much of an error difference between a non-primary and primary lane is required to consider the former performing better. Lowering this parameter makes lane switching more responsive to smaller 'relative' errors, and in practical you will see a more aggressive lane switching, and, vice-versa.
 

--- a/common/source/docs/common-ek3-affinity-lane-switching.rst
+++ b/common/source/docs/common-ek3-affinity-lane-switching.rst
@@ -5,7 +5,16 @@
 EKF3 Affinity and Lane Switching
 ================================
 
-The :ref:`EKF <dev:extended-kalman-filter>` instantiates multiple instances of the filter called 'lanes'. The primary lane is the one that provides state estimates, rest are updated in the background and available for switching to. The number of possible lanes is exactly equal to the number of IMUs enabled for use. Conventionally, each lane uses the primary instance of the Airspeed, Barometer, GPS and Magnetometer sensors. The primary sensor can be set as a user-modifiable parameter, but can be later changed by the system, even in-flight, in case of a driver-level fault. However, modern-day vehicles are known to have multiple sensors installed of good quality. Affinity is a way for the EKF lanes to use non-primary sensors within any running lane. This provides a statistically consistent way to make use of multiple high quality sensors and use lane-switching to select the lane which has best performing combination of sensors. The lane error score takes into account innovations from all sensors used by a lane. This way, the vehicle can be saved from mishaps using noisy non-IMU sensors as well.
+The :ref:`EKF <dev:extended-kalman-filter>` instantiates multiple instances of the filter called 'lanes'.
+The primary lane is the one that provides state estimates, rest are updated in the background and available for switching to.
+The number of possible lanes is exactly equal to the number of IMUs enabled for use.
+Conventionally, each lane uses the primary instance of the Airspeed, Barometer, GPS and Magnetometer sensors.
+The primary sensor can be set as a user-modifiable parameter, but can be later changed by the system, even in-flight, in case of a driver-level fault.
+However, modern-day vehicles are known to have multiple sensors installed of good quality.
+Affinity is a way for the EKF lanes to use non-primary sensors within any running lane.
+This provides a statistically consistent way to make use of multiple high quality sensors and use lane-switching to select the lane which has best performing combination of sensors.
+The lane error score takes into account innovations from all sensors used by a lane.
+This way, the vehicle can be saved from mishaps using noisy non-IMU sensors as well.
 
 
 **A simple example of an affinity configuration for a vehicle which has 2 Barometers, 2 GPS, 2 Airspeeds, 3 Magnetometers and 3 IMUs -**
@@ -29,7 +38,8 @@ Configuration Parameters
 
     Affinity is only available with EKF3, so make sure you are using it by ensuring :ref:`EK3_ENABLE <EK3_ENABLE>` is set to "1" and :ref:`AHRS_EKF_TYPE <AHRS_EKF_TYPE>` is set to "3"
 
-The :ref:`EK3_AFFINITY <EK3_AFFINITY>` parameter is a bitmask which gives you the option to choose the sensors you want to enable affinity for. Non-enabled will follow the default primary sensor allotment.
+The :ref:`EK3_AFFINITY <EK3_AFFINITY>` parameter is a bitmask which gives you the option to choose the sensors you want to enable affinity for.
+Non-enabled will follow the default primary sensor allotment.
 
 The :ref:`EK3_ERR_THRESH <EK3_ERR_THRESH>` parameter controls the sensitivity of lane switching. Lane errors are accumulated over time relative to the active primary lane. This threshold controls how much of an error difference between a non-primary and primary lane is required to consider the former performing better. Lowering this parameter makes lane switching more responsive to smaller 'relative' errors, and in practical you will see a more aggressive lane switching, and, vice-versa. 
 

--- a/common/source/docs/common-ek3-affinity-lane-switching.rst
+++ b/common/source/docs/common-ek3-affinity-lane-switching.rst
@@ -41,10 +41,10 @@ Configuration Parameters
 The :ref:`EK3_AFFINITY <EK3_AFFINITY>` parameter is a bitmask which gives you the option to choose the sensors you want to enable affinity for.
 Non-enabled will follow the default primary sensor allotment.
 
-The :ref:`EK3_ERR_THRESH <EK3_ERR_THRESH>` parameter controls the sensitivity of lane switching. Lane errors are accumulated over time relative to the active primary lane. This threshold controls how much of an error difference between a non-primary and primary lane is required to consider the former performing better. Lowering this parameter makes lane switching more responsive to smaller 'relative' errors, and in practical you will see a more aggressive lane switching, and, vice-versa. 
+The :ref:`EK3_ERR_THRESH <EK3_ERR_THRESH>` parameter controls the sensitivity of lane switching. Lane errors are accumulated over time relative to the active primary lane. This threshold controls how much of an error difference between a non-primary and primary lane is required to consider the former performing better. Lowering this parameter makes lane switching more responsive to smaller 'relative' errors, and in practical you will see a more aggressive lane switching, and, vice-versa.
 
 .. warning::
-    
+
     Misconfiguring the :ref:`EK3_ERR_THRESH <EK3_ERR_THRESH>` parameter could adversely affect the lane switching mechanism and have serious consequences which could lead to the loss of your vehicle. Please tune carefully.
 
 

--- a/common/source/docs/common-ek3-affinity-lane-switching.rst
+++ b/common/source/docs/common-ek3-affinity-lane-switching.rst
@@ -10,21 +10,28 @@ The "primary" lane is the one currently providing state estimates, other lanes a
 
 .. note::
 
-    This page describes an advanced configuration topic. The source code is the truth. This page hopefully provides conceptual clarity, but it *is not perfect* on the details.
+    This page attempts to clarify an advanced configuration topic. The source code is the truth.
 
 The number of possible lanes is the number of IMUs enabled for use (see :ref:`EK3_IMU_MASK <EK3_IMU_MASK>`).
 Furthermore, the lanes are 1-1 bound to the (used) IMUs: lane 1 for IMU 1, lane 2 for IMU 2, etc.
 
-For each of the other sensor-types {Airspeed, Barometer, GPS, and Magnetometer (aka Compass)}:
-If affinity for that sensor-type is disabled, each lane uses the system's "primary" instance of the sensor.
-(Affinity being disabled for every sensor-type is the conventional/default choice.)
+Now, consider the other sensor types {Airspeed, Barometer, GPS, and Magnetometer (aka Compass)}.
+First, it is important to define the system's notion of the "primary" sensor instance of each type.
+The primary sensor instance is the instance being actively relied upon.
 The initial primary sensor instance is selected by a user-modifiable parameter.
 The system may change which sensor instance is its primary, even in-flight, for example in case of a sensor fault.
+Thus "changing the primary instance" is one mechanism the system can use to switch which sensor instance is being relied upon.
 
-Because modern-day vehicles may have redundant good quality sensors installed, "affinity" provides a way to have some EKF lanes prefer sensor instances which are not the system-wide primary.
-For sensors with affinity enabled, lane-switching should be thought of as sensor-switching.
-The lane error score (used to make a switching decision) takes into account innovations from all sensors used by a lane.
-Thus in the case of noisy-but-not-broken non-IMU sensors, affinity might avoid a mishap by simply EKF lane-switching to a less-noisy IMU+sensor combination.
+A second mechanism for selecting which sensor instance to rely on is provided by "affinity" & lane-switching.
+Because modern-day vehicles may have redundant good quality sensors installed, affinity provides a way to force some EKF lanes to prefer sensor instances which are not the system-wide primary.
+If affinity for a sensor-type is disabled, each lane uses the system's primary instance of the sensor.
+(Affinity being disabled is the conventional/default choice.)
+If affinity for a sensor-type is enabled, the sensor instances are distributed to lanes in a similar way as IMUs.
+Now with affinity enabled, lane-switching becomes a mechanism for sensor-switching.
+Each lane's error score---used by the system to make a switching decision---takes into account innovations from all sensors used by that lane.
+Consider a noisy but not faulted sensor for which affinity is enabled: it makes the error-score for its lane bad.
+The system responds to the bad error score by lane-switching away from relying on it.
+Thus a mishap may be avoided by simply EKF lane-switching to a less-noisy IMU+sensor combination.
 
 **Example: Vehicle uses 4 IMUs, 2 Airspeeds, 3 Barometers, 2 GPS, and 3 Magnetometers.
 Affinity is disabled for airspeed & barometers, enabled for GPS & magnetometers.**


### PR DESCRIPTION
EKF3 affinity is difficult to understand from our wiki docs. This (hopefully!) improves it's clarity.

**Reviewers: I determined this from source-diving. Please carefully examine this PR's content for mistakes.**

Summary of significant points:
- The concept of "primary" is clarified. We have both "primary" EKF lanes, but also "primary" sensor instances.
- The 1-1ness of lanes & used IMU instances was inferred, but is now explicitly stated.
- The example provided was too simple. The new example shows more.

The first commit switches to one-sentence-per-line. I find this style much easier for future reviews/changes. (I did not fix the whole file. That has the downside of leaving us with mixed style in a single file. IMO, any movement towards one-sentence-per-line is improvement.) I will revert this to preserve the "one paragraph per line" style if any reviewer objects.

The second commit fixes some trailing whitespace. I'll drop it if any reviewer objects.

Testing:
Built locally, renders as expected. (The image may be outdated as we wordsmith via the review process.)
<img width="551" height="817" alt="image" src="https://github.com/user-attachments/assets/97eb30ed-34d6-4377-b88b-7628f338c1b9" />
