### PR TITLE
Add pre-commit to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,6 @@ git+https://github.com/ArduPilot/sphinxcontrib-youtube.git
 
 # and a parser to use getting posts from Discourse (forum) and insert in FrontEnd
 beautifulsoup4
+
+# The pre-commit tool is used to run rapid tools like linters, spellcheckers, and formatters.
+pre-commit


### PR DESCRIPTION
Add pre-commit tool to our requirements for running rapid tools like linters, spellcheckers, and formatters.