### PR TITLE
Enable sphinx-lint rule dangling-hyphen

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,6 @@ repos:
       - id: sphinx-lint
         args:
           - --disable=backtick-before-role
-          - --disable=dangling-hyphen
           - --disable=horizontal-tab
           - --disable=hyperlink-reference-missing-backtick
           - --disable=missing-final-newline

--- a/copter/source/docs/traditional-helicopter-first-flight-tests.rst
+++ b/copter/source/docs/traditional-helicopter-first-flight-tests.rst
@@ -30,8 +30,8 @@ Hover Trim
 
 Trimming the helicopter in pitch and roll axes is an important step to keep the
 aircraft from drifting in modes like Stabilize and Althold.  The trim attitude 
-in the roll axis is affected by the tail rotor thrust.  All conventional single-
-rotor helicopters with a torque-compensating tail rotor hover either right skid 
+in the roll axis is affected by the tail rotor thrust.  All conventional single-rotor
+helicopters with a torque-compensating tail rotor hover either right skid 
 low or left skid low, depending on which way the main rotor turns. The 
 ArduCopter software has a parameter, :ref:`ATC_HOVR_ROL_TRM<ATC_HOVR_ROL_TRM>`, to compensate for this phenomenon. 
 Dual rotor helicopters have counter rotating rotor systems which mostly cancel the torque.  For these aircraft,

--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -22,7 +22,7 @@ A demo of AirSim running with ArduPilot SITL
 .. youtube:: ElFAqtpEfKo
     :width: 100%
 
-A list of topics for easier navigation in the page-
+A list of topics for easier navigation in the page:
 
 #. :ref:`Install AirSim <sitl-with-airsim-install>`
 
@@ -144,7 +144,7 @@ The file is in usual JSON format. On the first startup, AirSim would create ``se
 Launch Copter SITL
 ++++++++++++++++++
 
-For using ArduCopter, the settings are as follows-
+For using ArduCopter, the settings are as follows:
 
 ::
 
@@ -193,7 +193,7 @@ You can restart by just pressing the Play button and then start the ArduPilot si
 Launch Rover SITL
 +++++++++++++++++
 
-``settings.json`` for using ArduRover-
+``settings.json`` for using ArduRover:
 
 ::
 
@@ -511,7 +511,7 @@ A ROS wrapper has also been added. See `airsim_ros_pkgs <https://github.com/micr
 Run on different machines
 +++++++++++++++++++++++++
 
-#. Change the following in the ``settings.json`` file-
+#. Change the following in the ``settings.json`` file:
 
     #. ``UdpIp`` to the IP address of the machine running ArduPilot (Can be found using ``ipconfig`` on Windows, ``ifconfig`` on Linux.)
     #. ``LocalHostIp`` to the IP address of the current machine which is running AirSim, specific to the network adapter being used such as Ethernet or WiFi. Can be set to ``0.0.0.0`` to receive messages on all networks
@@ -519,7 +519,7 @@ Run on different machines
 
 #. Use ``-A`` argument in ``sim_vehicle.py`` (passes the arguments following it to the SITL instance), followed by ``--sim-address`` to specify Airsim's IP address
 
-An example-
+An example:
 
 ::
 
@@ -541,7 +541,7 @@ Using different ports
 - ``--sim-port-in`` should be equal to sensor port i.e. port specified in ``UdpPort``
 - ``--sim-port-out`` should be equal to motor control port i.e. port specified in ``ControlPort``
 
-Similar to changing the IP address as mentioned above, use ``-A`` to pass the arguments to the SITL instance. Example-
+Similar to changing the IP address as mentioned above, use ``-A`` to pass the arguments to the SITL instance. Example:
 
 ::
 

--- a/dev/source/docs/submitting-patches-back-to-master.rst
+++ b/dev/source/docs/submitting-patches-back-to-master.rst
@@ -39,8 +39,8 @@ Preparing commits
   describe what it does. Be prepared to explain/defend the importance of
   any new comments to reviewers, and defer to their judgement to resolve
   any disagreement over a comment's value. Comments should not explain
-  "what" code does, they explain "why" (or perhaps "how" in a clever-but-
-  difficult implementation).
+  "what" code does, they explain "why" (or perhaps "how" in a
+  clever-but-difficult implementation).
 
 - Resist moving code within files/libraries. Preserving the in-file
   location of code is preferred over rearranging the file(s) to improve


### PR DESCRIPTION
* #7506

Remove the --disable=dangling-hyphen option from sphinx-lint running in pre-commit.

Careful review, please, because I mostly use markdown, not reStructuredText.