### PR TITLE
Enable sphinx-lint rules role-without-backticks and missing-space-in-hyperlink

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,8 +36,6 @@ repos:
           - --disable=missing-space-after-role
           - --disable=missing-space-before-default-role
           - --disable=missing-space-before-role
-          - --disable=missing-space-in-hyperlink
           - --disable=missing-underscore-after-hyperlink
-          - --disable=role-without-backticks
           - --disable=trailing-whitespace
           - --disable=unbalanced-inline-literals-delimiters

--- a/common/source/docs/common-corvonf405v2_1.rst
+++ b/common/source/docs/common-corvonf405v2_1.rst
@@ -46,7 +46,7 @@ RC Input
 The default RC input is configured on the UART6_RX input which is inverted from the SBUS pin. Other RC  protocols  should be applied at UART1 which has DMA, and set the :ref:`SERIAL1_PROTOCOL<SERIAL1_PROTOCOL>` ='23' and change :ref:`SERIAL6_PROTOCOL<SERIAL6_PROTOCOL>` to something other than '23'.
 
 * CRSF/ELRS also requires a TX1 connection, in addition to RX1, and automatically provides telemetry.
-* FPort requires connection to TX1 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to "7". See :ref:common-FPort-receivers.
+* FPort requires connection to TX1 and :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` set to "7". See :ref:`common-FPort-receivers`.
 * SRXL2 requires a connection to TX2 and automatically provides telemetry. Set :ref:`SERIAL1_OPTIONS<SERIAL1_OPTIONS>` to “4”.
 
 OSD Support

--- a/common/source/docs/common-tbs-rc.rst
+++ b/common/source/docs/common-tbs-rc.rst
@@ -54,7 +54,7 @@ ELRS MAVLink Configuration
 Instead of CRSF protocol, MAVLink protocol can be used if the receiver is configured for it. In this case, using SERIAL 4 for example:
 
 - Set :ref:`SERIAL4_PROTOCOL <SERIAL4_PROTOCOL>` = 2
-- Set :ref:SERIAL4_BBAUD <SERIAL4_BAUDL>` = 115
+- Set :ref:`SERIAL4_BAUD <SERIAL4_BAUD>` = 115
 - Set :ref:`RSSI_TYPE <RSSI_TYPE>` = 5
 
 If the ELRS transmitter module has WIFI capability, then the telemetry data can be forwarded wirelessly to a PC or phone based GCS close to the transmitter.

--- a/common/source/docs/common-uavcan-peripherals.rst
+++ b/common/source/docs/common-uavcan-peripherals.rst
@@ -122,7 +122,7 @@ Servos and Actuators
     UltraMotion Can Servos* <https://www.ultramotion.com/servo-cylinder/>
     VimDrones <https://dev.vimdrones.com/products/vimdrones_can_servo_hub/>
 
-    * requires `LUA Scripting <common-lua-scripts> be setup and `LUA driver<https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/UltraMotion.lua>`__ used.
+    * requires `LUA Scripting <common-lua-scripts> be setup and `LUA driver <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/UltraMotion.lua>`__ used.
 
 ESCs/Output Expanders
 =====================


### PR DESCRIPTION
* #7506

Remove the `--disable=role-without-backticks` and `--disable=missing-space-in-hyperlink` options from `sphinx-lint` running in pre-commit.

Careful review, please, because I mostly use markdown, not reStructuredText.