### PR TITLE
Enable sphinx-lint rule missing-underscore-after-hyperlink

### DIFF
--- a/common/source/docs/common-ardusimple-rtk-gps-simplertk2b-budget.rst
+++ b/common/source/docs/common-ardusimple-rtk-gps-simplertk2b-budget.rst
@@ -47,7 +47,7 @@ XBee socket
 ===========
 The onboard XBee socket can be used to expand functionality with `Plugin accessories <https://www.ardusimple.com/radio-links/>`_ (MR/LR radios, Bluetooth, WiFi, Ethernet, Dataloggers, RS232, Canbus, L-Band). 
 
-Not compatible with high power XBee accessories (XLR radio and 4G NTRIP Master). To have this full compatibility consider `simpleRTK2B Pro. <https://www.ardusimple.com/product/simplertk2b-pro/>`
+Not compatible with high power XBee accessories (XLR radio and 4G NTRIP Master). To have this full compatibility consider `simpleRTK2B Pro. <https://www.ardusimple.com/product/simplertk2b-pro/>`__
 
 .. note:: The cables/connectors may be modified to connect to other autopilot boards, using the Pin Map information provided above.
 

--- a/common/source/docs/common-marvelmind.rst
+++ b/common/source/docs/common-marvelmind.rst
@@ -32,7 +32,7 @@ Connecting to an autopilot
 - Here is a package with tested param files for the Autopilot and Marvelmind hedge: <https://marvelmind.com/pics/marvelmind_ardupilot_settings.zip>
   Upload the param file corresponding to your version of Autopilot software with  Mission Planner or QGroundControl.
 - Set latitude and longitude of the point (X=0, Y=0) on the Marvelmind map in Georeferencing settings of the modem in the dashboard 
-- Refer to section 11.11 of the `user manual <https://marvelmind.com/pics/marvelmind_navigation_system_manual.pdf>` to setup correct north direction on the map
+- Refer to section 11.11 of the `user manual <https://marvelmind.com/pics/marvelmind_navigation_system_manual.pdf>`__ to setup correct north direction on the map
 
 Ground Testing
 ==============

--- a/common/source/docs/common-rc-systems.rst
+++ b/common/source/docs/common-rc-systems.rst
@@ -174,7 +174,7 @@ Note 2: See :ref:`common-frsky-yaapu`. The ability to change parameters over FRS
 
 Note 3: ArduPilot provides a means to send its telemetry data via CRSF such that it can be displayed on `OpenTX <https://www.open-tx.org/>`__ transmitters using the :ref:`Yaapu Telemetry LUA Script<common-frsky-yaapu>`. The ability to change parameters over CRSF telemetry from an Open TX compatible transmitter in addition to displaying the telemetry data is also possible. See :ref:`common-crsf-telemetry`
 
-Note 4: ELRS (ExpressLRS) is a flexible open-source system that can output CRSF, SBUS, or MAVLink (with embedded RC) protocols. Telemetry requires the use of CRSF or Mavlink, and the receiver must be wired to a full UART.  See `ExpressLRS site <https://www.expresslrs.org/>`  and :ref:`TBS CRSF/ ELRS <common-tbs-rc>` for more information.
+Note 4: ELRS (ExpressLRS) is a flexible open-source system that can output CRSF, SBUS, or MAVLink (with embedded RC) protocols. Telemetry requires the use of CRSF or Mavlink, and the receiver must be wired to a full UART.  See `ExpressLRS site <https://www.expresslrs.org/>__`  and :ref:`TBS CRSF/ ELRS <common-tbs-rc>` for more information.
 
 Note 5: The mLRS project is firmware designed specifically to carry both RC and MAVLink. The usable telemetry speed varies by the chosen mode and is managed via RADIO_STATUS flow control. It uses the CRSF (TBS Crossfire) RC protocol on both the receiver and Tx module.  It also integrates full MAVLink telemetry via serial connections on the Tx module and the receiver.
 

--- a/dev/source/docs/porting.rst
+++ b/dev/source/docs/porting.rst
@@ -60,7 +60,7 @@ Step 2 - create a hwdef.dat and hwdef-bl.dat files for the board
 
 Step 3 - Build the firmware
 ---------------------------
-- First, create the bootloader. To create a bootloader that is just right for your board you need to build the a hwdef-bl.dat for your board. That goes in the same directory as your hwdef.dat, and has the same format, but should not include things like I2C, SPI or CAN peripherals. There are lots of examples of hwdef-bl.dat files already in the `hwdef <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef>` directory you can use as examples.
+- First, create the bootloader. To create a bootloader that is just right for your board you need to build the a hwdef-bl.dat for your board. That goes in the same directory as your hwdef.dat, and has the same format, but should not include things like I2C, SPI or CAN peripherals. There are lots of examples of hwdef-bl.dat files already in the `hwdef <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef>`__ directory you can use as examples.
 
 The key things you must have in your hwdef-bl.dat are:
 


### PR DESCRIPTION
% `uvx sphinx-lint --disable=all --enable=missing-underscore-after-hyperlink`

* #7506

Enable four missing-spaces rules from `sphinx-lint` running in pre-commit.
* --disable=missing-underscore-after-hyperlink

Careful review, please, because I mostly use markdown, not reStructuredText.