### PR TITLE
Enable sphinx-lint rule hyperlink-reference-missing-backtick

### DIFF
--- a/blimp/source/docs/getting-started.rst
+++ b/blimp/source/docs/getting-started.rst
@@ -112,7 +112,7 @@ MHz (Europe).
 Actuators
 =========
 
-For control and propulsion, the Flapping Fin Blimp uses micro servos, such as`these <https://usa.banggood.com/search/1.7g-servo.html>`__ . Larger versions could scale their size, accordingly.
+For control and propulsion, the Flapping Fin Blimp uses micro servos, such as `these <https://usa.banggood.com/search/1.7g-servo.html>`__ . Larger versions could scale their size, accordingly.
 
 .. toctree::
     :hidden:

--- a/common/source/docs/common-teraranger-one-rangefinder.rst
+++ b/common/source/docs/common-teraranger-one-rangefinder.rst
@@ -12,7 +12,7 @@ The TeraBee EVO family of rangefinders are lightweight distance measurement sens
 
 .. note::
 
-    Specifications are derived from tests in controlled conditions. Bright sunlight, target surface reflectivity and other variables will affect sensor performance. The combination of very bright sunshine and low reflectivity targets (such as grass) can reduce maximum range to 10m or less. For additional information, please find the following <https://terabee.b-cdn.net/wp-content/uploads/2019/04/TeraRanger-Evo-60m-Test-Results-Report-Outdoor.pdf>`__
+    Specifications are derived from tests in controlled conditions. Bright sunlight, target surface reflectivity and other variables will affect sensor performance. The combination of very bright sunshine and low reflectivity targets (such as grass) can reduce maximum range to 10m or less. For additional information, please find the `following <https://terabee.b-cdn.net/wp-content/uploads/2019/04/TeraRanger-Evo-60m-Test-Results-Report-Outdoor.pdf>`__
 
 More technical information about these senors can be found below:
 
@@ -66,7 +66,7 @@ the open-ended cable included with the sensor.
 
 .. note:: Do not power from autopilot port, unless port is known to have sufficient current capability. If this is the case just connect the SCL/SDA lines from the rangefinder to the autopilot's I2C signals of the same name. 
 .. note:: some of these rangefinders consume over 100ma of current and should NOT be powered from the autopliots's I2C port, but from an external 5V regulated supply source.
-.. note:: For more information please visit this link <https://www.terabee.com/connection-to-pixhawk-autopilots-teraranger-evo/>`__ 
+.. note:: For more information please visit this `link <https://www.terabee.com/connection-to-pixhawk-autopilots-teraranger-evo/>`__ 
 
 Setup in Mission Planner
 ========================

--- a/common/source/docs/common-torqeedo.rst
+++ b/common/source/docs/common-torqeedo.rst
@@ -119,7 +119,7 @@ Introduction Videos
 TorqLink Controlled Motors
 ==========================
 
-A LUA driver is provided 'here <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/torqeedo-torqlink.lua>`__ for control of one or two motors via the ``SERVOx_FUNCTION`` of "Throttle" or "ThrottleLeft, ThrottleRight". The motor(s) control is attached to the autopilot's CAN port. Follow the `readme <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/torqeedo-torqlink.md>`__ for the driver.
+A LUA driver is provided `here <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/torqeedo-torqlink.lua>`__ for control of one or two motors via the ``SERVOx_FUNCTION`` of "Throttle" or "ThrottleLeft, ThrottleRight". The motor(s) control is attached to the autopilot's CAN port. Follow the `readme <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/torqeedo-torqlink.md>`__ for the driver.
 
 [copywiki destination="rover"]
 

--- a/common/source/docs/common-uavlogviewer.rst
+++ b/common/source/docs/common-uavlogviewer.rst
@@ -58,7 +58,7 @@ Plot Features
 
 #. You can remove a data plot by clicking the trash can icon.
 
-#. You can even create and plot expressions that use the fields by "Add Expression" button. See ` Graph Expressions for MavExplorer <https://ardupilot.org/dev/docs/using-mavexplorer-for-log-analysis.html#graph-expressions>`__ for examples of using expressions in a plot analysis.
+#. You can even create and plot expressions that use the fields by "Add Expression" button. See `Graph Expressions for MavExplorer <https://ardupilot.org/dev/docs/using-mavexplorer-for-log-analysis.html#graph-expressions>`__ for examples of using expressions in a plot analysis.
 
 #. You can also save the present plot and its setup using the "Save Preset" button. These are persistent from session to session. A preset can be removed by tbd.
 

--- a/dev/source/docs/odroid-via-mavlink.rst
+++ b/dev/source/docs/odroid-via-mavlink.rst
@@ -30,7 +30,7 @@ These parts are required:
    OR `8GB eMMC Module <https://www.hardkernel.com/shop/8gb-emmc-module-c1-c0-linux/>`__
    preloaded with Linux (the EMMC module is about 4x faster which may be
    useful for image processing)
--  'FTDI Cable <https://www.amazon.com/ftdi-adapter/s?k=ftdi+adapter>`__ or USB
+-  `FTDI Cable <https://www.amazon.com/ftdi-adapter/s?k=ftdi+adapter>`__ or USB
    to Serial interface like `this <https://www.amazon.com/Prolific-PL2303-USB-TTL-Module/dp/B008958S7A>`__. This `link <https://www.sjoerdlangkemper.nl/2019/03/20/usb-to-serial-uart/>`__ provides an overview of USB-TTL modules.
 
 These optional items may also be useful:


### PR DESCRIPTION
% `uvx sphinx-lint --disable=all --enable=hyperlink-reference-missing-backtick`

* #7506

Enable the hyperlink-reference-missing-backtick rule from `sphinx-lint` running in pre-commit.
* --disable=hyperlink-reference-missing-backtick

Careful review, please, because I mostly use markdown, not reStructuredText.