### PR TITLE
Should we accelerate build tests by upgrading to Python 3.14?

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.10", "3.12", "3.14", "3.14t"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,6 @@ jobs:
           done
       - name: Test build
         run: |
+          pip install setuptools
           export AP_SPHINXOPTS=-W
           ./update.py --parallel 4 --verbose --destdir=/tmp/web


### PR DESCRIPTION
### Our slowest GitHub Action workflow is sped up by 90 seconds...

Will it pass?
* Yes, with setuptools on Py3.12 and later.

Will it be faster?
* Yes, save 1m24s on the Test build step and 1m30s on the overall workflow.

1. [ModuleNotFoundError: No module named 'distutils'](https://docs.python.org/3/library/distutils.html)
2. pip install setuptools
3. Test build step: 8m51s on Py3.14 vs. 10m15s on Py3.10