### PR TITLE
4.7: Document AHRS origin persistence for non-GPS flight

### DIFF
--- a/common/source/docs/common-non-gps-navigation-landing-page.rst
+++ b/common/source/docs/common-non-gps-navigation-landing-page.rst
@@ -43,6 +43,30 @@ These are the available options that allow a vehicle to estimate its position wi
 
 .. image:: ../../../images/setorigin.jpg
 
+Persistent Origin Storage
+=========================
+
+In ArduPilot 4.7 and later, the EKF origin can be automatically saved and restored across power cycles using the following parameters:
+
+-  :ref:`AHRS_OPTIONS<AHRS_OPTIONS>` bit 3 (RecordOrigin): When enabled, the current EKF origin is automatically saved to parameters whenever it becomes valid (e.g. after GPS lock or manual origin set). The saved origin is stored in:
+
+   -  :ref:`AHRS_ORIGIN_LAT<AHRS_ORIGIN_LAT>` - Last known origin latitude (degrees)
+   -  :ref:`AHRS_ORIGIN_LON<AHRS_ORIGIN_LON>` - Last known origin longitude (degrees)
+   -  :ref:`AHRS_ORIGIN_ALT<AHRS_ORIGIN_ALT>` - Last known origin altitude (meters)
+
+-  :ref:`AHRS_OPTIONS<AHRS_OPTIONS>` bit 4 (UseRecordedOriginForNonGPS): When enabled, the AHRS will automatically restore the saved origin on boot when GPS is not being used. This allows position-controlled flight modes (Loiter, Auto, Guided, etc.) to work indoors without GPS after the origin has been recorded from a previous flight.
+
+This eliminates the need to manually set the origin via GCS or Lua script on every power cycle when flying indoors with non-GPS position sources.
+
+**Typical setup for indoor flight with optical flow or external navigation:**
+
+1. Enable :ref:`AHRS_OPTIONS<AHRS_OPTIONS>` bit 3 to auto-record the origin
+2. Fly outdoors first (or manually set :ref:`AHRS_ORIGIN_LAT<AHRS_ORIGIN_LAT>`, :ref:`AHRS_ORIGIN_LON<AHRS_ORIGIN_LON>`, :ref:`AHRS_ORIGIN_ALT<AHRS_ORIGIN_ALT>`) to establish a valid origin
+3. Enable :ref:`AHRS_OPTIONS<AHRS_OPTIONS>` bit 4 to auto-restore the origin for non-GPS flights
+4. On subsequent indoor flights, the origin will be automatically restored from the saved parameters
+
+.. note:: ArduSub enables bit 4 (UseRecordedOriginForNonGPS) by default since underwater vehicles typically operate without GPS.
+
 .. note::
    The low cost IMUs (accelerometers, gyros, compass) used in most autopilots drift too quickly to allow position estimation without an external velocity or position source.  In other words, low-cost IMUs on their own are not sufficient for estimating position.
    

--- a/copter/source/docs/indoor-flying.rst
+++ b/copter/source/docs/indoor-flying.rst
@@ -62,6 +62,6 @@ Safe Indoor Flying Don'ts
    warehouse with a high roof = OK, bedroom = not OK.
 -  Don't use Auto\* modes
 
-\* Autonomous and semi-autonomous modes requires GPS (e.g. :ref:`Loiter <loiter-mode>`, :ref:`Guided <ac2_guidedmode>`, :ref:`Auto <auto-mode>`, :ref:`RTL <rtl-mode>`)
+\* Autonomous and semi-autonomous modes require a position estimate. This can come from GPS or from :ref:`Non-GPS Navigation <common-non-gps-navigation-landing-page>` sources such as optical flow, external navigation, or motion capture systems. In ArduPilot 4.7 and later, the EKF origin can be automatically saved and restored across power cycles — see :ref:`Persistent Origin Storage <common-non-gps-navigation-landing-page>` for details.
 
 \*\* Non-autonomous modes include :ref:`Stabilize <stabilize-mode>` and :ref:`AltHold <altholdmode>`


### PR DESCRIPTION
## Summary
- Document new AHRS_OPTIONS bits for automatic EKF origin save/restore:
  - Bit 3 (RecordOrigin): Auto-save origin to parameters when it becomes valid
  - Bit 4 (UseRecordedOriginForNonGPS): Auto-restore saved origin on boot for non-GPS flights
- Document new parameters: AHRS_ORIGIN_LAT, AHRS_ORIGIN_LON, AHRS_ORIGIN_ALT
- Add "Persistent Origin Storage" section to non-GPS navigation page with setup instructions
- Update indoor flying page to reference the new capability

This enables position-controlled modes (Loiter, Auto, Guided, etc.) to work indoors without GPS after the origin has been recorded from a previous flight, eliminating the need for manual origin setting on every power cycle.

Relates to ArduPilot PR #31177.