### PR TITLE
Common: add XFRobot to camera gimbal landing page

### DIFF
--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -34,6 +34,7 @@ gimbals in which ArduPilot controls the stabilisation. Some gimbals also integra
 -  :ref:`Topotek Gimbal <common-topotek-gimbal>`
 -  :ref:`ViewPro gimbals <common-viewpro-gimbal>`
 -  :ref:`Xacti gimbals <common-xacti-gimbal>`
+-  :ref:`XFRobot gimbals <common-xfrobot-gimbal>`
 
 Gimbals may be attached to retractable mounts to prevent ground contact or to reduce air resistant in flight. Mount control is covered on the :ref:`common-mount-targeting` page.
 
@@ -115,6 +116,7 @@ more scenic photos. ArduPilot will stabilize the gimbal to whatever position you
     SToRM32 Gimbal Controller <common-storm32-gimbal>
     ViewPro gimbals <common-viewpro-gimbal>
     Xacti gimbals <common-xacti-gimbal>
+    XFRobot gimbals <common-xfrobot-gimbal>
     FLIR Vue Pro Thermal Camera <common-flir-vue-pro>
     Airpixel ENTIRE Geotagger <common-geotagging-airpixel-entire>
     Airpixel TAG-E Geotagger <common-geotagging-airpixel-tag-e>

--- a/common/source/docs/common-master-features.rst
+++ b/common/source/docs/common-master-features.rst
@@ -15,7 +15,6 @@ New Peripherals
 .. toctree::
     :maxdepth: 1
 
-    XFRobot camera gimbals <common-xfrobot-gimbal>
 [/site]
 [site wiki="plane"]
 New Features


### PR DESCRIPTION
This adds a link to the XFRobot page to the camera/gimbals landing page while also removing it from the upcoming features page

I've tested this locally and it looks OK to me