### PR TITLE
Dev: add security landing page

### DIFF
--- a/dev/source/docs/security-landing-page.rst
+++ b/dev/source/docs/security-landing-page.rst
@@ -1,0 +1,35 @@
+.. _security-landing-page:
+
+========
+Security
+========
+
+This page describes how to protect an ArduPilot from external threats.
+
+.. toctree::
+    :maxdepth: 1
+
+    Secure Firmware (tamper-proof) <secure-firmware>
+
+- :ref:`MAVLink2 Signing <common-MAVLink2-signing>`
+
+Security Attack Surface
+-----------------------
+
+ArduPilot works in a resource-constrained environment.  We can't afford all of the sanity checks that we might otherwise include.
+
+To this end, we do not consider every input to the autopilot firmware potentially malicious.  We trust our SPI-connected inertial sensors to be well-behaved, for example.
+
+Ground Control Stations
+.......................
+
+Most notable amongst "trusted" data sources are connections to the Ground Control Station.  We expect GCSs to be well-behaved in terms of the data sent to the autopilot.  Remember that your GCS can disarm your vehicle mid-air or force it into terrain as a matter of course.
+
+We disable floating point exceptions in the embedded firmware, meaning that a lot of floating point operations which would result in a Floating Point Exception now simply don't.  By default we do NOT disable floating point exceptions in SITL, allowing errors in Ground Control Stations to be picked up in SITL rather than when someone is flying a real vehicle!
+
+One exception to the trusted-ground-control-station model is if :ref:`MAVLink Signing <common-MAVLink2-signing>` is enabled.  If data coming into ArduPilot on a serial port configured for signed-only MAVLink2 connections from a GCS which does not have the signing key can cause the vehicle to misbehave (ignoring DOS attacks), we *do* consider this to be a security issue.
+
+Disabling FPE in SITL
+.....................
+
+To more-closely approximate what happens on our embedded platforms, you can use the ``SIM_FLOAT_EXCEPT`` parameter to disable floating point exceptions in ArduPilot SITL.  This may help find real problems with trying to use fuzzers to find problems with the ArduPilot codebase.

--- a/dev/source/docs/style-guide.rst
+++ b/dev/source/docs/style-guide.rst
@@ -769,25 +769,3 @@ No Dead Code
 ------------
 
 We don't keep dead code in ArduPilot.  If code is unused, it should be removed - not just commented out.  This is a general rule and not universally adhered to.
-
-
-Security Attack Surface
------------------------
-
-ArduPilot works in a resource-constrained environment.  We can't afford all of the sanity checks that we might otherwise include.
-
-To this end, we do not consider every input to the autopilot firmware potentially malicious.  We trust our SPI-connected inertial sensors to be well-behaved, for example.
-
-Ground Control Stations
-.......................
-
-Most notable amongst "trusted" data sources are connections to the Ground Control Station.  We expect GCSs to be well-behaved in terms of the data sent to the autopilot.  Remember that your GCS can disarm your vehicle mid-air or force it into terrain as a matter of course.
-
-We disable floating point exceptions in the embedded firmware, meaning that a lot of floating point operations which would result in a Floating Point Exception now simply don't.  By default we do NOT disable floating point exceptions in SITL, allowing errors in Ground Control Stations to be picked up in SITL rather than when someone is flying a real vehicle!
-
-One exception to the trusted-ground-control-station model is if MAVLink signing is enabled.  If data coming into ArduPilot on a serial port configured for signed-only MAVLink2 connections from a GCS which does not have the signing key can cause the vehicle to misbehave (ignoring DOS attacks), we *do* consider this to be a security issue.
-
-Disabling FPE in SITL
-.....................
-
-To more-closely approximate what happens on our embedded platforms, you can use the ``SIM_FLOAT_EXCEPT`` parameter to disable floating point exceptions in ArduPilot SITL.  This may help find real problems with trying to use fuzzers to find problems with the ArduPilot codebase.

--- a/dev/source/index.rst
+++ b/dev/source/index.rst
@@ -161,7 +161,7 @@ Table of Contents
     RemoteID <docs/opendroneid>
     ROS1/ROS2 <docs/ros>
     RTF Vehicle Developer Information <docs/ready-to-fly-rtf-vehicle-developer-information>
-    Secure Firmware <docs/secure-firmware>
+    Security <docs/security-landing-page>
     Support Proxy <docs/support_proxy>
     Training Centers <docs/common-training-centers>
     USB IDs <docs/USB-IDs>


### PR DESCRIPTION
This adds a Security landing page which includes:

- link to Secure Firmware (this new page also replaces this page on the index page's left menu)
- MAVLink2 signing
- @peterbarker's "attack surface" paragraphs which had been recently placed in the code-style section of the wiki (see PR https://github.com/ArduPilot/ardupilot_wiki/pull/7359)

I've built this locally and it looks OK to me.  The link to MAVLink2 signing is weird but that was the best I could do.  It looks mostly OK to the reader

BTW, this PR is built on top of the index re-ording PR https://github.com/ArduPilot/ardupilot_wiki/pull/7545