### PR TITLE
Ruff rules UP for pyupgrade

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -352,7 +352,7 @@ def generate_rst_files(commits_to_checkout_and_parse):
         For each parameter file generate by param_parse.py, it inserts a version tag in anchors
         to do not make confusing in sphinx toctrees.
         """
-        file_in = open(source_file, "r")
+        file_in = open(source_file)
         file_out = open(dest_file, "w")
         found_original_title = False
         if "latest" not in version_tag:

--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -2,6 +2,8 @@
 """
 Script to get last blog entries on Discourse (https://discuss.ardupilot.org/)
 """
+from __future__ import annotations
+
 import argparse
 import hashlib
 import json
@@ -10,7 +12,7 @@ import platform
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -96,7 +98,7 @@ class BlogPostsFetcher:
         except requests.exceptions.RequestException as err:
             cache_path = BlogPostsFetcher._get_cache_path(url)
             if cache_path.exists():
-                with open(cache_path, "r", encoding="utf-8") as f:
+                with open(cache_path, encoding="utf-8") as f:
                     return json.load(f)
             raise RequestExecutionError(f"Request failed with {err}. URL: {url}")
 
@@ -118,7 +120,7 @@ class BlogPostsFetcher:
         return str(litem[:140] + ' (...)')
 
     @staticmethod
-    def get_first_youtube_or_img_link(request: str) -> Tuple[str, bool]:
+    def get_first_youtube_or_img_link(request: str) -> tuple[str, bool]:
         """ Returns the first YouTube link or image link in the request, if any.
             True if the link is a Youtube link."""
         request_lines = request.splitlines()
@@ -186,7 +188,7 @@ class BlogPostsFetcher:
         data = [self.get_post_data(content, i, verbose) for i in range(1, n_posts + 1)]
         self.write_to_json(url, data)
 
-    def write_to_json(self, url: str, data: List[Post]) -> None:
+    def write_to_json(self, url: str, data: list[Post]) -> None:
         try:
             if url not in self.files_names:
                 raise ValueError(f"No filename associated with url: {url}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,15 @@ skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 [tool.ruff]
 target-version = "py310"
 line-length = 127
-lint.extend-select = [
+lint.select = [
   # "C4",   # flake8-comprehensions
+  "E",      # pycodestyle
+  "F",      # pyflakes
   "FURB",   # refurb
   "I",      # isort
   # "PERF", # Perflint
   "Q003",   # avoidable-escaped-quote
-  "UP031",  # printf-string-formatting
-  "UP032",  # f-string
-  # "UP",   # pyupgradde
+  "UP",     # pyupgrade
+  "W",      # pycodestyle
 ]
+lint.future-annotations = true

--- a/scripts/build_motor_diagrams.py
+++ b/scripts/build_motor_diagrams.py
@@ -108,7 +108,7 @@ def load_json(file_path):
     load a json file and return the contents as a dict
     """
     try:
-        with open(file_path, "r") as file:
+        with open(file_path) as file:
             return json.load(file)
     except (FileNotFoundError, json.JSONDecodeError) as e:
         print(f"Motor Diagrams: load_json() error\n{e}", file=stderr)

--- a/scripts/cap_params.py
+++ b/scripts/cap_params.py
@@ -14,7 +14,7 @@ args = parser.parse_args()
 
 for f in args.files:
     print(f"Processing {f}")
-    txt = open(f, 'r').read()
+    txt = open(f).read()
     matches = re.findall(r'[,.\s][A-Z][A-Z0-9]+_[A-Z_]+[,.\s]', txt)
     matches = re.findall(r'[,.\s][A-Z]+_[A-Z_]+[,.\s]', txt)
     changed = False

--- a/scripts/rename_params.py
+++ b/scripts/rename_params.py
@@ -23,8 +23,8 @@ parser.add_argument("files", nargs="+", default=None, help="directories or files
 args = parser.parse_args()
 
 
-def load_param_map(fname):
-    lines = open(fname, 'r').readlines()
+def load_param_map(fname) -> dict:
+    lines = open(fname).readlines()
     ret = {}
     for line in lines:
         if line.startswith("#"):
@@ -46,7 +46,7 @@ def process_file(fname, param_map):
             print(f"Skipping common file {fname}")
         return
     needs_write = False
-    txt = open(fname, "r").read()
+    txt = open(fname).read()
 
     replacements = [":ref:`PARAMNAME <PARAMNAME>`",
                     ":ref:`PARAMNAME<PARAMNAME>`"]
@@ -68,7 +68,7 @@ def process_file(fname, param_map):
 
 
 param_map = load_param_map(args.param_map)
-print(f"Loaded param map for {len(param_map.keys())} parameters")
+print(f"Loaded param map for {len(param_map)} parameters")
 
 for fname in args.files:
     if os.path.isfile(fname):

--- a/update.py
+++ b/update.py
@@ -31,6 +31,7 @@ Build notes:
 Parameters files are fetched from autotest using requests
 
 """
+from __future__ import annotations
 
 import argparse
 import errno
@@ -49,7 +50,6 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
 import requests
@@ -58,8 +58,8 @@ from sphinx.application import Sphinx
 import rst_table
 from frontend.scripts import get_discourse_posts
 
-if sys.version_info < (3, 8):
-    print("Minimum python version is 3.8")
+if sys.version_info < (3, 9):  # noqa: UP036
+    print("Minimum Python version is 3.9")
     sys.exit(1)
 
 DEFAULT_COPY_WIKIS = ['copter', 'plane', 'rover', 'sub']
@@ -149,7 +149,7 @@ def fetch_and_rename(fetchurl: str, target_file: str, new_name: str) -> None:
     os.replace(new_name, target_file)
 
 
-def fetch_url(fetchurl: str, fpath: Optional[str] = None, verbose: bool = True) -> None:
+def fetch_url(fetchurl: str, fpath: str | None = None, verbose: bool = True) -> None:
     """Fetches content at url and puts it in a file corresponding to the filename in the URL"""
     progress(f"Fetching {fetchurl}")
 
@@ -192,7 +192,7 @@ def get_request_file_size(url: str) -> int:
     return 0
 
 
-def fetchparameters(site: Optional[str] = None, cache: Optional[str] = None) -> None:
+def fetchparameters(site: str | None = None, cache: str | None = None) -> None:
     dataname = "Parameters"
     fetch_ardupilot_generated_data(
         PARAMETER_SITE,
@@ -204,7 +204,7 @@ def fetchparameters(site: Optional[str] = None, cache: Optional[str] = None) -> 
     )
 
 
-def fetchlogmessages(site: Optional[str] = None, cache: Optional[str] = None) -> None:
+def fetchlogmessages(site: str | None = None, cache: str | None = None) -> None:
     dataname = "LogMessages"
     fetch_ardupilot_generated_data(
         LOGMESSAGE_SITE,
@@ -216,8 +216,8 @@ def fetchlogmessages(site: Optional[str] = None, cache: Optional[str] = None) ->
     )
 
 
-def fetch_ardupilot_generated_data(site_mapping: Dict, base_url: str, sub_url: str, document_name: str,
-                                   site: Optional[str] = None, cache: Optional[str] = None) -> None:
+def fetch_ardupilot_generated_data(site_mapping: dict, base_url: str, sub_url: str, document_name: str,
+                                   site: str | None = None, cache: str | None = None) -> None:
     """Fetches the data for all the sites from the test server and
     copies them to the correct location.
 
@@ -225,9 +225,9 @@ def fetch_ardupilot_generated_data(site_mapping: Dict, base_url: str, sub_url: s
     parameters or logmessage have changed.)
 
     """
-    urls: List[str] = []
-    targetfiles: List[str] = []
-    names: List[str] = []
+    urls: list[str] = []
+    targetfiles: list[str] = []
+    names: list[str] = []
 
     for key, value in site_mapping.items():
         fetchurl = f'{base_url}/{value}/{sub_url}'
@@ -444,7 +444,7 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
         for file in files:
             if file.endswith(".rst"):
                 source_file_path = os.path.join(root, file)
-                with open(source_file_path, 'r', encoding='utf-8') as f:
+                with open(source_file_path, encoding='utf-8') as f:
                     source_content = f.read()
                 targets = get_copy_targets(source_content)
                 for wiki in targets:
@@ -478,7 +478,7 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
             if file.endswith(".rst"):
                 # debug("  FILE: %s" % file)
                 source_file_path = os.path.join(root, file)
-                source_file = open(source_file_path, 'r', encoding='utf-8')
+                source_file = open(source_file_path, encoding='utf-8')
                 source_content = source_file.read()
                 source_file.close()
                 targets = get_copy_targets(source_content)
@@ -511,7 +511,7 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                     shutil.copy2(src, dst)
             elif file.endswith(".js"):
                 source_file_path = os.path.join(root, file)
-                source_file = open(source_file_path, 'r', encoding='utf-8')
+                source_file = open(source_file_path, encoding='utf-8')
                 source_content = source_file.read()
                 source_file.close()
                 targets = get_copy_targets(source_content)
@@ -842,7 +842,7 @@ def check_ref_directives():
     wiki_glob = set(glob.glob("**/*.rst", recursive=True))
     files_to_check = wiki_glob.difference(skipped_files)
     for f in files_to_check:
-        with open(f, "r", encoding='utf-8') as file:
+        with open(f, encoding='utf-8') as file:
             try:
                 for i, line in enumerate(file.readlines()):
                     if character_before_ref_tag.search(line):


### PR DESCRIPTION
Make all of [ruff's pyupgrade rules](https://docs.astral.sh/ruff/rules/#pyupgrade-up) mandatory in pre-commit.

This pull request makes the ___minimum Python v3.10___, which matches the default Python of the oldest Standard Support Ubuntu LTS as recommended at:
* https://github.com/ArduPilot/ardupilot/pull/32453#discussion_r2951643145

Related to:
* #7551