### PR TITLE
Vagrantfile: Add Ubuntu 24.04 LTS noble and 26.04 LTS resolute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,29 +14,26 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
       with:
-        python-version: "3.10"
+        python-version: 3.x
     - uses: pre-commit/action@v3.0.1
 
   shellcheck:
     runs-on: ubuntu-slim
     steps:
     - uses: actions/checkout@v6
-    - run: find . -type f -name "*.sh" -exec shellcheck {} +
+    - name: find . -type f -name "*.sh" -exec shellcheck {} +
+      run: |
+        shellcheck --version
+        find . -type f -name "*.sh" -exec shellcheck {} +
 
   build-linux:
-
-    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: ["3.10"]
-
+        os: [ubuntu-latest]  # [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Setting environment
         run: |
           mkdir /tmp/web
@@ -57,4 +54,4 @@ jobs:
       - name: Test build
         run: |
           export AP_SPHINXOPTS=-W
-          ./update.py --parallel 4 --verbose --destdir=/tmp/web
+          .venv/bin/python update.py --parallel 4 --verbose --destdir=/tmp/web

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -8,3 +8,7 @@ disable=SC2046  # 3 instances
 disable=SC2086  # Many instances
 disable=SC2162  # 3 instances
 disable=SC2185  # 1 instance
+
+# Enable shell files to run commands in the Python .venv/bin directory:
+external-sources=true
+source-path=.venv/bin/activate

--- a/Sphinxsetup.sh
+++ b/Sphinxsetup.sh
@@ -17,7 +17,7 @@ else
 fi
 
 if [ ${DISTRIBUTION_ID} = 'Ubuntu' ]; then
-  if [ ${DISTRIBUTION_CODENAME} = 'focal' ] || [ ${DISTRIBUTION_CODENAME} = 'bionic' ] || [ ${DISTRIBUTION_CODENAME} = 'noble' ]; then
+  if [ ${DISTRIBUTION_CODENAME} = 'jammy' ] || [ ${DISTRIBUTION_CODENAME} = 'noble' ] || [ ${DISTRIBUTION_CODENAME} = 'resolute' ]; then
     sudo add-apt-repository universe
   fi
 fi
@@ -43,12 +43,12 @@ if [[ "$(uname)" == "Darwin" ]]; then
     exit 0
 fi
 
-sudo apt-get -y update
-sudo apt-get install -y unzip git imagemagick curl wget make python3
-
-# Install packages release specific
-if [ ${DISTRIBUTION_CODENAME} = 'bionic' ]; then
-  sudo apt-get install -y python3-distutils
+sudo apt-get --yes update
+# Migrate to Python virtual environments on Ubuntu 24.04 and later.
+if [ ${DISTRIBUTION_CODENAME} = 'noble' ] || [ ${DISTRIBUTION_CODENAME} = 'resolute' ]; then
+  sudo apt-get install --yes curl git imagemagick make unzip wget python3-venv
+else
+  sudo apt-get install --yes curl git imagemagick make unzip wget python3-pip
 fi
 
 # For WSL (esp. version 2) make DISPLAY empty to allow pip to run
@@ -58,14 +58,17 @@ if grep -qi -E '(Microsoft|WSL)' /proc/version; then
   export DISPLAY=
 fi
 
-sudo apt-get install -y python3-pip
-
-# Install required python packages
+# Python package requirements are in the same directory as this script.
 SCRIPT_DIR=$(dirname $(realpath ${BASH_SOURCE[0]}))
-if [ "${DISTRIBUTION_CODENAME}" = "noble" ]; then
-    python3 -m pip install --upgrade -r "$SCRIPT_DIR"/requirements.txt
+
+# Activate the Python venv with the latest pip and setuptools on Ubuntu 24.04 and later.
+if [ ${DISTRIBUTION_CODENAME} = 'noble' ] || [ ${DISTRIBUTION_CODENAME} = 'resolute' ]; then
+  python3 -m venv --upgrade-deps .venv
+  # shellcheck source=/dev/null
+  source .venv/bin/activate
+  python3 -m pip install --upgrade -r "$SCRIPT_DIR"/requirements.txt
 else
-    python3 -m pip install --user --upgrade -r "$SCRIPT_DIR"/requirements.txt
+  python3 -m pip install --upgrade --user -r "$SCRIPT_DIR"/requirements.txt
 fi
 
 # Reset the value of DISPLAY

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,11 +18,11 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
-  # default to jammy for building the Wiki:
+  # default to Ubuntu jammy for building the Wiki:
   config.vm.box = "ubuntu/jammy"
 
   # https://releases.ubuntu.com
-  # https://ubuntu.com/about/release-cycle
+  # https://ubuntu.com/about/release-cycle -- Try here first and then fall back to:
   # https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions
 
   # 22.04 LTS Standard Support EOL May 2027
@@ -33,6 +33,30 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     jammy.vm.provision "shell", path: "./scripts/initvagrant.sh"
     jammy.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--memory", "20480"]
+    end
+  end
+
+  # 24.04 LTS Standard Support EOL May 2029
+  config.vm.define "noble", autostart: false do |noble|
+    noble.vm.box = "ubuntu/noble64"
+    noble.vm.provider "virtualbox" do |vb|
+        vb.name = "ArduPilot_wiki (noble)"
+    end
+    noble.vm.provision "shell", path: "./scripts/initvagrant.sh"
+    noble.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--memory", "20480"]
+    end
+  end
+
+  # 26.04 LTS Standard Support EOL May 2031
+  config.vm.define "resolute", autostart: false do |resolute|
+    resolute.vm.box = "ubuntu/resolute64"
+    resolute.vm.provider "virtualbox" do |vb|
+        vb.name = "ArduPilot_wiki (resolute)"
+    end
+    resolute.vm.provision "shell", path: "./scripts/initvagrant.sh"
+    resolute.vm.provider "virtualbox" do |vb|
         vb.customize ["modifyvm", :id, "--memory", "20480"]
     end
   end


### PR DESCRIPTION
All Ubuntu releases in `Vagrantfile` are no longer under Ubuntu Standard Support, so upgrade them to align with:
* https://ubuntu.com/about/release-cycle

Why?  Ubuntu 20.04 default Python 3.8.10 is also [`end-of-life`](https://devguide.python.org/versions) and can no longer be proven to be compatible with this project's code.

% `docker run -it ubuntu:20.04`
\# `apt update ; apt install --yes lsb-release python-is-python3 ; lsb_release -ds ; python -V && exit`
```
Ubuntu 20.04.6 LTS
Python 3.8.10
```
Should we ___wait a month___ and also add Ubuntu 26.04?

> [!CAUTION]
> Ubuntu 20.04 LTS Resolute Raccoon is scheduled to be released on Thu 23rd Apr 2026 (~10 days).
https://documentation.ubuntu.com/release-notes/26.04/schedule/#resolute-raccoon-schedule

Related to:
* #6316

I have never used Vagrant so ___this pull request has not been tested in any way!!!___

The `vb.customize` memory settings should be carefully reviewed by someone who knows Vagrant.