### PR TITLE
build_parameters.py: don't update submodule on parameter update

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -161,7 +161,6 @@ def setup():
         os.system("git fetch origin master")
         os.system("git reset --hard origin/master")
         os.system("git pull")
-        os.system("git submodule update --init --recursive")
         global BASEPATH
         BASEPATH = os.getcwd()
         check_temp_folders()


### PR DESCRIPTION
this is slow and not use to generate the parameters