### PR TITLE
Ruff rules for comprehensions and performance

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -352,7 +352,7 @@ def generate_rst_files(commits_to_checkout_and_parse):
         For each parameter file generate by param_parse.py, it inserts a version tag in anchors
         to do not make confusing in sphinx toctrees.
         """
-        file_in = open(source_file, "r")
+        file_in = open(source_file)
         file_out = open(dest_file, "w")
         found_original_title = False
         if "latest" not in version_tag:
@@ -456,7 +456,7 @@ def generate_json(vehicles):
         debug(f"Creating JSON files for {vehicle}")
 
         # Creates the JSON lines from available rst files
-        parameters_files = [f for f in glob.glob(f"parameters-{vehicle}*.rst")]
+        parameters_files = list(glob.glob(f"parameters-{vehicle}*.rst"))
         parameters_files.sort(reverse=True)
 
         vehicle_json = {}
@@ -504,12 +504,12 @@ def move_results(vehicles):
                 os.makedirs(folder)
 
             # Cleaning last run, iff exists
-            files_to_delete = [f for f in glob.glob(f"{folder}*")]
+            files_to_delete = list(glob.glob(f"{folder}*"))
             for old_file in files_to_delete:
                 os.remove(old_file)
 
             # Moving files (use shutil.move for cross-device compatibility)
-            files_to_move = [f for f in glob.glob(f"parameters-{vehicle}*")]
+            files_to_move = list(glob.glob(f"parameters-{vehicle}*"))
             for file in files_to_move:
                 if "latest" not in file:  # Trying to re-enable toc list on the left bar on the wiki by forcing latest file name.  # noqa: E501
                     shutil.move(file, f"{folder}{file}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,10 @@ skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 target-version = "py310"
 line-length = 127
 lint.extend-select = [
-  # "C4",   # flake8-comprehensions
+  "C4",     # flake8-comprehensions
   "FURB",   # refurb
-  "I",      # isort
-  # "PERF", # Perflint
+  "I",    # isort
+  "PERF",   # Perflint
   "Q003",   # avoidable-escaped-quote
   "UP031",  # printf-string-formatting
   "UP032",  # f-string

--- a/update.py
+++ b/update.py
@@ -106,7 +106,7 @@ LOGMESSAGE_SITE = {
     'antennatracker': 'Tracker',
     'blimp': 'Blimp',
 }
-error_log = list()
+error_log = []
 N_BACKUPS_RETAIN = 10
 
 VERBOSE = False
@@ -593,7 +593,7 @@ def logmatch_code(matchobj, prefix):
     for i in range(9):
         try:
             progress(f"{prefix} m{i}: {matchobj.group(i)}")
-        except IndexError:  # The object has less groups than expected
+        except IndexError:  # noqa: PERF203 The object has less groups than expected
             progress(f"{prefix}: except m{i}")
 
 
@@ -639,8 +639,7 @@ def fetch_versioned_parameters(site=None):
                 else:
                     old_parameters_mask = f"{os.getcwd()}/{key}/source/docs/parameters-{key.title()}-"
                 try:
-                    old_parameters_files = [
-                        f for f in glob.glob(f"{old_parameters_mask}*.rst")]
+                    old_parameters_files = list(glob.glob(f"{old_parameters_mask}*.rst"))
                     for filename in old_parameters_files:
                         debug(f"Erasing rst {filename}")
                         os.remove(filename)
@@ -673,9 +672,7 @@ def fetch_versioned_parameters(site=None):
                 # Copy all parameter files to vehicle folder IFF it is new
                 try:
                     new_parameters_folder = f"{os.getcwd()}/../new_params_mversion/{value}/"
-                    new_parameters_files = [
-                        f for f in glob.glob(f"{new_parameters_folder}*.rst")
-                    ]
+                    new_parameters_files = list(glob.glob(f"{new_parameters_folder}*.rst"))
                 except Exception as e:
                     error(e)
                     pass
@@ -702,7 +699,7 @@ def fetch_versioned_parameters(site=None):
                             debug(f"Copying {filename} to {new_file}")
                             shutil.copy2(filename, new_file)
 
-                    except Exception as e:
+                    except Exception as e:  # noqa: PERF203
                         error(e)
                         pass
 
@@ -734,25 +731,19 @@ def cache_parameters_files(site=None):
         if (site == key or site is None) and (key != 'AP_Periph'):  # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
             try:
                 old_parameters_folder = f"{os.getcwd()}/../old_params_mversion/{value}/"
-                old_parameters_files = [
-                    f for f in glob.glob(f"{old_parameters_folder}*.*")
-                ]
+                old_parameters_files = list(glob.glob(f"{old_parameters_folder}*.*"))
                 for file in old_parameters_files:
                     debug(f"Removing {file}")
                     os.remove(file)
 
                 new_parameters_folder = f"{os.getcwd()}/../new_params_mversion/{value}/"
-                new_parameters_files = [
-                    f for f in glob.glob(f"{new_parameters_folder}parameters-*.rst")
-                ]
+                new_parameters_files = list(glob.glob(f"{new_parameters_folder}parameters-*.rst"))
                 for filename in new_parameters_files:
                     debug(f"Copying {filename} to {old_parameters_folder}")
                     shutil.copy2(filename, old_parameters_folder)
 
                 built_folder = f"{os.getcwd()}/{key}/build/html/docs/"
-                built_parameters_files = [
-                    f for f in glob.glob(f"{built_folder}parameters-*.html")
-                ]
+                built_parameters_files = list(glob.glob(f"{built_folder}parameters-*.html"))
                 for built in built_parameters_files:
                     debug(f"Copying {built} to {old_parameters_folder}")
                     shutil.copy2(built, old_parameters_folder)
@@ -771,9 +762,7 @@ def put_cached_parameters_files_in_sites(site=None):
         if (site == key or site is None) and (key != 'AP_Periph'): # and (key != 'AP_Periph') workaround until create a versioning for AP_Periph in firmware server # noqa: E501
             try:
                 built_folder = f"{os.getcwd()}/../old_params_mversion/{value}/"
-                built_parameters_files = [
-                    f for f in glob.glob(f"{built_folder}parameters-*.html")
-                ]
+                built_parameters_files = list(glob.glob(f"{built_folder}parameters-*.html"))
                 vehicle_folder = f"{os.getcwd()}/{key}/build/html/docs/"
                 debug(f"Site {site} getting previously built files from {built_folder}")
                 for built in built_parameters_files:
@@ -972,7 +961,7 @@ def create_features_page(features, build_options_by_define, vehicletype):
 
     all_features_rows = []
     for feature in sorted(build_options_by_define.values(), key=lambda x : (x.category + x.label).lower()):
-        all_features_rows.append([feature.category, feature.label, feature.description])
+        all_features_rows.append([feature.category, feature.label, feature.description])  # noqa: PERF401
     all_features = rst_table.tablify(all_features_rows, headings=["Category", "Feature", "Description"])
 
     return f'''


### PR DESCRIPTION
Add ruff rules for [comprehensions](https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4) and [performance](https://docs.astral.sh/ruff/rules/#perflint-perf). 
```diff
[tool.ruff]
lint.extend-select = [
+  "C4",     # flake8-comprehensions
+  "PERF",   # Perflint
]
```
% `ruff check --select=C4,PERF --statistics`
```
9	C416   	unnecessary-comprehension
2	PERF203	try-except-in-loop
1	C408   	unnecessary-collection-call
1	PERF401	manual-list-comprehension
Found 13 errors.
```
% `ruff rule C416`
# unnecessary-comprehension (C416)

Derived from the **flake8-comprehensions** linter.

Fix is always available.

## What it does
Checks for unnecessary dict, list, and set comprehension.

## Why is this bad?
It's unnecessary to use a dict/list/set comprehension to build a data structure if the
elements are unchanged. Wrap the iterable with `dict()`, `list()`, or `set()` instead.

## Example
```python
{a: b for a, b in iterable}
[x for x in iterable]
{x for x in iterable}
```

Use instead:
```python
dict(iterable)
list(iterable)
set(iterable)
```

## Known problems

This rule may produce false positives for dictionary comprehensions that iterate over a mapping.
The dict constructor behaves differently depending on if it receives a sequence (e.g., a
list) or a mapping (e.g., a dict). When a comprehension iterates over the keys of a mapping,
replacing it with a `dict()` constructor call will give a different result.

For example:

```pycon
>>> d1 = {(1, 2): 3, (4, 5): 6}
>>> {x: y for x, y in d1}  # Iterates over the keys of a mapping
{1: 2, 4: 5}
>>> dict(d1)               # Ruff's incorrect suggested fix
{(1, 2): 3, (4, 5): 6}
>>> dict(d1.keys())        # Correct fix
{1: 2, 4: 5}
```

When the comprehension iterates over a sequence, Ruff's suggested fix is correct. However, Ruff
cannot consistently infer if the iterable type is a sequence or a mapping and cannot suggest
the correct fix for mappings.

## Fix safety
Due to the known problem with dictionary comprehensions, this fix is marked as unsafe.

Additionally, this fix may drop comments when rewriting the comprehension.
