### PR TITLE
Ensure Python import ordering

### DIFF
--- a/antennatracker/source/conf.py
+++ b/antennatracker/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/ardupilot/source/conf.py
+++ b/ardupilot/source/conf.py
@@ -11,12 +11,12 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"
 sys.path.insert(0, '../..')
 import common_conf  # noqa: E402
-
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/blimp/source/conf.py
+++ b/blimp/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -25,17 +25,17 @@
 
 """
 
+import argparse
+import glob
+import json
+import logging
 import os
+import re
 import shutil  # noqa: F401
 import sys
 import time  # noqa: F401
-import logging
-import json
-from html.parser import HTMLParser
 import urllib.request
-import re
-import glob
-import argparse
+from html.parser import HTMLParser
 
 parser = argparse.ArgumentParser(description="python3 build_parameters.py [options]")
 parser.add_argument("--verbose", dest='verbose', action='store_false', default=True, help="show debugging output")

--- a/common_conf.py
+++ b/common_conf.py
@@ -1,8 +1,8 @@
 # This contains common configuration information for the ardupilot wikis.
 # This information is imported by the conf.py files in each of the sub wikis
 
-import sys
 import os
+import sys
 
 # Add the wiki root and extensions directory to the path so our custom extensions can be found
 _wiki_root = os.path.dirname(os.path.abspath(__file__))

--- a/copter/source/conf.py
+++ b/copter/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/dev/source/conf.py
+++ b/dev/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -3,18 +3,18 @@
 Script to get last blog entries on Discourse (https://discuss.ardupilot.org/)
 """
 import argparse
-import json
-import re
 import hashlib
+import json
 import os
 import platform
+import re
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, List, Tuple
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
-from dataclasses import dataclass
-from typing import List, Any, Tuple
 
 
 class RequestExecutionError(Exception):

--- a/mavproxy/source/conf.py
+++ b/mavproxy/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/plane/source/conf.py
+++ b/plane/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/planner/source/conf.py
+++ b/planner/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/planner2/source/conf.py
+++ b/planner2/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,12 @@ skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 target-version = "py310"
 line-length = 127
 lint.extend-select = [
+  # "C4",   # flake8-comprehensions
   "FURB",   # refurb
+  "I",      # isort
+  # "PERF", # Perflint
   "Q003",   # avoidable-escaped-quote
   "UP031",  # printf-string-formatting
   "UP032",  # f-string
+  # "UP",   # pyupgradde
 ]

--- a/rover/source/conf.py
+++ b/rover/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/scripts/cap_params.py
+++ b/scripts/cap_params.py
@@ -4,8 +4,8 @@ script to find and optionally replace param refs in rst files
 '''
 
 import re
-
 from argparse import ArgumentParser
+
 parser = ArgumentParser('find and optionally replace parameters')
 parser.add_argument("--change", action='store_true', help="change matches to use param markup")
 parser.add_argument("files", nargs='+')

--- a/scripts/extensions/sphinx_skip_versioned_params.py
+++ b/scripts/extensions/sphinx_skip_versioned_params.py
@@ -7,8 +7,9 @@ of labels for versioned parameter files (e.g., parameters-Copter-stable-V4.6.0.r
 Only the latest parameters.rst files maintain full cross-linking capability.
 """
 
-import re
 import logging
+import re
+
 from sphinx.application import Sphinx
 from sphinx.environment import BuildEnvironment
 

--- a/scripts/rename_params.py
+++ b/scripts/rename_params.py
@@ -8,9 +8,8 @@ examples:
     do one directory: scripts/rename_params.py data/plane4.5-parmchange.txt plane/source/docs
 '''
 
-import os
 import glob
-
+import os
 from argparse import ArgumentParser
 
 parser = ArgumentParser(description="parameter conversion tool")

--- a/sub/source/conf.py
+++ b/sub/source/conf.py
@@ -11,6 +11,7 @@
 # serve to show the default.
 
 import sys
+
 import sphinx_rtd_theme
 
 # Import common configuration information as "common_conf"

--- a/update.py
+++ b/update.py
@@ -35,10 +35,10 @@ Parameters files are fetched from autotest using requests
 import argparse
 import errno
 import filecmp
-import json
 import glob
 import gzip
 import hashlib
+import json
 import multiprocessing
 import os
 import platform
@@ -47,16 +47,15 @@ import shutil
 import subprocess
 import sys
 import time
-import requests
-from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional, Dict, List
-
-
-from sphinx.application import Sphinx
-import rst_table
 from datetime import datetime
+from typing import Dict, List, Optional
+from urllib.parse import urlparse
 
+import requests
+from sphinx.application import Sphinx
+
+import rst_table
 from frontend.scripts import get_discourse_posts
 
 if sys.version_info < (3, 8):


### PR DESCRIPTION
% `ruff check --select=I --fix ` # https://docs.astral.sh/ruff/rules/#isort-i

Like:
* ArduPilot/ardupilot#32421
* ArduPilot/ardupilot#32438

% `ruff rule I001`
# unsorted-imports (I001)

Derived from the **isort** linter.

Fix is sometimes available.

## What it does
De-duplicates, groups, and sorts imports based on the provided `isort` settings.

## Why is this bad?
Consistency is good. Use a common convention for imports to make your code
more readable and idiomatic.

## Example
```python
import pandas
import numpy as np
```

Use instead:
```python
import numpy as np
import pandas
```