### PR TITLE
Ruff rules FURB for refurb

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.15.7
     hooks:
       - id: ruff-check
 

--- a/build_parameters.py
+++ b/build_parameters.py
@@ -477,7 +477,7 @@ def generate_json(vehicles):
         json_filename = "parameters-" + vehicle + ".json"
         try:
             with open(json_filename, 'w') as f:
-                for lines in json_lines:
+                for lines in json_lines:  # noqa: FURB122
                     f.write(f"{lines}\n")
         except Exception as e:
             error("Error while creating the JSON file " + vehicle + " in folder " + str(os.getcwd()))  # noqa: E501

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 target-version = "py310"
 line-length = 127
 lint.extend-select = [
+  "FURB",   # refurb
   "UP031",  # printf-string-formatting
   "UP032",  # f-string
 ]

--- a/update.py
+++ b/update.py
@@ -537,7 +537,7 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
 
 
 def get_copy_targets(content):
-    p = re.compile(r'\[copywiki.*?destination\=\"(.*?)\".*?\]', flags=re.S)
+    p = re.compile(r'\[copywiki.*?destination\=\"(.*?)\".*?\]', flags=re.DOTALL)
     m = p.search(content)
     targetset = set()
     if m:
@@ -568,7 +568,7 @@ def strip_content(content, site):
     newText = re.sub(r'\[copywiki.*?\]',
                      fix_copywiki_shortcode,
                      content,
-                     flags=re.M)
+                     flags=re.MULTILINE)
 
     def fix_site_shortcode(matchobj):
         # logmatch_code(matchobj, 'SITESC_')
@@ -584,7 +584,7 @@ def strip_content(content, site):
     newText = re.sub(r'\[site\s.*?wiki\=\"(.*?)\".*?\](.*?)\[\/site\]',
                      fix_site_shortcode,
                      newText,
-                     flags=re.S)
+                     flags=re.DOTALL)
 
     return newText
 


### PR DESCRIPTION
% `ruff check --select=FURB --statistics ` # https://docs.astral.sh/ruff/rules/#refurb-furb
```
3	FURB167	[*] regex-flag-alias
1	FURB122	[*] for-loop-writes
Found 4 errors.
[*] 4 fixable with the `--fix` option.
```
% `ruff check --select=FURB --fix`

% `ruff rule FURB167`
# regex-flag-alias (FURB167)

Derived from the **refurb** linter.

Fix is always available.

## What it does
Checks for the use of shorthand aliases for regular expression flags
(e.g., `re.I` instead of `re.IGNORECASE`).

## Why is this bad?
The regular expression module provides descriptive names for each flag,
along with single-letter aliases. Prefer the descriptive names, as they
are more readable and self-documenting.

## Example
```python
import re

if re.search("^hello", "hello world", re.I):
    ...
```

Use instead:
```python
import re

if re.search("^hello", "hello world", re.IGNORECASE):
    ...
```
