### PR TITLE
Common: param lockdown script rename fix (flight code PR:32489)

### DIFF
--- a/common/source/docs/common-parameter-lockdown.rst
+++ b/common/source/docs/common-parameter-lockdown.rst
@@ -4,7 +4,7 @@
 Parameter Lockdown
 ==================
 
-To avoid accidental changes to critical parameters, ArduPilot provides a parameter lockdown feature using the `param_set.lua <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-set.lua>`__ Lua applet.
+To avoid accidental changes to critical parameters, ArduPilot provides a parameter lockdown feature using the `param-lockdown.lua <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-lockdown.lua>`__ Lua applet.
 
 As with other Lua scripts this requires an autopilot with a fast CPU and sufficient memory (e.g. STM32H7).
 
@@ -13,18 +13,18 @@ Please note that this is not an iron clad security feature because some ground s
 Setup
 -----
 
-Details on the setup can be found in the `param-set.md file <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-set.md>`__ but in short this involves:
+Details on the setup can be found in the `param-lockdown.md file <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-lockdown.md>`__ but in short this involves:
 
 - Follow the :ref:`Lua Script setup instructions <common-lua-scripts>` to set up Lua scripting on the autopilot including setting :ref:`SCR_ENABLE <SCR_ENABLE>` = 1
-- Download `param-set.lua <https://raw.githubusercontent.com/ArduPilot/ardupilot/refs/heads/master/libraries/AP_Scripting/applets/param-set.lua>`__ from the ArduPilot repository
+- Download `param-lockdown.lua <https://raw.githubusercontent.com/ArduPilot/ardupilot/refs/heads/master/libraries/AP_Scripting/applets/param-lockdown.lua>`__ from the ArduPilot repository
 - Copy the script to the autopilot's SD card's /APM/scripts/ directory and restart the autopilot
-- Confirm the script has loaded by looking for "param-set script loaded" in the GCS's messages tab
+- Confirm the script has loaded by looking for "param-lockdown script loaded" in the GCS's messages tab
 - Confirm parameters cannot be set by using the GCS's full parameter list to change a single parameter value. If using Mission Planner it may be necessary to reload parameters and then check if the parameter value has actually changed or not
 
 Customising the Script
 ----------------------
 
-The list of parameters that may be changed is called the "white list" and can be found `here in the param-set script <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-set.lua#L120>`__
+The list of parameters that may be changed is called the "white list" and can be found `here in the param-lockdown script <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/param-lockdown.lua#L120>`__
 
 .. code-block:: lua
 
@@ -35,5 +35,10 @@ The list of parameters that may be changed is called the "white list" and can be
     parameters_which_can_be_set["BATT_ARM_MAH"] = true
 
 This list can be customised by adding or removing lines from the list and then re-uploading the script to the autopilot
+
+Alternative Method
+------------------
+
+Parameters can be marked as ``@READONLY`` in the defaults.parm file as described in the :ref:`OEM Customisations <common-oem-customizations>` page.
 
 [copywiki destination="copter,plane,rover,sub,dev"]


### PR DESCRIPTION
Flight code PR https://github.com/ArduPilot/ardupilot/pull/32489 renamed param-set.lua to param-lockdown.lua so this updates the param lockdown wiki page to reflect this.

I've also added a new section pointing users at the OEM Customisation page which has an alternative method of accomplishing something similar.

I've built this locally and it looks OK to me

