### PR TITLE
Use `with open() as:` to close file handles

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -352,8 +352,8 @@ def generate_rst_files(commits_to_checkout_and_parse):
         For each parameter file generate by param_parse.py, it inserts a version tag in anchors
         to do not make confusing in sphinx toctrees.
         """
-        file_in = open(source_file, "r")
-        file_out = open(dest_file, "w")
+        file_in = open(source_file, "r")  # noqa: SIM115
+        file_out = open(dest_file, "w")  # noqa: SIM115
         found_original_title = False
         if "latest" not in version_tag:
             file_out.write(':orphan:\n\n')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore-words-list = "bu,collets,diamon,dout,empy,extint,fram,inh,minite,ned,parm
 skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py38"
 line-length = 127
 lint.extend-select = [
   # "C4",   # flake8-comprehensions
@@ -12,6 +12,7 @@ lint.extend-select = [
   "I",      # isort
   # "PERF", # Perflint
   "Q003",   # avoidable-escaped-quote
+  "SIM115", # open-file-with-context-handler
   "UP031",  # printf-string-formatting
   "UP032",  # f-string
   # "UP",   # pyupgradde

--- a/scripts/cap_params.py
+++ b/scripts/cap_params.py
@@ -14,7 +14,8 @@ args = parser.parse_args()
 
 for f in args.files:
     print(f"Processing {f}")
-    txt = open(f, 'r').read()
+    with open(f, 'r') as in_file:
+        txt = in_file.read()
     matches = re.findall(r'[,.\s][A-Z][A-Z0-9]+_[A-Z_]+[,.\s]', txt)
     matches = re.findall(r'[,.\s][A-Z]+_[A-Z_]+[,.\s]', txt)
     changed = False
@@ -29,4 +30,5 @@ for f in args.files:
         else:
             print(f"Found [{s}]")
     if changed:
-        open(f, 'w').write(txt)
+        with open(f, 'w') as out_file:
+            out_file.write(txt)

--- a/scripts/rename_params.py
+++ b/scripts/rename_params.py
@@ -24,7 +24,8 @@ args = parser.parse_args()
 
 
 def load_param_map(fname):
-    lines = open(fname, 'r').readlines()
+    with open(fname, 'r') as in_file:
+        lines = in_file.readlines()
     ret = {}
     for line in lines:
         if line.startswith("#"):
@@ -46,7 +47,8 @@ def process_file(fname, param_map):
             print(f"Skipping common file {fname}")
         return
     needs_write = False
-    txt = open(fname, "r").read()
+    with open(fname, "r") as in_file:
+        txt = in_file.read()
 
     replacements = [":ref:`PARAMNAME <PARAMNAME>`",
                     ":ref:`PARAMNAME<PARAMNAME>`"]
@@ -64,7 +66,8 @@ def process_file(fname, param_map):
     if not needs_write:
         return
     print(f"Updating {fname}")
-    open(fname, "w").write(txt)
+    with open(fname, "w") as out_file:
+        out_file.write(txt)
 
 
 param_map = load_param_map(args.param_map)

--- a/update.py
+++ b/update.py
@@ -478,9 +478,8 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
             if file.endswith(".rst"):
                 # debug("  FILE: %s" % file)
                 source_file_path = os.path.join(root, file)
-                source_file = open(source_file_path, 'r', encoding='utf-8')
-                source_content = source_file.read()
-                source_file.close()
+                with open(source_file_path, 'r', encoding='utf-8') as source_file:
+                    source_content = source_file.read()
                 targets = get_copy_targets(source_content)
                 for wiki in targets:
                     content = strip_content(source_content, wiki)
@@ -511,9 +510,8 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                     shutil.copy2(src, dst)
             elif file.endswith(".js"):
                 source_file_path = os.path.join(root, file)
-                source_file = open(source_file_path, 'r', encoding='utf-8')
-                source_content = source_file.read()
-                source_file.close()
+                with open(source_file_path, 'r', encoding='utf-8') as source_file:
+                    source_content = source_file.read()
                 targets = get_copy_targets(source_content)
                 for wiki in targets:
                     content = strip_content(source_content, wiki)
@@ -872,7 +870,8 @@ def create_features_pages(site):
     # fetch and load most-recently-built features.json
     remove_if_exists("features.json.gz")
     fetch_url("https://firmware.ardupilot.org/features.json.gz")
-    features_json = json.load(gzip.open("features.json.gz"))
+    with gzip.open("features.json.gz") as in_file:
+        features_json = json.load(in_file)
     if features_json["format-version"] != "1.0.0":
         progress("bad format version")
         return


### PR DESCRIPTION
Like:
* ArduPilot/ardupilot#32533

% [`ruff rule SIM115`](https://docs.astral.sh/ruff/rules/open-file-with-context-handler)
# open-file-with-context-handler (SIM115)

Derived from the **flake8-simplify** linter.

## What it does
Checks for cases where files are opened (e.g., using the builtin `open()` function)
without using a context manager.

## Why is this bad?
If a file is opened without a context manager, it is not guaranteed that
the file will be closed (e.g., if an exception is raised), which can cause
resource leaks. The rule detects a wide array of IO calls where context managers
could be used, such as `open`, `pathlib.Path(...).open()`, `tempfile.TemporaryFile()`
or`tarfile.TarFile(...).gzopen()`.

## Example
```python
file = open("foo.txt")
...
file.close()
```

Use instead:
```python
with open("foo.txt") as file:
    ...
```

## References
- [Python documentation: `open`](https://docs.python.org/3/library/functions.html#open)
