### PR TITLE
Vagrantfile: Remove Ubuntu 18.04 LTS Standard Support EOL in May 2023

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,19 +10,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # default to focal for building the Wiki:
   config.vm.box = "ubuntu/focal"
 
-  # 18.04 LTS EOL April 2023
-  config.vm.define "bionic", autostart: false do |bionic|
-    bionic.vm.box = "ubuntu/bionic64"
-    bionic.vm.provider "virtualbox" do |vb|
-        vb.name = "ArduPilot_wiki (bionic)"
-    end
-    bionic.vm.provision "shell", path: "./scripts/initvagrant.sh"
-    bionic.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "2048"]
-    end
-  end
+  # https://releases.ubuntu.com
+  # https://ubuntu.com/about/release-cycle
+  # https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions
 
-  # 20.04 LTS  EOL April 2025
+  # 20.04 LTS Standard Support EOL May 2025
   config.vm.define "focal", autostart: true do |focal|
     focal.vm.box = "ubuntu/focal64"
     focal.vm.provider "virtualbox" do |vb|


### PR DESCRIPTION
Vagrantfile: Remove Ubuntu 18.04 LTS Bionic, which lost Standard Support in May 2023.

Why?  Ubuntu 18.04's default Python [v3.6.9](https://devguide.python.org/versions/) can no longer be proven compatible with this project's code.

% `docker run -it ubuntu:18.04`
\# `apt update ; apt install --yes lsb-release ; lsb_release -ds ; python3 -V && exit`
```
Ubuntu 18.04.6 LTS
Python 3.6.9
```
Related to:
* #7551
* https://releases.ubuntu.com
* https://ubuntu.com/about/release-cycle -- Try here first and then fall back to:
* https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions