### PR TITLE
LAND mode: clarify additional landed-detection checks

### DIFF
--- a/copter/source/docs/land-mode.rst
+++ b/copter/source/docs/land-mode.rst
@@ -26,8 +26,9 @@ features:
 .. note::
 
     Copter will recognise that it has landed if the motors are being commanded to be at low
-    level by the vertical position controller, its climb rate remains between -20cm/s and +20cm/s, and
-    is not accelerating for one second.  It does not use the altitude to decide whether to shut off the
+    level by the vertical position controller, its climb rate remains between -20cm/s and +20cm/s, 
+    is not accelerating for one second, and other internal landing-detection checks, such as attitude-related checks, 
+    are also satisfied.  It does not use the altitude to decide whether to shut off the
     motors except that the copter must also be below 10m above the home
     altitude, unless a rangefinder is being used, in which case it must be within 2m of the ground.
 


### PR DESCRIPTION
This PR clarifies the LAND mode documentation by noting that, in addition to the currently described conditions, other internal landing-detection checks (such as attitude-related checks) must also be satisfied before landing is recognized.

resolves #7578