### PR TITLE
Add warning that QuadPlane VTOL mission legs do not support Terrain waypoints

### DIFF
--- a/common/source/docs/common-terrain-following.rst
+++ b/common/source/docs/common-terrain-following.rst
@@ -60,6 +60,10 @@ In Plane terrain following is available in the following flight modes:
 -  GUIDED - "fly to" waypoints
 -  AUTO - fully autonomous missions
 
+.. warning:: QuadPlane mission legs flown in VTOL mode do not currently
+   support waypoints with altitude set to Terrain. Use Relative or Absolute
+   altitudes for VTOL waypoints.
+
 Use of terrain following in RTL, LOITER, CRUISE, FBWB and GUIDED modes
 is controlled by the :ref:`TERRAIN_FOLLOW<TERRAIN_FOLLOW>` parameter. That parameter defaults
 to off, so no terrain following will be used in those modes. Setting the bitmask in :ref:`TERRAIN_FOLLOW<TERRAIN_FOLLOW>` determines which altitude controlled modes terrain following is active. For example, setting it to "10" enables following in FBWB and AUTO.

--- a/plane/source/docs/quadplane-auto-mode.rst
+++ b/plane/source/docs/quadplane-auto-mode.rst
@@ -107,6 +107,10 @@ command takes a single parameter. If the parameter is set to 3 then
 the aircraft will change to VTOL mode. If the parameter is set to 4
 then it will change to fixed wing mode.
 
+.. warning:: QuadPlane mission legs flown in VTOL mode do not currently
+   support waypoints with altitude set to Terrain. Use Relative or Absolute
+   altitudes for VTOL waypoints.
+
 .. image:: ../images/quadplane-vtol-transition.jpg
     :target: ../_images/quadplane-vtol-transition.jpg
 
@@ -154,4 +158,3 @@ When hovering at the destination in GUIDED mode if a new GUIDED
 destination is given then the aircraft will transition back to fixed
 wing flight, fly to the new location and then hover again in VTOL
 mode.
-


### PR DESCRIPTION
As pointed out by a Partner who came across this not so obvious gap in current function of qplane, this warns users that QuadPlane mission legs flown in VTOL mode do not currently support waypoints with altitude set to Terrain.

Adds the same warning in:
- QuadPlane AUTO missions
- Terrain Following