### PR TITLE
Docs: fix incorrect 10m-above-home motor shutoff condition in LAND mode

### DIFF
--- a/copter/source/docs/land-mode.rst
+++ b/copter/source/docs/land-mode.rst
@@ -25,11 +25,22 @@ features:
 
 .. note::
 
-    Copter will recognise that it has landed if the motors are being commanded to be at low
-    level by the vertical position controller, its vertical speed is close to zero (within ±1 m/s by default), 
-    is not accelerating for one second, and other internal landing-detection checks, such as attitude-related checks, 
-    are also satisfied.  It does not use the altitude to decide whether to shut off the
-    motors, except that when a healthy rangefinder is being used, the copter must be within 2m of the ground.
+   Copter will recognise that it has landed when ALL of the following are true for
+   approximately one second:
+
+   - Motors are commanded to their lower limit by the vertical position controller
+   - Throttle mix is at minimum (``is_throttle_mix_min``)
+   - No large angle is being requested (roll/pitch target < 15°)
+   - No large angle error exists (attitude error < 30°)
+   - The airframe is not accelerating (earth-frame accel ≈ 0)
+   - Vertical speed is within 1 m/s of zero
+   - If a healthy rangefinder is available: altitude is below 2m
+   - Weight-on-Wheels (WoW) sensor (if present) confirms contact or is unknown
+
+   Altitude above home is **not** used as a motor shutoff condition (except when a rangefinder is used,see above).
+   The ``LAND_ALT_LOW_M`` parameter (default 10m) only controls the
+   **descent speed transition** from :ref:`LAND_SPD_HIGH_MS<LAND_SPD_HIGH_MS>`
+   to :ref:`LAND_SPD_MS<LAND_SPD_MS>` — it has no role in landing detection or disarming.
 
 .. note:: For Traditional Heli, the low motor check in the above landing detection algorithm is replaced with a check that Collective output is below
    mid-position (controlled by the vertical position controller, ie in descent). The rotor still may be at governor speed up until Motor Interlock is removed and  disarming occurs.

--- a/copter/source/docs/land-mode.rst
+++ b/copter/source/docs/land-mode.rst
@@ -29,12 +29,12 @@ features:
    approximately one second:
 
    - Motors are commanded to their lower limit by the vertical position controller
-   - Throttle mix is at minimum (``is_throttle_mix_min``)
+   - Throttle is at minimum 
    - No large angle is being requested (roll/pitch target < 15°)
    - No large angle error exists (attitude error < 30°)
-   - The airframe is not accelerating (earth-frame accel ≈ 0)
-   - Vertical speed is within 1 m/s of zero
-   - If a healthy rangefinder is available: altitude is below 2m
+   - The airframe is not accelerating downward > 1m/s/s ( >2 m/s/s if Weight on Wheels feature is enabled)
+   - Vertical speed is within 1 m/s of zero ( within 2 m/s if Weight on Wheels feature is enabled)
+   - If a healthy rangefinder is available, and rangefinder altitude is below 2m
    - Weight-on-Wheels (WoW) sensor (if present) confirms contact or is unknown
 
    Altitude above home is **not** used as a motor shutoff condition (except when a rangefinder is used,see above).
@@ -42,8 +42,7 @@ features:
    **descent speed transition** from :ref:`LAND_SPD_HIGH_MS<LAND_SPD_HIGH_MS>`
    to :ref:`LAND_SPD_MS<LAND_SPD_MS>` — it has no role in landing detection or disarming.
 
-.. note:: For Traditional Heli, the low motor check in the above landing detection algorithm is replaced with a check that Collective output is below
-   mid-position (controlled by the vertical position controller, ie in descent). The rotor still may be at governor speed up until Motor Interlock is removed and  disarming occurs.
+.. note:: For Traditional Heli, the low motor check in the above landing detection algorithm is replaced with a check that Collective output is below mid-position (controlled by the vertical position controller, ie in descent). The rotor still may be at governor speed up until Motor Interlock is removed and  disarming occurs.
 
 .. note:: Using a Weight on Wheels (WoW) switch will increase the descent rate and
     accelerometer ranges that are acceptable for landing detection. This


### PR DESCRIPTION
Fixes #7577
Fixes #7574

The Note block incorrectly states that motor shutoff requires the copter 
to be below 10m above home altitude. After reading land_detector.cpp, 
no such check exists in update_land_detector(). 

LAND_ALT_LOW_M (10m default) only controls the descent speed transition 
from LAND_SPD_HIGH_MS to LAND_SPD_MS, not the disarm condition.

Updated the Note block to reflect the actual landing detection conditions.