### PR TITLE
build_parameters.py: fix htmlparser

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -400,7 +400,9 @@ def fetch_releases(firmware_url, vehicles):
                 if tag == 'a':
                     attr = dict(attrs)
                     href = attr.get('href')
-                    self.links.append(href)
+                    if href and vehicle.lower() in href.lower():
+                        # Only select folders with the vehicle name in it
+                        self.links.append(href)
 
         html_parser = ParseText()
         try:
@@ -454,7 +456,8 @@ def get_commit_dict(releases_parsed):
                 if tag == 'a':
                     attr = dict(attrs)
                     href = attr.get('href')
-                    self.links.append(href)
+                    if href:
+                        self.links.append(href)
 
         html_parser = ParseText()
         try:
@@ -467,6 +470,9 @@ def get_commit_dict(releases_parsed):
         except Exception as e:
             error(f"Board folders list download error: {e}")
         finally:
+            if len(html_parser.links) == 0:
+                error(f"No board folders found in {url}, skipping this release.")
+                return ""
             last_folder = html_parser.links.pop()
             board_name = os.path.basename(last_folder)
             debug(f"Returning link of the last board folder ({board_name})")
@@ -481,6 +487,9 @@ def get_commit_dict(releases_parsed):
         fetch_link = f"{version_link}/{board}/{file}"
 
         progress(f"Processing link...\t{fetch_link}")
+        if board == "":
+            error(f"Board folder not found in {version_link}, skipping this release.")
+            return "error", "error", "error"
 
         try:
             response = session.get(fetch_link, timeout=30)


### PR DESCRIPTION
fix class (python use capitalize name, links was missing from class but use in exception handling)
fix error handling
fix parsing element
simplify elements parsed and return: get the href directly as that is what interest us and simplify the parsing, pre-filter links to keep only the necessary, do better return to avoid broad exception on missing directory

<img width="1891" height="1019" alt="image" src="https://github.com/user-attachments/assets/eae15a0c-6f49-4324-8c07-ac1c3fbef224" />
