### PR TITLE
pyproject.toml: target-version = "py38" to match Vagrantfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ ignore-words-list = "bu,collets,diamon,dout,empy,extint,fram,inh,minite,ned,parm
 skip = "ARCHIVED/*,LICENSE,*.ai,*.pdf,*.svg"
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py38"
 line-length = 127
 lint.extend-select = [
   "FURB",   # refurb


### PR DESCRIPTION
Related to:
* https://docs.astral.sh/ruff/settings/#target-version
* #7551
* #7635

Vagrant still uses Ubuntu 20.04 focal which defaults to Python 3.8.
https://github.com/ArduPilot/ardupilot_wiki/blob/3464385e1521f3c76bead96fd4af8fafa2c1a54c/Vagrantfile#L10-L11
To upgrade to `py39`, we would need to merge #7551 (or similar).

Debian Bullseye LTS end-of-life is [2026-08-31](https://wiki.debian.org/DebianReleases#Versions_of_Debian_stable), which is why the main repo is pinned to `py39`.