### PR TITLE
build_parameters.py: fix parameters duplication issues for old and no…

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -81,6 +81,82 @@ VEHICLES = ALLVEHICLES
 
 BASEPATH = ""
 
+
+def rst_has_duplicate_labels(filepath: str) -> bool:
+    """
+    Check an RST file for duplicate label definitions.
+    Returns True if duplicates are found, False otherwise.
+
+    RST labels look like: .. _label_name:
+    """
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except (UnicodeDecodeError, OSError) as e:
+        error(f"Error checking RST file {filepath}: {e}")
+        return False
+
+    # Find all RST label definitions
+    labels = re.findall(r'^\.\. _([^:]+):', content, re.MULTILINE)
+
+    # Check for duplicates
+    seen = set()
+    duplicates = []
+    for label in labels:
+        label_lower = label.lower()  # RST labels are case-insensitive
+        if label_lower in seen:
+            duplicates.append(label)
+        seen.add(label_lower)
+
+    if duplicates:
+        logger.warning(f"Found {len(duplicates)} duplicate RST labels in {filepath}: {duplicates[:5]}")
+        return True
+    return False
+
+
+def dedupe_rngfnd_parameters_sections(filepath: str) -> None:
+    """Keep only the first RNGFNDx_* Parameters section and drop subsequent duplicate sections."""
+    label_re = re.compile(r'^\.\. _parameters_RNGFND([0-9A-Za-z]+)_.*:$', re.IGNORECASE)
+    section_label_re = re.compile(r'^\.\. _RNGFND([0-9A-Za-z]+).*:$', re.IGNORECASE)
+
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+    except (UnicodeDecodeError, OSError) as e:
+        debug(f"Failed to dedupe RNGFND parameters in {filepath}: {e}")
+        return
+
+    seen_labels = set()
+    saved_lines = []  # Lines to write back to the file after deduplication
+    i = 0
+    while i < len(lines):
+        current_line = lines[i]
+        current_line_stripped = current_line.strip()
+
+        rangefinder_label = label_re.match(current_line_stripped)
+        if rangefinder_label:
+            rngfnd_id = rangefinder_label.group(1)
+            if rngfnd_id in seen_labels:
+                # Don't save the duplicated line on new file, skip to next section
+                i += 1
+                while i < len(lines) and not section_label_re.match(lines[i].strip()):
+                    i += 1
+                continue
+
+            seen_labels.add(rngfnd_id)
+
+        saved_lines.append(current_line)
+        i += 1
+
+    if len(saved_lines) != len(lines):
+        try:
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.writelines(saved_lines)
+            debug(f"Dedupe applied to RNGFND sections in {filepath}")
+        except (UnicodeDecodeError, OSError) as e:
+            debug(f"Failed to dedupe RNGFND parameters in {filepath}: {e}")
+
+
 # Dicts for name replacing
 vehicle_new_to_old_name = { # Used because "param_parse.py" args expect old names
     "Rover": "APMrover2",
@@ -428,6 +504,12 @@ def generate_rst_files(commits_to_checkout_and_parse):
                 replace_anchors("Parameters.rst", filename, filename[10:-4])
                 os.remove("Parameters.rst")
                 debug(f"File {filename} generated. ")
+                # Remove duplicate RNGFNDx_ Parameters sections before checking labels.
+                dedupe_rngfnd_parameters_sections(filename)
+                # Check for duplicate RST labels in the generated file
+                if rst_has_duplicate_labels(filename):
+                    debug(f"RST duplicate labels detected in {filename}")
+
             else:
                 # this was an error, but turns out we are missing a
                 # bunch of these, eg.


### PR DESCRIPTION
…tify for new

This fix the parameters duplicate we got on some old parameters (4.0.X serie). Resolving the duplication fix also the RAM issue on building.
The ram issue comes from duplicated label and sphinx looping on duplicated label.

A new function report if duplicate a found