### PR TITLE
Common: Hobbywing DataLink v2 link fix

### DIFF
--- a/common/source/docs/common-escs-and-motors.rst
+++ b/common/source/docs/common-escs-and-motors.rst
@@ -75,7 +75,7 @@ Telemetry
     :maxdepth: 1
 
     ESC Telemetry <common-esc-telemetry>
-    Hobbywing Telemetry Hub (DatalinkV2)(uses LUA driver) <https://www.hobbywingdirect.com/products/data-link-v2>
+    Hobbywing DataLink V2 (Lua Driver) <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/drivers/Hobbywing_DataLink.md>
 
 .. note:: Currently ArduPilot only supports telemetry on BLHeli or DroneCAN/CAN ESCs, not throttle signal wire reported telemetry that some single unit ESCs report.
 


### PR DESCRIPTION
This resolves issue https://github.com/ArduPilot/ardupilot_wiki/issues/7604 by fixing the link to the Hobbywing DataLink v2 to point to our Lua driver.  I've also slightly renamed the wording attached to the link to make it more closely match the product itself.

Related flight code PR: https://github.com/ArduPilot/ardupilot/pull/32668

I've built this locally and it looks good to me.