### PR TITLE
Copter: Add doc on newly supported auto_trim in position hold modes and fix punctuation

### DIFF
--- a/copter/source/docs/autotrim.rst
+++ b/copter/source/docs/autotrim.rst
@@ -20,19 +20,19 @@ With AHRS AutoTrim the roll and pitch corrections are captured as you fly in a s
 .. image:: ../images/MP_SaveTrim_Ch7PWMCheck.png
     :target: ../_images/MP_SaveTrim_Ch7PWMCheck.png
 
-2. Set the CH7 Option to "AHRS AutoTrim" on the Software > Copter Pids screen and press the "Write Params" button
+2. Set the CH7 Option to "AHRS AutoTrim" on the Software > Copter Pids screen and press the "Write Params" button.
 
-3. Find a wind free environment with sufficient space to fly your copter without crashing into something
+3. Find a wind free environment with sufficient space to fly your copter without crashing into something.
 
-4. Put the vehicle in STABILIZE or ALT_HOLD mode.
+4. Put the vehicle in manual Stabilize/AltHold mode or a position hold Loiter/PosHold mode (recommended). 
 
-5. Arm the vehicle and lift into a hover. The vehicle must be flying in order to enable autotrim. Flip the switch that you setup(CH7) to its High position (>1800us). "Autotrim running" message will be sent to the GCS.
+5. Arm the vehicle and lift into a hover. The vehicle must be flying in order to enable autotrim. Flip the switch that you setup (CH7) to its High position (>1800us). "Autotrim running" message will be sent to the GCS.
 
-6. Fly your copter for about 25 seconds in a stable hover in position, keeping it from drifting with the pitch and roll sticks. As the trim is adjusted, less and less corrections with the sticks will be required.
+6. If in a manual mode, fly your copter for about 25 seconds in a stable hover in position, keeping it from drifting with the pitch and roll sticks. As the trim is adjusted, less and less corrections with the sticks will be required. If using a position hold mode, take off and let the copter hover in place while not touching the sticks. 
 
 7. Once satisfied, flip the switch low, saving the trims, and land. "Trim save" message will be sent to the GCS.
 
-8. Take off again in stabilize mode and check if your copter is flying level now. If not repeat steps 4 - 7 again.
+8. Take off in AltHold mode and check if your copter is flying level now. If not repeat steps 4 - 7 again.
 
 .. note::
 
@@ -40,7 +40,7 @@ With AHRS AutoTrim the roll and pitch corrections are captured as you fly in a s
 
 .. note::
 
-    It is nearly impossible to get rid of all drift so that your copter remains completely motionless without any input.
+    It is nearly impossible to get rid of all drift so that your copter remains completely motionless without any input. It may be preferable to yaw the copter 90 degrees and holding that orientation for about 6-7 seconds each time so that any external disturbances will get cancelled out, resulting in a better trim.
 
 Save Trim
 ~~~~~~~~~
@@ -48,12 +48,12 @@ Save Trim
 
 Save trim involves essentially transferring your radio transmitter's trims to correct the autopilot's accelerometer trim. Normally, once :ref:`common-accelerometer-calibration` is done, you never want to change the transmitter's trims, but in this case it is done **temporarily**. The "Save Trim" function ("5") is assigned to any free RC channel, usually a switch based one, using an :ref:`common-auxiliary-functions`. For the example below, Channel 7 will be used.
 
-1. Check that your CH7 switch goes above 1800 on the MissionPlanner's Hardware > Mandatory Hardware > Radio Calibration screen
+1. Check that your CH7 switch goes above 1800 on the MissionPlanner's Setup > Mandatory Hardware > Radio Calibration screen
 
 .. image:: ../images/MP_SaveTrim_Ch7PWMCheck.png
     :target: ../_images/MP_SaveTrim_Ch7PWMCheck.png
 
-2. Set the CH7 Option to Save Trim on the Software > Copter Pids screen and press the "Write Params" button
+2. Set the RC7 Option to Save Trim in the Config > Extended Tuning screen and press the "Write Params" button
 
 .. image:: ../images/MP_SaveTrim_Ch7.png
     :target: ../_images/MP_SaveTrim_Ch7.png


### PR DESCRIPTION
Auto Trim is supported in position hold modes in Copter 4.7. Add documentation to cover this.