### PR TITLE
common: use-cases-and-applications: expand Sub section

### DIFF
--- a/common/source/docs/common-use-cases-and-applications.rst
+++ b/common/source/docs/common-use-cases-and-applications.rst
@@ -16,11 +16,49 @@ Use Cases
 
 .. image:: ../../../images/case-sub.jpg
 
+- Observation and exploration
+
+.. youtube:: T_FMx7C5P_8
+   :width: 100%
+
+- Wreck discovery and documenting
+
+.. youtube:: BV91zgzEFHs
+   :width: 100%
+
+- Photography and videography
+
+.. youtube:: 8IOn9yDXBLM
+   :width: 100%
+
+- Boat, equipment, and infrastructure inspection
+
+.. youtube:: LCWA_9RFQ24
+   :width: 100%
+
+- Biological sampling and surveying
+
+.. youtube:: t6J94qbZqKk
+   :width: 100%
+
+- Underwater retrieval
+
+.. youtube:: _tzUh62LPjA
+   :width: 100%
+
+- Academic and research projects
+
+.. youtube:: X8CUwg6_y7E
+   :width: 100%
+
+- ROV and AUV competitions
 
 - Bathymetry Boat
 
 .. image:: ../../../images/case-boat.jpg
 
+.. youtube:: p24jFOGKxb8
+   :width: 100%
 
 - Autonomous Mowers and Tractors
 
@@ -32,10 +70,8 @@ Use Cases
 .. image:: ../../../images/case-cmu-nrec-drone.png
 
 
-..  youtube:: k6jKkpmj4-k
-    :width: 640
-    :height: 480
-
+.. youtube:: k6jKkpmj4-k
+   :width: 100%
 
 .. toctree::
     :maxdepth: 1

--- a/sub/source/docs/additional-information.rst
+++ b/sub/source/docs/additional-information.rst
@@ -11,6 +11,5 @@ Additional Information and Topics of Interest
     Upcoming Features <common-master-features>
     Ready to Swim/Use Vehicles <common-rtf>
     OEM Customization <common-oem-customizations>
-    Use Cases and Applications <common-use-cases-and-applications>
     Web Tools <https://firmware.ardupilot.org/Tools/WebTools/>
     Appendix <common-appendix>

--- a/sub/source/docs/introduction.rst
+++ b/sub/source/docs/introduction.rst
@@ -4,6 +4,12 @@
 Introduction to Sub
 ===================
 
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   common-use-cases-and-applications
+
 Sub is an advanced open-source autopilot system for submersible ROVs (Remote Operated Vehicle) that supports multiple vehicle configurations. It offers a variety of operating modes from fully manual to fully autonomous, and is designed to be safe, feature-rich, open-ended, and easy to use even for novice users. 
 
 .. image:: ../images/sub-system.jpg
@@ -50,3 +56,4 @@ Sub provides access to many functionalities through its fine-grained :ref:`param
 * Optional Buoyancy Control instead of vertical thrusters/neutral buoyancy
 
 **No programming is required** for standard operation, but highly detailed interfaces are available for programmatic control (including :ref:`MAVLink commands<dev:mavlink-commands>`), and the autopilot firmware can be freely modified and extended (including through dynamically loaded :ref:`common-lua-scripts`).
+


### PR DESCRIPTION
@Williangalvani I've transferred across the Sub use-cases [from the original docs](https://www.ardusub.com/introduction/applications.html), with some video examples where I could find them.

I've also moved the use-cases and applications to the Introduction section of the sidebar, because I don't expect many users will find it in the "Additional Information" down the bottom. Unfortunately there is [a Sphinx limitation](https://github.com/sphinx-doc/sphinx/issues/8287) that means it needs to be at the top of the sidebar section it's in, but doesn't feel _too_ problematic 🤷‍♂️ 

<img width="299" height="120" alt="Screenshot 2026-04-08 at 8 33 52 pm" src="https://github.com/user-attachments/assets/82395cbb-6537-47ff-a81f-2e46a29861cc" />

---

~~@Hwurzburg While I was at it I decided to add site filtering to minimise the irrelevant use-cases in each wiki, and in doing so found that the non-gps content was being filtered out of vehicles that support it, so fixed that too.~~
Moved to #7648