### PR TITLE
Add a `Python` label to pull requests that modify `.py` files

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,31 @@
+name: ci
+on:
+  pull_request_target:  # pull_request_target, NOT pull_request
+    types: [opened, synchronize, reopened]
+jobs:
+  labels-by-language:
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write  # So we can add labels to the pull request
+    steps:  # Do NOT "uses: actions/checkout" here!
+    - uses: actions/github-script@v9
+      with:
+        script: |
+          // Get the list of filenames changed in this PR
+          const filenames = (await github.paginate(github.rest.pulls.listFiles, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number,
+            per_page: 100,
+          })).map(file => file.filename);
+          console.log(filenames);
+
+          // If one or more filenames have a .py extension, add the "Python" label to this PR
+          if (filenames.some(filename => filename.endsWith('.py'))) {
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Python'],
+            })
+          }


### PR DESCRIPTION
<img width="72" height="60" alt="image" src="https://github.com/user-attachments/assets/02c50c74-df62-4fc7-8792-efe886f134cc" />  Add a ___Python___ label to pull requests that modify `.py` files.

This repository currently contains only [22 Python files](https://github.com/search?q=repo%3AArduPilot%2Fardupilot_wiki++language%3APython), so most pull requests will not modify these files.

However, some contributors will have Python expertise and will be interested in reviewing relevant pull requests.
This quick GitHub Action will add a label to enable the rapid isolation of Python-related pull requests.
* https://github.com/ArduPilot/ardupilot_wiki/pulls?q=label:Python

### How was this tested?
Try creating a pull request at https://github.com/cclauss/labels_by_language, adding `test.py`.

It is quite difficult to test `pull_request_target` triggered GitHub Actions on a repo that you are not a maintainer of because GitHub purposefully makes it difficult to generate `pull_request_target` events.