### PR TITLE
scripts/initvagrant.sh: Drop Ubuntu 18.04 and Python 3.6

### DIFF
--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -40,7 +40,7 @@ Install some required packages
 ------------------------------
 
 If you are on a debian based system (such as Ubuntu or Mint), we provide `a script <https://github.com/ArduPilot/ardupilot/blob/master/Tools/environment_install/install-prereqs-ubuntu.sh>`__ that will do it for you. 
-This script does NOT support building on operating systems that have reached end of support such as Ubuntu Bionic (18.04).
+This script does NOT support building on operating systems that have reached end of Standard Support such as Ubuntu 20.04 LTS (Focal Fossa).
 
 From the cloned ardupilot directory :
 ::

--- a/scripts/initvagrant.sh
+++ b/scripts/initvagrant.sh
@@ -5,15 +5,6 @@ set -x
 
 echo "---------- $0 start ----------"
 
-DISTRIBUTION_ID=$(lsb_release -i -s)
-if [ ${DISTRIBUTION_ID} == 'Ubuntu' ]; then
-  DISTRIBUTION_CODENAME=$(lsb_release -c -s)
-  if [ ${DISTRIBUTION_CODENAME} == 'bionic' ]; then
-      # make python3 the default Python on bionic:
-      sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 20
-  fi
-fi
-
 pushd /vagrant  # allow Sphinxsetup.sh to assume it is running in its own directory
 sudo -H -u vagrant ./Sphinxsetup.sh
 popd


### PR DESCRIPTION
Ubuntu 18.04 LTS Standard Support EOL was in May 2023. -- https://ubuntu.com/about/release-cycle 

Python 3.6 EOL was 2021-12-23. -- https://devguide.python.org/versions 
