### PR TITLE
parameters: version-selector: select the current file

### DIFF
--- a/antennatracker/source/_static/parameters_versioning_script.inc
+++ b/antennatracker/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }

--- a/blimp/source/_static/parameters_versioning_script.inc
+++ b/blimp/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }

--- a/copter/source/_static/parameters_versioning_script.inc
+++ b/copter/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }

--- a/plane/source/_static/parameters_versioning_script.inc
+++ b/plane/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }

--- a/rover/source/_static/parameters_versioning_script.inc
+++ b/rover/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }

--- a/sub/source/_static/parameters_versioning_script.inc
+++ b/sub/source/_static/parameters_versioning_script.inc
@@ -20,6 +20,9 @@ document.addEventListener("DOMContentLoaded", function() {
       var opt = document.createElement('option');
       opt.value = json[key];
       opt.innerHTML = key;
+      if (json[key] === window.location.pathname.split('/').pop()) {
+        opt.selected = true;
+      }
       selectPicker.appendChild(opt);
     }
   }


### PR DESCRIPTION
Defaults the param version selector to match the current page (pulled from the URL). Without a default specified, a HTML `<select>` element defaults the first option in the list (which then makes that un-selectable, in this case).

I've tested this in a browser console (on the live wiki site), and it works as far as I can tell. I did confirm that the pathname doesn't include fragment IDs (`#...`), so it's not affected by the page having optionally been reached with a link to a specific parameter.

As I understand it, [the cache gets invalidated for changed files](https://github.com/ArduPilot/ardupilot_wiki/blob/master/update.py#L696), so this should fix all the versioned parameter files at the next site build after it's merged.

Fixes #7609.