### PR TITLE
Fix incorrect remotes.schema.json path in Custom Build Server docs

### DIFF
--- a/dev/source/docs/custom-build-server.rst
+++ b/dev/source/docs/custom-build-server.rst
@@ -8,7 +8,7 @@ Design
 ------
 The ArduPilot Custom Firmware Builder is a monolithic Flask application running on ArduPilot's autotest server, with Apache WSGI serving as the web server. The application includes a builder thread that continuously consumes build requests from a queue and processes them accordingly.
 
-The available versions are listed in a file called `remotes.json`. You can find the schema for the `remotes.json` file `here <https://github.com/ArduPilot/CustomBuild/blob/main/remotes.schema.json>`__. We also have an automated setup that updates this file with the latest releases from ArduPilot, as well as some tags from certain whitelisted repositories belonging to members of the ArduPilot development team. Below is a diagram illustrating how the `remotes.json` file is updated automatically.
+The available versions are listed in a file called `remotes.json`. You can find the schema for the `remotes.json` file `here <https://github.com/ArduPilot/CustomBuild/blob/main/metadata_manager/remotes.schema.json>`__. We also have an automated setup that updates this file with the latest releases from ArduPilot, as well as some tags from certain whitelisted repositories belonging to members of the ArduPilot development team. Below is a diagram illustrating how the `remotes.json` file is updated automatically.
 
 ::
 


### PR DESCRIPTION
The documentation references `remotes.schema.json`, but the link points to an incorrect path.

This PR updates the link to the correct location under `metadata_manager`, ensuring the schema file is accessible and avoiding confusion for users.