### PR TITLE
Simplify command-line testing of get_discourse_posts.py

### DIFF
--- a/frontend/scripts/get_discourse_posts.py
+++ b/frontend/scripts/get_discourse_posts.py
@@ -2,6 +2,14 @@
 """
 Script to get last blog entries on Discourse (https://discuss.ardupilot.org/)
 """
+# PEP 723 Inline script metadata enables testing via:
+# pipx run frontend/scripts/get_discourse_posts.py  # or
+# uv run frontend/scripts/get_discourse_posts.py
+# /// script
+# dependencies = [
+#   "requests",
+# ]
+# ///
 import argparse
 import hashlib
 import json


### PR DESCRIPTION
Add PEP 723 Inline script metadata to get_discourse_posts.py.  This simplifies command-line testing via:
% `pipx run frontend/scripts/get_discourse_posts.py ` # or
% `uv run frontend/scripts/get_discourse_posts.py`

https://peps.python.org/pep-0723

### How was this tested?
Run both commands above to verify correct execution.  Also,

% `uv run frontend/scripts/get_discourse_posts.py --help`
```
usage: get_discourse_posts.py [-h] [--n_posts N_POSTS] [--verbose]

python3 get_discourse_posts.py

options:
  -h, --help         show this help message and exit
  --n_posts N_POSTS  Number of posts to retrieve
  --verbose          show debugging output
```