### PR TITLE
Run shellcheck in GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,12 @@ jobs:
         python-version: "3.10"
     - uses: pre-commit/action@v3.0.1
 
+  shellcheck:
+    runs-on: ubuntu-slim
+    steps:
+    - uses: actions/checkout@v6
+    - run: find . -type f -name "*.sh" -exec shellcheck {} +
+
   build-linux:
 
     runs-on: ubuntu-22.04

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,10 @@
+# https://www.shellcheck.net -- 'shellcheck --help'
+# https://github.com/koalaman/shellcheck
+# 'find . -type f -name "*.sh" -exec shellcheck {} +'
+
+# To improve our code quality, comment out one for the following and create a pull request:
+disable=SC2006  # 1 instance
+disable=SC2046  # 3 instances
+disable=SC2086  # Many instances
+disable=SC2162  # 3 instances
+disable=SC2185  # 1 instance


### PR DESCRIPTION
### https://github.com/koalaman/shellcheck
`shellcheck` is [preinstalled](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md#installed-apt-packages) on GitHub Actions runners.

Closes: #7620
* #7620

Like:
* ArduPilot/ardupilot#32715

### How was this tested?
Compare the results of:
% `find . -type f -name "*.sh" -exec shellcheck {} +`
with this GitHub Action job to ensure they match when modifying the config file `.shellcheckrc`.