### PR TITLE
Isse #7639: Fix BATT_FS param values in plane failsafe docs

### DIFF
--- a/plane/source/docs/apms-failsafe-function.rst
+++ b/plane/source/docs/apms-failsafe-function.rst
@@ -170,7 +170,7 @@ Plane includes a two-layer battery failsafe.  This allows setting up a follow-up
 
 - :ref:`BATT_CRT_VOLT <BATT_CRT_VOLT>` - holds the secondary (lower) voltage threshold.  Set to zero to disable. Default is zero.
 - :ref:`BATT_CRT_MAH <BATT_CRT_MAH>` - holds the secondary (lower) capacity threshold.  Set to zero to disable. Default is zero.
-- :ref:`BATT_FS_CRT_ACT <BATT_FS_CRT_ACT>` - holds the secondary action to take.  A reasonable setup would be to have :ref:`BATT_FS_LOW_ACT <BATT_FS_LOW_ACT>` = 2 (RTL) and :ref:`BATT_FS_CRT_ACT <BATT_FS_CRT_ACT>` = 1 (Land)
+- :ref:`BATT_FS_CRT_ACT <BATT_FS_CRT_ACT>` - holds the secondary action to take.  A reasonable setup would be to have :ref:`BATT_FS_LOW_ACT <BATT_FS_LOW_ACT>` = 1 (RTL) and :ref:`BATT_FS_CRT_ACT <BATT_FS_CRT_ACT>` = 2 (Land)
 
 Advanced Battery Failsafe Settings
 ----------------------------------


### PR DESCRIPTION
Documentation update for `BATT_FS_LOW_ACT` and `BATT_FS_CRT_ACT` values which were incorrect (based on complete params list). Labels (in parenthesis) remain the same but now matching the action values.