### PR TITLE
Python shebangs: #!/usr/bin/env python3

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     This script aims to provide multiple parameters source files for each vehicle based on the versions available at
     https://firmware.ardupilot.org

--- a/scripts/build_motor_diagrams.py
+++ b/scripts/build_motor_diagrams.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """****************************************************************************
 * build_motor_diagrams.py
 *   -- Yuri Rage - 2024

--- a/scripts/cap_params.py
+++ b/scripts/cap_params.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 script to find and optionally replace param refs in rst files
 '''

--- a/scripts/generate_motor_json.py
+++ b/scripts/generate_motor_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """****************************************************************************
 * generate_motor_json.py
 *   -- Yuri Rage - 2024


### PR DESCRIPTION
Some were `python` and others were `python3` so let's pick just one.

As discussed at https://github.com/ArduPilot/ardupilot_wiki/pull/7551#issuecomment-4213536493

% `git grep "#\!" **/*.py`
```
build_parameters.py:#!/usr/bin/env python  # <--
frontend/scripts/get_discourse_posts.py:#!/usr/bin/env python3
frontend/scripts/serve.py:#!/usr/bin/env python3
scripts/build_motor_diagrams.py:#!/usr/bin/env python  # <--
scripts/cap_params.py:#!/usr/bin/env python  # <--
scripts/generate_motor_json.py:#!/usr/bin/env python  # <--
scripts/rename_params.py:#!/usr/bin/env python3
update.py:#!/usr/bin/env python3
```
`python-is-python3` is [preinstalled](https://github.com/actions/runner-images/blob/main/images/ubuntu-slim/ubuntu-slim-Readme.md#installed-apt-packages) on GitHub Actions runners, so this does not matter in workflow jobs.