### PR TITLE
build_parameters.py: tidy parsing of list html

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -268,7 +268,8 @@ def fetch_releases(firmware_url, vehicles):
             def handle_starttag(self, tag, attrs):
                 if tag == 'a':
                     attr = dict(attrs)
-                    self.links.append(attr)
+                    href = attr.get('href')
+                    self.links.append(href)
 
         html_parser = ParseText()
         try:
@@ -287,7 +288,7 @@ def fetch_releases(firmware_url, vehicles):
 
         for folder in page_links:  # Non clever way to filter the strings insert by makehtml.py, unwanted folders, and so.
             version_folder = str(folder)
-            firmware_version_url = f"{firmware_url[:-1]}{version_folder[10:-2]}"
+            firmware_version_url = f"{firmware_url[:-1]}{version_folder}"
             if "stable" in version_folder and not version_folder.endswith("stable"): # If finish with
                 stableFirmwares.append(firmware_version_url)
             elif "latest" in version_folder:
@@ -317,7 +318,8 @@ def get_commit_dict(releases_parsed):
             def handle_starttag(self, tag, attrs):
                 if tag == 'a':
                     attr = dict(attrs)
-                    self.links.append(attr)
+                    href = attr.get('href')
+                    self.links.append(href)
 
         html_parser = ParseText()
         try:
@@ -326,10 +328,10 @@ def get_commit_dict(releases_parsed):
         except Exception as e:
             error(f"Board folders list download error: {e}")
         finally:
-            last_item = html_parser.links.pop()
-            last_folder = last_item['href']
-            debug(f"Returning link of the last board folder ({last_folder[last_folder.rindex('/')+1:]})")
-            return last_folder[last_folder.rindex('/')+1:]  # clean the partial link
+            last_folder = html_parser.links.pop()
+            board_name = os.path.basename(last_folder)
+            debug(f"Returning link of the last board folder ({board_name})")
+            return board_name
     ####################################################################################################
 
     def fetch_commit_hash(version_link, board, file):


### PR DESCRIPTION
the existing code is parsing the stringification of a structure, which is just bad form.

Extract the href directly from the HTML attributes and use it for further parsing

More stuff extracted from https://github.com/ArduPilot/ardupilot_wiki/pull/7597/changes
