### PR TITLE
Copter: clarify FS_OPTIONS bit 5 in radio, GCS, and battery failsafe docs

### DIFF
--- a/copter/source/docs/failsafe-battery.rst
+++ b/copter/source/docs/failsafe-battery.rst
@@ -53,9 +53,10 @@ The :ref:`FS_OPTIONS<FS_OPTIONS>` parameter (Copter 4.0 and later) is a bitmask 
 - bit 2 set: Continue if in guided mode :ref:`Radio Failsafe <radio-failsafe>`
 - bit 3 set: Continue if landing on any failsafe
 - bit 4 set: Continue in pilot control on :ref:`Ground Control Station Failsafe<gcs-failsafe>`
+- bit 5 set: Release gripper during failsafe handling
 - if none of the above are set, then execute the :ref:`BATT_FS_LOW_ACT <BATT_FS_LOW_ACT>` or :ref:`BATT_FS_CRT_ACT <BATT_FS_CRT_ACT>` options as configured.
 
-.. note:: Only bitmask bit 3 affects actions taken during Battery failsafe. This parameter also works in conjunction with the GCS and radio failsafe, so ensure you are taking all options into account when setting this parameter.
+.. note:: Only bitmask bit 3 & 5 affects actions taken during Battery failsafe. This parameter also works in conjunction with the GCS and radio failsafe, so ensure you are taking all options into account when setting this parameter.
 
 .. note::
 

--- a/copter/source/docs/gcs-failsafe.rst
+++ b/copter/source/docs/gcs-failsafe.rst
@@ -55,9 +55,10 @@ The :ref:`FS_OPTIONS<FS_OPTIONS>` parameter (Copter 4.0 and later) is a bitmask 
 - bit 2 set: Continue if in guided mode :ref:`Radio Failsafe <radio-failsafe>`
 - bit 3 set: Continue if landing on any failsafe
 - bit 4 set: Continue in pilot control on :ref:`Ground Control Station Failsafe<gcs-failsafe>`
+- bit 5 set: Release gripper during failsafe handling
 - If none of the above are set, then execute the :ref:`FS_GCS_ENABLE <FS_GCS_ENABLE>` option as configured.
 
-.. note:: Only bitmask bits 1, 3, & 4 affect actions taken during GCS failsafe. This parameter also works in conjunction with the battery and radio failsafe, so ensure you are taking all options into account when setting this parameter.
+.. note:: Only bitmask bits 1, 3, 4 & 5 affect actions taken during GCS failsafe. This parameter also works in conjunction with the battery and radio failsafe, so ensure you are taking all options into account when setting this parameter.
 
 .. image:: ../images/FailsafeAdvPar801.jpg
     :target: ../_images/FailsafeAdvPar801.jpg

--- a/copter/source/docs/radio-failsafe.rst
+++ b/copter/source/docs/radio-failsafe.rst
@@ -92,9 +92,10 @@ The :ref:`FS_OPTIONS<FS_OPTIONS>`  parameter (Copter 4.0 and later) is a bitmask
 - bit 2 set: Continue if in guided mode :ref:`Radio Failsafe <radio-failsafe>`
 - bit 3 set: Continue if landing on any failsafe
 - bit 4 set: Continue in pilot control on :ref:`Ground Control Station Failsafe<gcs-failsafe>`
+- bit 5 set: Release gripper during failsafe handling
 - if none of the above are set, then execute the :ref:`FS_THR_ENABLE<FS_THR_ENABLE>` option as configured.
 
-.. note:: Only bitmask bits 0, 2, & 3 affect actions taken during radio failsafe. This parameter also works in conjunction with the battery and GCS failsafe, so ensure you are taking all options into account when setting this parameter.
+.. note:: Only bitmask bits 0, 2, & 3 affect actions taken during radio failsafe; bit 5 may additionally release the gripper. This parameter also works in conjunction with the battery and GCS failsafe, so ensure you are taking all options into account when setting this parameter.
 
 Below is a screenshot of the Mission Planner Initial Setup >> Mandatory Hardware >> Failsafe menu.
 

--- a/copter/source/docs/radio-failsafe.rst
+++ b/copter/source/docs/radio-failsafe.rst
@@ -95,7 +95,7 @@ The :ref:`FS_OPTIONS<FS_OPTIONS>`  parameter (Copter 4.0 and later) is a bitmask
 - bit 5 set: Release gripper during failsafe handling
 - if none of the above are set, then execute the :ref:`FS_THR_ENABLE<FS_THR_ENABLE>` option as configured.
 
-.. note:: Only bitmask bits 0, 2, & 3 affect actions taken during radio failsafe; bit 5 may additionally release the gripper. This parameter also works in conjunction with the battery and GCS failsafe, so ensure you are taking all options into account when setting this parameter.
+.. note:: Only bitmask bits 0, 2, 3 & 5 affect actions taken during radio failsafe. This parameter also works in conjunction with the battery and GCS failsafe, so ensure you are taking all options into account when setting this parameter.
 
 Below is a screenshot of the Mission Planner Initial Setup >> Mandatory Hardware >> Failsafe menu.
 


### PR DESCRIPTION
The current failsafe pages list FS_OPTIONS bits 0..4 only, but the parameter definitions already include bit 5 ("Release Gripper").