### PR TITLE
Dev: mavlink interface link fix

### DIFF
--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -83,6 +83,6 @@ Vehicle Parameter References
 Software Integration Tools
 ==========================
 
--   MAVSDK <https://github.com/ArduPilot/ardupilot-mavsdk>
--   Pymavlink python script <https://github.com/ArduPilot/pymavlink>
+-   `MAVSDK <https://github.com/ArduPilot/ardupilot-mavsdk>`__
+-   `Pymavlink python script <https://github.com/ArduPilot/pymavlink>`__
 


### PR DESCRIPTION
This fixes the two links at the bottom of the mavlink interface page.  I've built this locally and it looks OK to me