### PR TITLE
Clarify FS_THR_VALUE low-throttle trigger separately from RC-loss tim…

### DIFF
--- a/copter/source/docs/radio-failsafe.rst
+++ b/copter/source/docs/radio-failsafe.rst
@@ -24,11 +24,12 @@ If enabled and set-up correctly the radio failsafe will trigger if any of these 
 
 -  The pilot turns off the RC transmitter.
 -  The vehicle travels outside of RC range and signal is lost.
--  The pilot forces the throttle channel below :ref:`FS_THR_VALUE<FS_THR_VALUE>` from the transmitter.
 -  RC_OVERRIDES are lost if :ref:`using a GCS only <common-gcs-only-operation>` is being used.
 -  The receiver loses power (unlikely).
 -  The wires connecting the receiver to the autopilot are broken
    (unlikely).
+
+The radio failsafe will also trigger if the pilot forces the throttle channel below :ref:`FS_THR_VALUE<FS_THR_VALUE>` from the transmitter.
 
 What will happen
 ================


### PR DESCRIPTION
rresolves #7674

Clarify that the FS_THR_VALUE low-throttle trigger is described separately from the RC_FS_TIMEOUT-based RC-loss timeout path.