### PR TITLE
Clarify Brake mode position requirement and remove misleading auto-disarm statement

### DIFF
--- a/copter/source/docs/brake-mode.rst
+++ b/copter/source/docs/brake-mode.rst
@@ -6,7 +6,7 @@ Brake Mode
 
 This very simple flight mode simply stops the vehicle as soon as
 possible.  Once invoked, this mode does not accept any input from
-the pilot. This mode requires GPS.
+the pilot. This mode requires a valid position estimate.
 
 Brake mode is subject to acceleration and angle limits imposed by the
 position and attitude controllers. For more aggressive braking, you can
@@ -21,7 +21,6 @@ as possible.  Good GPS position, :ref:`low magnetic interference on the compass 
 :ref:`low vibrations <common-diagnosing-problems-using-logs_vibrations>`
 are all important in achieving good performance.
 
-If the vehicle is landed in Brake mode it will immediately disarm.
 
 ..  youtube:: -Db4u8LJE5w&t=103s
     :width: 100%


### PR DESCRIPTION
This issue was discussed in issue [#31877](https://github.com/ArduPilot/ardupilot/issues/31877).
1.Clarify Brake mode requires a usable position estimate, not strictly GPS
Update the Brake mode page to say the mode requires a usable position estimate rather than GPS specifically, matching behavior when non-GPS positioning remains available.

2.Remove misleading Brake mode auto-disarm statement
Remove the “immediately disarm” sentence from the Brake mode page for clarity, as discussed in issue #31877. The current wording can be misleading because the observed behavior follows general landing/disarm logic rather than a Brake-specific rule.

Also, in the default configuration, auto-disarm timing is not necessarily immediate and may instead follow the DISARM_DELAY setting (default: 10 seconds). More generally, whether and when auto-disarm occurs can vary with disarm-related settings such as PILOT_THR_BHV and DISARM_DELAY.