### PR TITLE
Common: joystick mode channel warning

### DIFF
--- a/common/source/docs/common-joystick.rst
+++ b/common/source/docs/common-joystick.rst
@@ -63,10 +63,9 @@ Setup with the Mission Planner
 
 -  Repeat for *Pitch*, *Throttle* and *Rudder* and push the **Save** button
 -  You will likely want to set-up other buttons for *Arm* and *Disarm*
--  Instead of setting up a stick or button for ch5 (the flight mode
-   channel), it is better to set individual buttons to initiate a flight
-   mode by selecting **Change Mode** and then push the **Settings**
-   button and select the flight mode from the drop-down (see pic above)
+-  The flight mode channel (e.g. RC5 or RC8) and :ref:`auxiliary function channels <common-auxiliary-functions>`
+   should not be controlled from the joystick especially if a regular RC receiver is also connected.  Instead it is better to configure buttons to set the flight
+   mode by selecting **Change Mode** and then push the **Settings** button and select the flight mode from the drop-down (see pic above).  Details on why this is important are documented in `issue #32862 <https://github.com/ArduPilot/ardupilot/issues/32862>`__.
 -  When done, push the **Save** button. This records the min and max calibrations and records the neutral positions of the joystick for the trim value. Mission Planner will then scale the joystick signal to the RC channel's ``RCx_MIN/MAX/TRIM`` parameters in the autopilot when sending RC override commands by the Joystick.
 
 Autopilot Setup

--- a/common/source/docs/common-joystick.rst
+++ b/common/source/docs/common-joystick.rst
@@ -4,10 +4,9 @@
 Joystick/Gamepad
 ================
 
-This article explains how you can control your vehicle with a Joystick or Gamepad using the Mission Planner which sends "RC Override" messages to the vehicle.
+This article explains how you can control your vehicle with a Joystick or Gamepad using the Mission Planner which sends "RC Channel Override" messages to the vehicle.
 
-Other GCSs may also support "RC overrides" but they are not covered in
-this article.
+Other GCSs including QGC also support "RC Channel Overrides" but they are not covered in this article.
 
 .. figure:: ../../../images/joystick_LogitechF310.jpg
    :target: ../_images/joystick_LogitechF310.jpg
@@ -17,8 +16,7 @@ this article.
 .. tip::
 
    Even if flying with a joystick, you should keep a regular
-   transmitter/receiver connected and ready for use as a backup.  In future
-   versions of ArduPilot, after more failsafe testing has been completed this recommendation may change.
+   transmitter/receiver connected and ready for use as a backup
 
 What you will need
 ==================
@@ -41,14 +39,14 @@ First you must calibrate the joystick using the Windows joystick/game controller
 Setup with the Mission Planner
 ==============================
 
--  Connect your USB joystick/gamepad to the laptop computer
+-  Connect your USB joystick/gamepad to the PC
 -  Open the *Mission Planner Flight Data* screen. On the **Actions** tab
    push the **Joystick** button
 
    .. image:: ../../../images/joystick_MPSetup.png
        :target: ../_images/joystick_MPSetup.png
    
--  Ensure the Logitech joystick appears in the drop-down
+-  Ensure the joystick appears in the drop-down
 -  The **Enable** button, once pushed, will tell the mission planner to
    start sending commands to the vehicle so for the initial setup do not
    push it.
@@ -118,7 +116,7 @@ To check the above controls move in the correct direction:
    Joystick setup screen.
 
 Next test you are able to arm, disarm and switch into the various flight
-modes (not need to connect the battery)
+modes (no need to connect the battery)
 
 Testing the failsafes
 =====================


### PR DESCRIPTION
This makes two sets of changes to the joystick page:

1. minor updates and corrections to wording
2. strengthens the advice to NOT use the joystick to control the flight mode channel nor auxiliary function channels

This should help users avoid this issue https://github.com/ArduPilot/ardupilot/issues/32862 which involves stale input being consumed from the regular RC after a fallback from the joystick to the regular RC

I've built this locally and it looks OK to me

fixes ArduPilot/ardupilot/issues/32862