### PR TITLE
Clarify Drift mode position-estimate requirement and failsafe action

### DIFF
--- a/copter/source/docs/drift-mode.rst
+++ b/copter/source/docs/drift-mode.rst
@@ -48,10 +48,10 @@ How Drift Mode works
    altitude.  If the pilot puts the throttle completely down the motors
    will go to their minimum rate (:ref:`MOT_SPIN_MIN <MOT_SPIN_MIN>`) and if the vehicle
    is flying it will lose attitude control and tumble.
--  Drift Mode relies on your GPS for control.
+-  Drift Mode relies on a valid position estimate, such as GPS, for control.
 -  If you lose your GPS signal in flight while in Drift Mode, your
    copter will either land or enter altitude hold based on your
-   failsafe_gps_enabled setting.
+   :ref:`FS_EKF_ACTION <FS_EKF_ACTION>` setting.
 -  You should also be prepared to switch back to Stabilize Mode for
    manual recovery if necessary.
 


### PR DESCRIPTION
Update Drift mode documentation to refer to position estimates and FS_EKF_ACTION instead of GPS-only control and the obsolete failsafe_gps_enabled setting.

- Drift mode requires a valid position estimate, not strictly GPS. In the code, Drift is marked as requiring position (requires_position()), and the position validity check (position_ok()) is based on EKF state rather than GPS alone. This allows non-GPS sources (e.g. Optical Flow) to satisfy the requirement.

- The failsafe behavior is handled by the EKF failsafe, not a dedicated GPS failsafe parameter(this was also discussed in [ArduPilot/ardupilot#3230](https://github.com/ArduPilot/ardupilot/issues/3230)). The previous reference to failsafe_gps_enabled appears to be obsolete; current behavior is controlled by FS_EKF_ACTION, which determines whether the vehicle switches to Land or AltHold when position estimate is lost.

- In SITL testing, disabling GPS while maintaining an alternative position source still allows entering and holding Drift mode, and when position estimate is lost, the vehicle transitions to LAND via EKF failsafe (e.g. “EKF Failsafe: changed to LAND Mode”).

