### PR TITLE
Fix various

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
         args:
           - --disable=missing-final-newline
           - --disable=trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: rst-literal-block-spacing
+        name: Check ReST literal block spacing
+        entry: python scripts/check_rst_literal_blocks.py
+        language: system
+        files: '\.rst$'

--- a/common/source/docs/common-beagle-bone-blue.rst
+++ b/common/source/docs/common-beagle-bone-blue.rst
@@ -27,7 +27,7 @@ Specifications
 -  **Processor**
 
    -  1GHz ARM Cortex-A8
-   -  2×32-bit 200-MHz programmable real-time units (PRUs)
+   -  2x32-bit 200-MHz programmable real-time units (PRUs)
    -  512MB DDR3 RAM integrated
    -  4GB 8-bit eMMC flash
 
@@ -76,13 +76,13 @@ Connect BBBlue to the internet using a shared internet connection over USB (see 
 
 On the BBBlue configure gateway and nameserver.
 
-::
+..code-block:: bash
     
     sudo nano /etc/network/interfaces
     
 Then paste the following lines under ``iface lo inet loopback``
 
-::
+..code-block::
 
     iface usb0 inet static
     address 192.168.7.2
@@ -112,13 +112,13 @@ Next, configure the Host (Linux or Windows):
 
 Host computer's command prompt:
 
-::
+..code-block:: bash
 
     ifconfig
     
 use this output to figure out which is your internet connected network adapter and replace in the following 'wlan0' by the name of it:
 
-::
+..code-block:: bash
 
     sudo sysctl net.ipv4.ip_forward=1
     sudo iptables -t nat -A POSTROUTING -o wlan0 -j MASQUERADE
@@ -128,19 +128,19 @@ use this output to figure out which is your internet connected network adapter a
 
 Reboot the BBBlue and then reconnect again using SSH
 
-::
+..code-block:: bash
 
     sudo reboot
 
 Eliminate the necessity for the user to enter the sudoer password:
 
-::
+..code-block:: bash
 
     echo "debian ALL=(ALL) NOPASSWD: ALL" | sudo tee -a /etc/sudoers.d/debian >/dev/null
 
 Install locales (a lot of programs complain otherwise) and set them:
 
-::
+..code-block:: bash
     
     sudo apt -y update
     sudo apt install -y locales
@@ -148,7 +148,7 @@ Install locales (a lot of programs complain otherwise) and set them:
 
 Choose a locale (e.g. en_US.UTF-8 = English, United States, UTF8). This may take a while.
 
-::
+..code-block:: bash
 
     sudo apt -y dist-upgrade
     sudo apt install -y git
@@ -156,7 +156,7 @@ Choose a locale (e.g. en_US.UTF-8 = English, United States, UTF8). This may take
 
 Set CPU profile to "Performance":
 
-::
+..code-block:: bash
 
     sudo sed -i 's/GOVERNOR="ondemand"/GOVERNOR="performance"/g' /etc/init.d/cpufrequtils
     
@@ -168,13 +168,13 @@ The following instructions show how to setup ArduPlane. It is the same for other
 
 Create an empty service file so that ardupilot automatically starts on boot and runs in the background:
 
-::
+..code-block:: bash
 
     sudo nano /lib/systemd/system/arduplane.service
 
 Paste following text. And replace ``<target IP address>`` with the IP address of the telemetry receiving computer:
 
-::
+..code-block:: systemd
 
     [Unit]
     Description=ArduPlane Service
@@ -190,13 +190,13 @@ Paste following text. And replace ``<target IP address>`` with the IP address of
     [Install]
     WantedBy=multi-user.target
 
-::
+..code-block:: bash
 
     sudo mkdir -p /usr/bin/ardupilot
 
 Download the latest ArduPilot binary for the ``blue`` target/FC from https://firmware.ardupilot.org/ (`Plane/stable-4.1.6/blue/arduplane <https://firmware.ardupilot.org/Plane/stable-4.1.6/blue/arduplane>`__ used in this example). Copy this file to `/usr/bin/ardupilot/`.
 
-::
+..code-block:: bash
 
     sudo wget -O /usr/bin/ardupilot/arduplane https://firmware.ardupilot.org/Plane/stable-4.1.6/blue/arduplane
     
@@ -207,7 +207,7 @@ Alternatively there are other possible sources like the https://custom.ardupilot
    In case this image does not exist anymore or is outdated, go to https://firmware.ardupilot.org/ and look for the vehicle type you want. Then look for the firmware you want - usually the most recent ``stable`` - and within that folder look for ``blue``. In this folder you will find some text files and the firmware binary/executable.
    
 
-::
+..code-block:: bash
 
     sudo chmod 0755 /usr/bin/ardupilot/a*
     sudo systemctl enable arduplane.service
@@ -230,14 +230,14 @@ Via Wifi
 
 Connect the BBBlue to an available access point - this does NOT setup the BBBlue to act as access point itself.
 
-::
+..code-block:: bash
 
     connmanctl services | grep 'YOUR_SSID' | grep -Po 'wifi_[^ ]+'
     cat >/var/lib/connman/wifi.config
 
 One line at a time, we're writing a file line by line:
 
-::
+..code-block:: systemd
 
     [service_<OUTPUT-FROM-CONNMANCTL-COMMAND>]
     Type = wifi
@@ -247,7 +247,7 @@ One line at a time, we're writing a file line by line:
 
 CTRL + C, should save File contents. Make sure to add a new line (press Enter) after Passphrase = ***** 
 
-::
+..code-block:: bash
 
     sudo reboot
 
@@ -255,7 +255,7 @@ Again, ssh into the BBBlue at the former IP.
 
 Obtain the IP of the BBBlue wifi interface:
 
-::
+..code-block:: bash
 
     ip addr
 
@@ -274,7 +274,7 @@ Generally you can compile ArduPilot on the BBBlue itself. But this takes a lot o
 
 Install Ubuntu 20.04 64-Bit as build machine (e.g. can be VM or github action).
 
-::
+..code-block:: bash
 
     sudo apt update
     sudo apt install git
@@ -283,12 +283,12 @@ Install Ubuntu 20.04 64-Bit as build machine (e.g. can be VM or github action).
 
 use either the stable tag ``ArduPlane-stable`` or the current Plane branch ``Plane-4.1`` (in the moment both refer to Plane-4.1.6) - make sure to use a ``stable`` version
 
-::
+..code-block:: bash
 
     ./Tools/environment_install/install-prereqs-ubuntu.sh
     git checkout Plane-4.1
 
-::
+..code-block:: bash
 
     ./waf configure --board=blue
     ./waf plane
@@ -302,20 +302,20 @@ In this section we update the kernel. There are two types of kernels: Real-time 
 
 Update local scripts:
 
-::
+..code-block:: bash
 
     cd /opt/scripts && git pull
 
 Update kernel:
 
-::
+..code-block:: bash
 
     sudo /opt/scripts/tools/update_kernel.sh --bone-rt-kernel --lts-5_10
 
 
 Specify device tree binary to be used at startup:
 
-::
+..code-block:: bash
 
     sudo sed -i 's/#dtb=/dtb=am335x-boneblue.dtb/g' /boot/uEnv.txt
 
@@ -328,7 +328,7 @@ There are two types of drivers available for the PRU's (Programmable Realtime Un
 
 Open uEnv.txt for editing:
 
-::
+..code-block:: bash
 
     sudo nano /boot/uEnv.txt
 
@@ -337,19 +337,19 @@ Set ``uboot_overlay_pru=AM335X-PRU-UIO-00A0.dtbo``.
 
 Finally reboot the board to finalize configuration.
 
-::
+..code-block:: bash
 
     sudo reboot
 
 Test to see if the device tree blob (DTB) is loaded
 
-::
+..code-block:: bash
 
     lsmod |grep uio
 
 It should show something like this:
 
-::
+..code-block::
 
     uio_pruss       4928 0
     uio_pdrv_genirq 3539 0
@@ -361,7 +361,7 @@ Flash SD card to eMMC
 
 You can use the following steps to copy everything over to the eMMC. This way the SD card can be removed or used for other purposes.
 
-::
+..code-block:: bash
 
     sudo nano /boot/uEnv.txt
 
@@ -369,7 +369,7 @@ Uncomment the line ``#cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.
 
 It should now be:
 
-::
+..code-block:: bash
 
     cmdline=init=/opt/scripts/tools/eMMC/init-eMMC-flasher-v3.sh
 
@@ -384,20 +384,20 @@ Power it up again and it should boot as usual.
 Check if booted from eMMC or SD card
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-::
+..code-block:: bash
 
     sudo apt-get install tiomapconf
 
 Boot from eMMC:
 
-::
+..code-block:: bash
 
     sudo omapconf read 0x44E10040
     0040033C
 
 Boot from microSD (boot button pressed):
 
-::
+..code-block:: bash
 
     sudo omapconf read 0x44E10040
     00400338
@@ -411,7 +411,7 @@ Via built-in Bluetooth
 
 In order to use the built-in Bluetooth connection as MAVLink some steps are required. First, we need a Python script that provides a rfcomm bluetooth service. The script also creates a virtual serial port (/dev/pts/0) which we will specify as ardupilot telemetry channel later. Everything that is sent or received to or from the virtual serial port will be redirected over bluetooth to our client application or ardupilot.
 
-::
+..code-block:: bash
 
     sudo python3 -m pip install pybluez
     sudo python3 -m pip install pyserial
@@ -421,7 +421,7 @@ In order to use the built-in Bluetooth connection as MAVLink some steps are requ
 
 Paste the following script
 
-::
+..code-block:: python
 
     import os, pty, serial, time
     from bluetooth import *
@@ -477,13 +477,13 @@ Paste the following script
     
 Next we create a systemd service for this script.
 
-::
+..code-block:: bash
 
     sudo nano /lib/systemd/system/bluetooth-serial.service
     
 And paste the following text.
 
-::
+..code-block:: systemd
 
     [Unit]
     Description=Bluetooth Serial Service
@@ -499,14 +499,14 @@ And paste the following text.
 
 We now have to adjust the previously created ardupilot service. Open the service file:
 
-::
+..code-block:: bash
 
     sudo nano /lib/systemd/system/arduplane.service
     
 
 It's mandatory that the bluetooth-serial.service starts before ardupilot. We can replace the After=[...] to
 
-::
+..code-block:: systemd
 
     After=bluetooth-serial.service
     
@@ -514,19 +514,20 @@ to achieve this behaviour.
 
 Next let's adjust the communication channel to our newly created virtual serial port:
 
-::
+..code-block:: systemd
 
     ExecStart=/usr/bin/ardupilot/arduplane -A /dev/pts/0
 
 Enable service:
-::
+
+..code-block:: bash
 
     sudo systemctl enable bluetooth-serial.service
 
 
 Save the file and reboot.
 
-::
+..code-block:: bash
 
     sudo reboot
     
@@ -555,13 +556,13 @@ Careful: The uboot_overlay_pru version in this Github comment is outdated. Use t
 Check system config
 -------------------
 
-::
+..code-block:: bash
 
     sudo /opt/scripts/tools/version.sh
 
 The ``current`` config should look like this (Use diffchecker or similar tool):
 
-::
+..code-block:: bash
 
     git:/opt/scripts/:[1583f354594aabfaff08dee2a4aabdfe61433024]
     eeprom:[A335BNLTBLA21736EL001182]

--- a/common/source/docs/common-lua-binding-syntax.rst
+++ b/common/source/docs/common-lua-binding-syntax.rst
@@ -15,7 +15,8 @@ Most methods have an alias defined to specify its binding group. For example, th
 ``singleton AP_AHRS alias ahrs``
 
 so that using its call to retrieve current roll is accessed:
-::
+
+.. code-block:: lua
 
     roll = ahrs:get_roll()
 
@@ -40,10 +41,12 @@ In the AP_Arming group:
 ``singleton AP_Arming method is_armed boolean``
 
 binds the public variable in AP_Arming.h:
-::
+
+.. code-block:: cpp
 
  bool is_armed();
- returning a boolean for armed
+
+returning a boolean for armed
 
 In the AP_Baro group:
 ~~~~~~~~~~~~~~~~~~~~~
@@ -51,10 +54,12 @@ In the AP_Baro group:
 ``singleton AP_Baro method get_temperature float``
 
 binds to the function in AP_Baro.h:
-::
+
+.. code-block:: cpp
 
   float get_temperature(void) const { return get_temperature(_primary); }
-  returning a float of the baro temperature for primary barometer
+
+returning a float of the baro temperature for primary barometer
 
 In the AP_Relay group:
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -62,19 +67,23 @@ In the AP_Relay group:
 ``singleton AP_Relay method on void uint8_t 0 AP_RELAY_NUM_RELAYS``
 
 binds to the function in AP_Relay.h:
-::
+
+.. code-block:: cpp
 
  void on(uint8_t instance) { set(instance, true); }
- returning nothing, but setting Relay instance ON, where instance
- is an unsigned 8 bit integer between 0 and AP_RELAY_NUM_RELAYS (currently 6)
+
+returning nothing, but setting Relay instance ON, where instance
+is an unsigned 8 bit integer between 0 and AP_RELAY_NUM_RELAYS (currently 6)
 
 ``singleton AP_Relay method enabled boolean uint8_t 0 AP_RELAY_NUM_RELAYS``
 
 binds to:
-::
+
+.. code-block:: cpp
 
   bool enabled(uint8_t instance) { return instance < AP_RELAY_NUM_RELAYS && _pin[instance] != -1; }
-  returning a boolean if the relay instance provided has been setup
+
+returning a boolean if the relay instance provided has been setup
 
 In the AP_AHRS group:
 ~~~~~~~~~~~~~~~~~~~~~
@@ -85,7 +94,8 @@ An example that takes advantage that a LUA variable can have a value or be NULL 
 ``Vector3f'Null float'Null``
 
 binding to:
-::
+
+.. code-block:: cpp
 
     // get_variances - provides the innovations normalized using the innovation variance where a value of 0
     // indicates perfect consistency between the measurement and the EKF solution and a value of 1 is the maximum
@@ -93,14 +103,17 @@ binding to:
     // boolean false is returned if variances are not available
     virtual bool get_variances(float &velVar, float &posVar, float &hgtVar, Vector3f &magVar, float &tasVar) const {
         return false;
-    returning multiple values, any of which can be NULL.
-    In this case the C++ function is boolean, but since the returns have 'NULL specified,
-    the C++ return of a boolean is ignored and the returned values can have NULL value.
-    Note that this call returns many values (arguments are variable pointers) and has no input 
-    variables.
+        }
+
+returning multiple values, any of which can be NULL.
+In this case the C++ function is boolean, but since the returns have 'NULL specified,
+the C++ return of a boolean is ignored and the returned values can have NULL value.
+Note that this call returns many values (arguments are variable pointers) and has no input 
+variables.
 
 In order to see how this would be used:
-:: 
+
+.. code-block:: lua
 
       velVar, posVar,hgtVar,magVar, tasVar = ahrs:get_variances()
       if velVar then

--- a/copter/source/docs/autotune.rst
+++ b/copter/source/docs/autotune.rst
@@ -197,7 +197,7 @@ This is during Pitch Rate P adjustment, indicating a twitch is about to happen a
 
 Anytime the process is interrupted by pilot stick movements, the
 
-:: 
+::
 
  09:09:38   AUTOTUNE: pilot overrides active
 

--- a/dev/source/docs/balance_bot-sitl-mavproxy-tutorial.rst
+++ b/dev/source/docs/balance_bot-sitl-mavproxy-tutorial.rst
@@ -6,7 +6,7 @@ Balance Bot SITL/MAVProxy Tutorial
 
 If you are new to using SITL, please follow these :ref:`instructions<setting-up-sitl-on-linux>` to setup SITL. For executing SITL balance bot, navigate to the ardupilot/Rover directory on terminal and execute the command:
 
-:: 
+::
 
     sim_vehicle.py -f balancebot --console --map
 

--- a/dev/source/docs/building-setup-linux.rst
+++ b/dev/source/docs/building-setup-linux.rst
@@ -43,6 +43,7 @@ If you are on a debian based system (such as Ubuntu or Mint), we provide `a scri
 This script does NOT support building on operating systems that have reached end of Standard Support such as Ubuntu 20.04 LTS (Focal Fossa).
 
 From the cloned ardupilot directory :
+
 ::
 
     Tools/environment_install/install-prereqs-ubuntu.sh -y
@@ -208,6 +209,7 @@ How to Build the Docker Image
 -----------------------------
 
 Build the docker image and tag it with the name ardupilot:
+
 ::
 
     docker build . -t ardupilot --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g)
@@ -217,6 +219,7 @@ Run ArduPilot Container
 The following command runs the docker container, linking your current directory with
 the Ardupilot source, and launches an interactive shell inside the container. From here
 you can build Ardupilot:
+
 ::
 
     docker run --rm -it -v "$(pwd):/ardupilot" -u "$(id -u):$(id -g)" ardupilot:latest bash

--- a/dev/source/docs/editing-prs.rst
+++ b/dev/source/docs/editing-prs.rst
@@ -19,7 +19,8 @@ First, determine if you have been given permission to modify the PR. If so, then
 "Add more commits by pushing to the ``xyz`` branch on ``username/ardupilot``"
 
 First set up a remote to username's repository, in this case we will call it ``tempremote`` :
-::
+
+.. code-block:: bash
 
    git remote add tempremote https://github.com/username/ardupilot.git
 
@@ -27,7 +28,7 @@ this sets up ``tempremote`` to point to the originators repository on GitHub.
 
 To pull the PR branch ``xyz`` down to your local computer's repository in order to modify it:
 
-::
+.. code-block:: bash
 
    git fetch tempremote  xyz
 
@@ -35,7 +36,7 @@ which will copy the PR's branch into a local buffer.
 
 Then create a local branch ``username-xyz`` and which is a copy of the PR
 
-::
+.. code-block:: bash
 
    git checkout -b username-xyz tempremote/xyz
 
@@ -46,7 +47,7 @@ You should also "squash" (see :ref:`git-interactive-rebase` ) your commit into t
 
 Finally, you can force push over the originators PR to include your modifications:
 
-::
+.. code-block:: bash
 
   git push -f tempremote HEAD:xyz
 

--- a/dev/source/docs/intel-edison.rst
+++ b/dev/source/docs/intel-edison.rst
@@ -118,16 +118,19 @@ It is important to note this will only work under Linux Ubuntu 14.04
 Download the latest version of xFSTK onto your Ubuntu 14.04 32-bit system from `here <https://communities.intel.com/external-link.jspa?url=http%3A%2F%2Fsourceforge.net%2Fprojects%2Fxfstk%2Ffiles%2F>`__. and extract.
 
     1. Unzip the downloaded file with
+
     ::
 
         tar xvfz xfstk-dldr-linux-source-1.7.2.tar.gz
 
     2. Navigate to the source folder
+
     ::
 
         cd xfstk-build/linux-source-package
 
     3. Install the required packages
+
     ::
 
         sudo apt-get install g++ qtcreator build-essential devscripts libxml2-dev alien doxygen graphviz libusb-dev libboost-all-dev  
@@ -135,22 +138,26 @@ Download the latest version of xFSTK onto your Ubuntu 14.04 32-bit system from `
         sudo apt-get install libusb-1.0-0-dev
 
     4. Create the following Symlink
+
     ::
 
         ln -s /usr/lib/x86_64-linux-gnu/libusb-1.0.a /usr/lib/libusb.a
 
     5. Configure the build parameters
+
     ::
 
         export DISTRIBUTION_NAME=ubuntu14.04  
         export BUILD_VERSION=0.0.0
 
     6. Build the xFSTK tools
+
     ::
 
         make --version -j 6
 
     7. Run cmake
+
     ::
 
         mkdir build
@@ -158,16 +165,19 @@ Download the latest version of xFSTK onto your Ubuntu 14.04 32-bit system from `
         cmake ..
 
     8. Build the package
+
     ::
 
         make package
 
     9. Install the package you just built
+
     ::
 
         dpkg -i [built package]
 
     10. May need to install:
+
     ::
 
         sudo apt-get install libboost-program-options1.55.0

--- a/dev/source/docs/interfacing-with-pixhawk-using-the-nsh.rst
+++ b/dev/source/docs/interfacing-with-pixhawk-using-the-nsh.rst
@@ -4,6 +4,10 @@
 Archived: Interfacing with Pixhawk using the NSH
 ===============================================
 
+.. warning::
+
+   This isn't supported anymore. We are now using Chibios RTOS instead of NuttX
+
 This article explains how to communicate with a Pixhawk using the `NuttX Shell (NSH) <http://nuttx.org/Documentation/NuttShell.html>`__ using
 either a serial or remote connection.
 

--- a/dev/source/docs/interfacing-with-pixhawk-using-the-nsh.rst
+++ b/dev/source/docs/interfacing-with-pixhawk-using-the-nsh.rst
@@ -1,7 +1,7 @@
 .. _interfacing-with-pixhawk-using-the-nsh:
 
 ===============================================
-Archived:Interfacing with Pixhawk using the NSH
+Archived: Interfacing with Pixhawk using the NSH
 ===============================================
 
 This article explains how to communicate with a Pixhawk using the `NuttX Shell (NSH) <http://nuttx.org/Documentation/NuttShell.html>`__ using

--- a/dev/source/docs/ros2.rst
+++ b/dev/source/docs/ros2.rst
@@ -105,6 +105,7 @@ Test *Micro-XRCE-DDS-Gen* installation:
     #     * IDL files.
 
 ::
+
     ⚠️ If you have installed FastDDS or FastDDSGen globally on your system: eProsima's libraries and the packaging system in 
     Ardupilot are not deterministic in this scenario. You may experience the wrong version of a library brought in, or runtime 
     segfaults. For now, avoid having simultaneous local and global installs. If you followed the `global install <https://fast-dds.docs.eprosima.com/en/latest/installation/sources/sources_linux.html#global-installation/>`_ section, 

--- a/dev/source/docs/rover-sitlmavproxy-tutorial.rst
+++ b/dev/source/docs/rover-sitlmavproxy-tutorial.rst
@@ -40,7 +40,7 @@ The tutorial assumes you have already set up :ref:`SITL on Windows <sitl-native-
 :ref:`Linux <setting-up-sitl-on-linux>` and that you have started SITL
 using the ``--map`` and ``--console`` options:
 
-::
+.. code-block:: bash
 
     cd ~/ardupilot/Rover
     sim_vehicle.py --map --console
@@ -55,6 +55,7 @@ Starting
 ========
 
 Change the rover into Guided mode and then arm it by entering the following on the mavproxy console
+
 ::
 
     GUIDED

--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -47,6 +47,7 @@ the default parameters for your vehicle.
    sim_vehicle.py --console --map -w
 
 Alternatively, if not starting in the ArduCopter directory, but at the base **ardupilot** directory:
+
 ::
 
    sim_vehicle.py -v copter --console --map -w

--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -4,6 +4,10 @@
 Using SITL with AirSim
 ======================
 
+.. warning::
+
+  This page is archived and is not being maintained anymore. AirSim integration with ArduPilot is still available and supported, but the instructions on this page might be outdated.
+
 .. youtube:: -WfTr1-OBGQ
    :width: 100%
 

--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -92,13 +92,13 @@ AirSim's page on Linux & MacOS Setup is `here <https://github.com/microsoft/AirS
 
   #. Clone the repository
 
-        ::
+        ..code-block:: bash
 
             git clone https://github.com/Microsoft/AirSim.git
 
   #. Build it
 
-        ::
+        ..code-block:: bash
 
             cd AirSim
             ./setup.sh
@@ -146,7 +146,7 @@ Launch Copter SITL
 
 For using ArduCopter, the settings are as follows:
 
-::
+..code-block:: json
 
     {
       "SettingsVersion": 1.2,
@@ -175,7 +175,7 @@ For using ArduCopter, the settings are as follows:
 
 First launch AirSim, after that launch the ArduPilot SITL using
 
-::
+..code-block:: bash
 
     sim_vehicle.py -v ArduCopter -f airsim-copter --console --map
 
@@ -195,7 +195,7 @@ Launch Rover SITL
 
 ``settings.json`` for using ArduRover:
 
-::
+..code-block:: json
 
     {
       "SettingsVersion": 1.2,
@@ -230,7 +230,7 @@ Launch Rover SITL
 
 First launch AirSim, after that launch the ArduPilot SITL using
 
-::
+..code-block:: bash
 
     sim_vehicle.py -v Rover -f airsim-rover --console --map
 
@@ -247,7 +247,7 @@ See `Lidar Settings <https://github.com/Microsoft/AirSim/blob/master/docs/lidar.
 
 Current `settings.json` file for launching ArduCopter with Lidar
 
-::
+..code-block:: json
 
     {
       "SettingsVersion": 1.2,
@@ -297,7 +297,7 @@ Current `settings.json` file for launching ArduCopter with Lidar
 
 Launch Copter with Lidar using
 
-::
+..code-block:: bash
 
     sim_vehicle.py -v ArduCopter -f airsim-copter --add-param-file=libraries/SITL/examples/Airsim/lidar.parm --console --map
 
@@ -315,7 +315,7 @@ Rangefinders in ArduPilot are called Distance Sensors in AirSim. See `AirSim's S
 
 Some example settings and parameters are shown below, to create a forward and downward-facing rangefinder. Note that only sensor settings are present, which can be easily inserted inplace of the ``Sensors`` element in the Lidar example above.
 
-::
+..code-block:: json
 
     "Sensors": {
         "Imu": {
@@ -383,7 +383,7 @@ For simulating 2 copters, an example script has been added which will create 2 c
 
 ``settings.json`` for 2 copters
 
-::
+..code-block:: json
 
     {
       "SettingsVersion": 1.2,
@@ -423,7 +423,7 @@ You can optionally specify the IP address of the computer with the GCS as the fi
 
 To attach MAVProxy -
 
-::
+..code-block:: bash
 
     mavproxy.py --master=127.0.0.1:14550 --source-system 1 --console --map
 
@@ -450,14 +450,15 @@ Using ROS for multi-vehicle tasks is a common usecase and Mavros is used for wor
 
 First is the `multi_vehicle.sh script <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/Airsim/multi_vehicle.sh>`__ which launches multiple ArduCopter binaries with different SYSIDs and ports for each vehicle. Usage is similar to the above script -
 
-::
+..code-block:: bash
 
     libraries/SITL/examples/Airsim/multi_vehicle.sh <IP>
 
 
 The `multi_uav_ros_sitl.launch file <https://github.com/ArduPilot/ardupilot/tree/master/libraries/SITL/examples/Airsim/multi_uav_ros_sitl.launch>`__ demonstrates how to write a launch file controlling multiple vehicles with Mavros. It creates a different namespace for each drone and each drone has a separate SYSID and ports according to how the script sets the variables.
 Launching the file -
-::
+
+..code-block:: bash
 
     roslaunch libraries/SITL/examples/Airsim/multi_uav_ros_sitl.launch
 
@@ -521,7 +522,7 @@ Run on different machines
 
 An example:
 
-::
+..code-block:: bash
 
     sim_vehicle.py -v ArduCopter -f airsim-copter --console --map -A --sim-address=127.0.0.1
 
@@ -543,7 +544,7 @@ Using different ports
 
 Similar to changing the IP address as mentioned above, use ``-A`` to pass the arguments to the SITL instance. Example:
 
-::
+..code-block:: bash
 
     sim_vehicle.py -v ArduCopter -f airsim-copter --console --map -A "--sim-port-in=9003 --sim-port-out=9002"
 

--- a/dev/source/docs/sitl-with-scrimmage.rst
+++ b/dev/source/docs/sitl-with-scrimmage.rst
@@ -3,6 +3,11 @@
 ===================================
 Using SCRIMMAGE as a SITL simulator
 ===================================
+
+.. warning::
+
+    As for April 2026, this simulation connection hasn't been maintained for a while and may not work with the latest ArduPilot code.
+
 `Simulating Collaborative Robots in Massive Mulit-Agent Game Execution (SCRIMMAGE) <http://www.scrimmagesim.org/>`__
 provides a flexible simulation environment for the experimentation and testing of novel mobile robotics algorithms.
 SCRIMMAGE provides a three-dimensional robotics environment that can simulate varying levels of sensor and motion model

--- a/dev/source/docs/sitl-with-scrimmage.rst
+++ b/dev/source/docs/sitl-with-scrimmage.rst
@@ -20,6 +20,7 @@ Starting an ArduPlane Simulation
 ================================
 
 To start an ArduPlane simulation use the ``-f`` argument in sim_vehicle.py:
+
 ::
 
     cd ArduPlane
@@ -29,6 +30,7 @@ Starting an ArduCopter Simulation
 =================================
 
 To start an ArduCopter simulation use the ``-f`` argument in sim_vehicle.py:
+
 ::
 
     cd ArduCopter
@@ -39,6 +41,7 @@ Additional SCRIMMAGE Parameters
 
 Additional parameters can be passed into SCRIMMAGE using the ``-A`` and ``--config`` arguments. These parameters can be used to
 overwrite the defaults in the SCRIMMAGE mission file such as the motion model, visual model, or terrain.
+
 ::
 
     cd ArduPlane

--- a/dev/source/docs/unit-tests.rst
+++ b/dev/source/docs/unit-tests.rst
@@ -183,6 +183,7 @@ A directory in the ArduPilot source tree can contain a `wscript` file designatin
 Each .cpp file in that directory is then considered a valid test, and will be included in the tests compiled when `waf` is invoked for the `tests` target.
 
 Tests are present in the following directories at time if writing:
+
 ::
 
     libraries/AP_Common/tests

--- a/dev/source/docs/using-mavexplorer-for-log-analysis.rst
+++ b/dev/source/docs/using-mavexplorer-for-log-analysis.rst
@@ -14,7 +14,7 @@ Installing MAVExplorer on Linux
 You will need the latest version of pymavlink and mavproxy installed. On
 Linux do this:
 
-::
+..code-block:: bash
 
     sudo apt-get install python3-matplotlib python3-serial python3-wxgtk3.0 python3-lxml
     sudo apt-get install python3-scipy python3-opencv  python3-pip python3-pexpect python3-tk
@@ -44,6 +44,7 @@ Installing MAVExplorer on MacOS
 ===============================
 
 To install MAVExplorer on MacOS you will need to have "pip" installed. If you don't have pip, then use:
+
 ::
 
   sudo easy_install pip

--- a/scripts/check_rst_literal_blocks.py
+++ b/scripts/check_rst_literal_blocks.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Check ReStructuredText literal block markers for blank lines before and after."""
+
+import argparse
+import pathlib
+import re
+
+MARKER_RE = re.compile(r"^\s*::\s*$")
+
+
+def check_file(path):
+    errors = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    for index, line in enumerate(lines):
+        if MARKER_RE.match(line):
+            prev_blank = index == 0 or lines[index - 1].strip() == ""
+            next_blank = index + 1 >= len(lines) or lines[index + 1].strip() == ""
+            if not prev_blank:
+                errors.append(
+                    f"{path}:{index + 1}: literal block marker must have a blank line before it"
+                )
+            if not next_blank:
+                errors.append(
+                    f"{path}:{index + 1}: literal block marker must have a blank line after it"
+                )
+    return errors
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check ReST :: code-block spacing")
+    parser.add_argument("files", nargs="+", help="RST files to check")
+    args = parser.parse_args()
+
+    all_errors = []
+    for file_name in args.files:
+        path = pathlib.Path(file_name)
+        if path.suffix.lower() != ".rst":
+            continue
+        all_errors.extend(check_file(path))
+
+    if all_errors:
+        print("Invalid ReST literal-block spacing detected:")
+        print("\n".join(all_errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This correct some non blocking warning

we use some block with :: and those need to have empty line before and after. 
Replace with ..code-block:: on some place instead, correct the other place

add some warning on old page about non maintenance, probably need to move on archived next.

add an automated check for the :: issue !

Check output : 
```
╰─$ pre-commit run --all-files                                                                                          130 ↵
codespell................................................................Passed
flake8...................................................................Passed
ruff check...............................................................Passed
Sphinx Lint..............................................................Passed
Check ReST literal block spacing.........................................Failed
- hook id: rst-literal-block-spacing
- exit code: 1

Invalid ReST literal-block spacing detected:
dev/source/docs/sitl-with-scrimmage.rst:23: literal block marker must have a blank line before it
dev/source/docs/sitl-with-scrimmage.rst:32: literal block marker must have a blank line before it
dev/source/docs/sitl-with-scrimmage.rst:42: literal block marker must have a blank line before it
dev/source/docs/sitl-with-airsim.rst:460: literal block marker must have a blank line before it
dev/source/docs/using-mavexplorer-for-log-analysis.rst:47: literal block marker must have a blank line before it
Invalid ReST literal-block spacing detected:
dev/source/docs/rover-sitlmavproxy-tutorial.rst:58: literal block marker must have a blank line before it
Invalid ReST literal-block spacing detected:
dev/source/docs/unit-tests.rst:186: literal block marker must have a blank line before it
Invalid ReST literal-block spacing detected:
dev/source/docs/editing-prs.rst:22: literal block marker must have a blank line before it
common/source/docs/common-beagle-bone-blue.rst:522: literal block marker must have a blank line before it
dev/source/docs/ros2.rst:107: literal block marker must have a blank line after it
Invalid ReST literal-block spacing detected:
dev/source/docs/intel-edison.rst:121: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:126: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:131: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:138: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:143: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:149: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:154: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:161: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:166: literal block marker must have a blank line before it
dev/source/docs/intel-edison.rst:171: literal block marker must have a blank line before it
Invalid ReST literal-block spacing detected:
dev/source/docs/setting-up-sitl-on-linux.rst:50: literal block marker must have a blank line before it

```
