### PR TITLE
update.py: correct common rst copy check

### DIFF
--- a/update.py
+++ b/update.py
@@ -596,15 +596,12 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
                     targetfile = f'{wiki}/source/docs/{file}'
 
                     # Only write if content has changed (preserves timestamps for unchanged files)
-                    # Use byte-accurate file comparison against the source file.
+                    # Use byte-accurate file comparison against the source file stripped of copywiki shortcodes.
                     if not clean_common and os.path.exists(targetfile):
-                        try:
-                            if filecmp.cmp(source_file_path, targetfile, shallow=False):
+                        with open(targetfile, 'r', encoding='utf-8') as f:
+                            if f.read() == content:
                                 files_skipped += 1
                                 continue
-                        except Exception as e:
-                            debug(f"filecmp failed for {source_file_path} vs {targetfile}: {e}")
-                            # treat as different and fall through to write
 
                     # debug(targetfile)
                     with open(targetfile, 'w', encoding='utf-8') as destination_file:

--- a/update.py
+++ b/update.py
@@ -50,6 +50,7 @@ import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from datetime import datetime
+from pathlib import Path
 from typing import Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -586,26 +587,21 @@ def copy_common_source_files(start_dir=COMMON_DIR, clean_common=False):
         for file in files:
             if file.endswith(".rst"):
                 # debug("  FILE: %s" % file)
-                source_file_path = os.path.join(root, file)
-                source_file = open(source_file_path, 'r', encoding='utf-8')
-                source_content = source_file.read()
-                source_file.close()
+                source_file_path = Path(root) / file
+                source_content = source_file_path.read_text(encoding='utf-8')
                 targets = get_copy_targets(source_content)
                 for wiki in targets:
                     content = strip_content(source_content, wiki)
-                    targetfile = f'{wiki}/source/docs/{file}'
+                    targetfile = Path(f"{wiki}/source/docs/{file}")
 
                     # Only write if content has changed (preserves timestamps for unchanged files)
-                    # Use byte-accurate file comparison against the source file stripped of copywiki shortcodes.
-                    if not clean_common and os.path.exists(targetfile):
-                        with open(targetfile, 'r', encoding='utf-8') as f:
-                            if f.read() == content:
-                                files_skipped += 1
-                                continue
+                    # Compare against the file content after stripping copywiki shortcodes.
+                    if not clean_common and targetfile.exists():
+                        if targetfile.read_text(encoding='utf-8') == content:
+                            files_skipped += 1
+                            continue
 
-                    # debug(targetfile)
-                    with open(targetfile, 'w', encoding='utf-8') as destination_file:
-                        destination_file.write(content)
+                    targetfile.write_text(content, encoding='utf-8')
                     files_copied += 1
             elif file.endswith(".css"):
                 for wiki in ALL_WIKIS:


### PR DESCRIPTION
filecmp.cmp is useless for most files that have a copy directives, so we need to do bytes to bytes comparison.
That is still cheap to do and faster than having sphinx to reread everything.

<img width="1146" height="1152" alt="image" src="https://github.com/user-attachments/assets/5be824f9-e4a1-435e-bb9c-545ce333dea0" />
