### PR TITLE
Add comments syntax and run command on start in .mavinit.scr

### DIFF
--- a/mavproxy/source/docs/getting_started/mavinit.rst
+++ b/mavproxy/source/docs/getting_started/mavinit.rst
@@ -34,5 +34,10 @@ will allow the user to graph the current battery level by typing
 
 .. code:: bash
 
+    # this is setting up aliases
     @alias add g graph
-    @alias add gbatt g SYS_STATUS.current_battery`` 
+    @alias add gbatt g SYS_STATUS.current_battery
+
+    # run command on startup 
+    module load graph
+    gbatt


### PR DESCRIPTION
I was setting up a script and I had to look through the source code to find out how comments worked, so I added an example comment to the example command. I also added example commands to load a module and show a graph so it is evident how to run commands on startup.