### PR TITLE
Create CODEOWNERS for auto review-requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# People/teams (with write access) who should be auto-requested for review when particular files are changed.
+# Latest and more specific patterns take priority.
+
+## Global owner
+@Hwurzburg
+
+## Infrastructure (root level files, scripts, CI workflows)
+/*           @peterbarker
+/*.py        @khancyr @peterbarker
+/.github/    @peterbarker @khancyr
+/scripts/    @peterbarker
+/frontend/   @khancyr
+
+## ArduSub docs are maintained partly independently
+/sub/   @ES-Alexander @Williangalvani


### PR DESCRIPTION
This adds the GitHub [Code Owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) feature, so new pull requests automatically have a relevant reviewer requested. This is particularly helpful for external contributors who don't have the permission to request reviews, and may not know who the most appropriate reviewer is for a given PR.

Picked some values that seemed to match how the review cycle goes in this repo, but can of course be changed if I've misunderstood, or people listed don't want to be considered responsible for a given section. Unsure whether @Hwurzburg (or someone else - maybe @khancyr?) should also be included in some of the infrastructure stuff 🤷‍♂️ 