### PR TITLE
Update Stabilize mode tuning parameter descriptions

### DIFF
--- a/copter/source/docs/stabilize-mode.rst
+++ b/copter/source/docs/stabilize-mode.rst
@@ -66,12 +66,11 @@ than manually adjusting PIDs. However, see :ref:`ac_rollpitchtuning` for roll an
 
 Other important parameters
 --------------------------
--  :ref:`ATC_ANGLE_MAX<ATC_ANGLE_MAX>` controls the maximum lean angle which by default is 45
-   (i.e. 45 degrees)
--  :ref:`ACRO_Y_RATE<ACRO_Y_RATE>` controls how quickly copter rotates based on a pilot's
-   yaw input.  The default of 4.5 commands a 200 deg/sec rate of
-   rotation when the yaw stick is held fully left or right.  Higher
-   values will make it rotate more quickly.
+-  :ref:`ATC_ANGLE_MAX<ATC_ANGLE_MAX>` controls the maximum lean angle which by default is 30
+   (i.e. 30 degrees)
+-  :ref:`PILOT_Y_RATE<PILOT_Y_RATE>` controls the maximum yaw rate requested by a pilot's
+   yaw input in Stabilize and other pilot-controlled modes except Acro. Higher
+   values request a faster yaw rate.
 -  :ref:`ATC_INPUT_TC<ATC_INPUT_TC>` can be used to control the responsiveness to changes in pitch and roll angles requested by pilot's inputs.
 
 


### PR DESCRIPTION
1. The `ATC_ANGLE_MAX` entry is updated to use the current default of 30 degrees instead of the outdated 45-degree wording. The current attitude-control default is defined as [`AC_ATTITUDE_CONTROL_ANGLE_MAX_DEFAULT = 30.0f`](https://github.com/ArduPilot/ardupilot/blob/master/libraries/AC_AttitudeControl/AC_AttitudeControl.cpp), and `ANGLE_MAX` is registered from that default in `AC_AttitudeControl`.

2. The yaw-rate entry is updated to refer to `PILOT_Y_RATE` instead of `ACRO_Y_RATE`. In the current parameter metadata, [`PILOT_Y_RATE`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/Parameters.cpp) is described as the pilot-controlled yaw-rate maximum used in pilot-controlled modes except Acro, while [`ACRO_Y_RATE`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/Parameters.cpp) is the Acro yaw-rate parameter.