### PR TITLE
Clarify Sport mode parameter references

### DIFF
--- a/copter/source/docs/sport-mode.rst
+++ b/copter/source/docs/sport-mode.rst
@@ -18,10 +18,11 @@ Overview
 -  The pilot's roll, pitch and yaw sticks control the rate of rotation
    of the vehicle so when the sticks are released the vehicle will
    remain in its current attitude.
--  The vehicle will not lean more than 45 degrees (this angle is
-   adjustable with the :ref:`ACRO_BAL_ROLL <ACRO_BAL_ROLL>` and :ref:`ACRO_BAL_PITCH <ACRO_BAL_PITCH>` parameters)
+-  The vehicle will not lean more than 30 degrees (this angle is
+   adjustable with the :ref:`ATC_ANGLE_MAX<ATC_ANGLE_MAX>` parameter)
 -  The altitude is maintained with the altitude hold controller so the
    vehicle will attempt to hold its current altitude when the sticks
-   are placed with 10% of mid-throttle. It will climb or descend at up
+   are within the mid-throttle deadzone, which is adjustable with
+   :ref:`THR_DZ<THR_DZ>`. It will climb or descend at up
    to 2.5m/s (this speed is adjustable with the :ref:`PILOT_SPD_UP<PILOT_SPD_UP>` and :ref:`PILOT_SPD_DN<PILOT_SPD_DN>`
    parameters). The acceleration used to establish these speeds is set by :ref:`PILOT_ACC_Z<PILOT_ACC_Z>`.


### PR DESCRIPTION
This updates two Sport Mode parameter references.

1. Sport mode uses [`attitude_control->lean_angle_max_rad()`](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_sport.cpp) for the lean angle limit, while `ACRO_BAL_ROLL` and `ACRO_BAL_PITCH` are used for balance/return-to-level behavior. This updates the maximum lean angle reference to `ATC_ANGLE_MAX`, which defaults to 30 degrees.

2. Sport uses the same mid-throttle deadzone concept as AltHold, and that deadzone is configurable via `THR_DZ`. The [AltHold page](https://ardupilot.org/copter/docs/altholdmode.html) already describes this as the “mid-throttle deadzone” and notes that it can be adjusted with `THR_DZ`. This avoids implying that the hold-altitude throttle range is fixed at 10% around mid-throttle.