### PR TITLE
scripts: add new dedupe_params script and use it for rangefinder and …

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -41,6 +41,8 @@ from html.parser import HTMLParser
 import requests
 from requests.adapters import HTTPAdapter
 
+from scripts.dedupe_params import dedupe_old_rangefinder_parameters
+
 parser = argparse.ArgumentParser(description="python3 build_parameters.py [options]")
 parser.add_argument("--verbose", dest='verbose', action='store_false', default=True, help="show debugging output")
 parser.add_argument("--ardupilotRepoFolder", dest='gitFolder', default="../ardupilot", help="Ardupilot git folder. ")
@@ -84,8 +86,10 @@ class ColoredFormatter(logging.Formatter):
 
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(ColoredFormatter('[build_parameters.py]: [%(levelname)s]: %(message)s'))
-logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO, handlers=[handler])
+logging_level = logging.DEBUG if args.verbose else logging.INFO
+logging.basicConfig(level=logging_level, handlers=[handler])
 logger = logging.getLogger(__name__)
+logging.getLogger('scripts.dedupe_params').setLevel(logging_level)
 
 # Global session for HTTP requests with connection pooling
 session = requests.Session()
@@ -174,49 +178,6 @@ def rst_has_duplicate_labels(filepath: str) -> bool:
         logger.warning(f"Found {len(duplicates)} duplicate RST labels in {filepath}: {duplicates[:5]}")
         return True
     return False
-
-
-def dedupe_rngfnd_parameters_sections(filepath: str) -> None:
-    """Keep only the first RNGFNDx_* Parameters section and drop subsequent duplicate sections."""
-    label_re = re.compile(r'^\.\. _parameters_RNGFND([0-9A-Za-z]+)_.*:$', re.IGNORECASE)
-    section_label_re = re.compile(r'^\.\. _RNGFND([0-9A-Za-z]+).*:$', re.IGNORECASE)
-
-    try:
-        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
-            lines = f.readlines()
-    except (UnicodeDecodeError, OSError) as e:
-        debug(f"Failed to dedupe RNGFND parameters in {filepath}: {e}")
-        return
-
-    seen_labels = set()
-    saved_lines = []  # Lines to write back to the file after deduplication
-    i = 0
-    while i < len(lines):
-        current_line = lines[i]
-        current_line_stripped = current_line.strip()
-
-        rangefinder_label = label_re.match(current_line_stripped)
-        if rangefinder_label:
-            rngfnd_id = rangefinder_label.group(1)
-            if rngfnd_id in seen_labels:
-                # Don't save the duplicated line on new file, skip to next section
-                i += 1
-                while i < len(lines) and not section_label_re.match(lines[i].strip()):
-                    i += 1
-                continue
-
-            seen_labels.add(rngfnd_id)
-
-        saved_lines.append(current_line)
-        i += 1
-
-    if len(saved_lines) != len(lines):
-        try:
-            with open(filepath, 'w', encoding='utf-8') as f:
-                f.writelines(saved_lines)
-            debug(f"Dedupe applied to RNGFND sections in {filepath}")
-        except (UnicodeDecodeError, OSError) as e:
-            debug(f"Failed to dedupe RNGFND parameters in {filepath}: {e}")
 
 
 def patch_cgi_escape_for_old_versions(version, param_metadata_dir):
@@ -685,7 +646,7 @@ def generate_rst_files(commits_to_checkout_and_parse):
                 os.remove(parameters_rst_path)
                 debug(f"File {filename} generated.")
                 # Remove duplicate RNGFNDx_ Parameters sections before checking labels.
-                dedupe_rngfnd_parameters_sections(output_file_path)
+                dedupe_old_rangefinder_parameters(output_file_path)
                 # Check for duplicate RST labels in the generated file
                 if rst_has_duplicate_labels(output_file_path):
                     debug(f"RST duplicate labels detected in {output_file_path}")

--- a/scripts/dedupe_params.py
+++ b/scripts/dedupe_params.py
@@ -1,0 +1,105 @@
+"""Shared RST parameter-section deduplication helper.
+
+Used by build_parameters.py (RNGFND sections) and update.py (NET_ sections).
+Both scripts run from the repo root, so ``from scripts.dedupe_params import``
+works as a namespace-package import without an __init__.py.
+"""
+
+import logging
+import os
+import re
+
+_logger = logging.getLogger(__name__)
+
+
+def dedupe_rst_parameter_sections(
+    filepath: str,
+    section_anchor_re: re.Pattern,
+    next_item_re: re.Pattern,
+    key_group: int = 0,
+) -> None:
+    """Remove duplicate RST parameter-section header blocks from *filepath* in-place.
+
+    A section header block begins with a label matching ``section_anchor_re``.
+    When the same key (extracted via ``key_group`` of the match) appears more
+    than once, the repeated header block is dropped.  Scanning for the end of a
+    header block stops at the first line that matches ``next_item_re`` or
+    another ``section_anchor_re``.
+
+    Args:
+        filepath:          Path to the RST file to process in-place.
+        section_anchor_re: Compiled regex matching a section header anchor line.
+        next_item_re:      Compiled regex marking the first content line of the
+                           section (used to stop consuming/skipping the block).
+        key_group:         Group index of ``section_anchor_re`` used as the dedup
+                           key.  0 = the full match string; use a capturing group
+                           index to differentiate numbered families (e.g. RNGFND1
+                           vs RNGFND2).
+    """
+    _logger.debug("Dedupe check: %s", filepath)
+    if not os.path.exists(filepath):
+        _logger.warning("File not found for deduplication: %s", filepath)
+        return
+    try:
+        with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+            lines = f.readlines()
+    except (OSError, UnicodeDecodeError) as e:
+        _logger.error("Failed to read %s for deduplication: %s", filepath, e)
+        return
+
+    seen_keys: set = set()
+    output: list = []
+    i = 0
+    while i < len(lines):
+        m = section_anchor_re.match(lines[i].strip())
+        if m:
+            key = m.group(key_group)
+            is_duplicate = key in seen_keys
+            seen_keys.add(key)
+
+            if not is_duplicate:
+                output.append(lines[i])
+            i += 1
+
+            # Consume the section header block (blank lines + title + underline)
+            # until we reach the first content item or another section anchor.
+            while i < len(lines) \
+                    and not next_item_re.match(lines[i]) \
+                    and not section_anchor_re.match(lines[i].strip()):
+                if not is_duplicate:
+                    output.append(lines[i])
+                i += 1
+            continue
+
+        output.append(lines[i])
+        i += 1
+
+    if len(output) != len(lines):
+        try:
+            with open(filepath, 'w', encoding='utf-8') as f:
+                f.writelines(output)
+            _logger.debug(
+                "Dedupe applied to %s: removed %d line(s)",
+                filepath, len(lines) - len(output),
+            )
+        except (OSError, UnicodeDecodeError) as e:
+            _logger.error("Failed to write deduped file %s: %s", filepath, e)
+
+
+def dedupe_old_rangefinder_parameters(filepath: str) -> None:
+    """Remove duplicate RNGFNDx_ parameter sections from *filepath* in-place."""
+    dedupe_rst_parameter_sections(
+        filepath,
+        section_anchor_re=re.compile(r'^\.\.\s_parameters_RNGFND([0-9A-Za-z]+)_.*:$', re.IGNORECASE),
+        next_item_re=re.compile(r'^\.\.\s_RNGFND[0-9A-Za-z]+.*:$', re.IGNORECASE),
+        key_group=1,
+    )
+
+
+def dedupe_periph_net_parameters(filepath: str) -> None:
+    """Remove duplicate NET_ parameter sections from *filepath* in-place."""
+    dedupe_rst_parameter_sections(
+        filepath,
+        section_anchor_re=re.compile(r'^\.\. _parameters_NET_:\s*$', re.IGNORECASE),
+        next_item_re=re.compile(r'^\.\. _NET_[A-Za-z0-9_+:]+:'),
+    )

--- a/update.py
+++ b/update.py
@@ -59,6 +59,7 @@ from sphinx.application import Sphinx
 
 import rst_table
 from frontend.scripts import get_discourse_posts
+from scripts.dedupe_params import dedupe_periph_net_parameters
 
 if sys.version_info < (3, 8):
     print("Minimum python version is 3.8")
@@ -1165,6 +1166,7 @@ class WikiUpdater:
 
         logging_level = logging.DEBUG if self.verbose else logging.INFO
         logger.setLevel(logging_level)
+        logging.getLogger('scripts.dedupe_params').setLevel(logging_level)
         stream_handler.setLevel(logging_level)
 
     def run(self) -> None:
@@ -1191,6 +1193,7 @@ class WikiUpdater:
                 cleanup_versioned_parameters(self.args.site)
                 fetchparameters(self.args.site, self.args.cached_parameter_files)
 
+            dedupe_periph_net_parameters('./dev/source/docs/AP_Periph-Parameters.rst')
             # Fetch most recent LogMessage metadata from autotest:
             fetchlogmessages(self.args.site, self.args.cached_parameter_files)
 


### PR DESCRIPTION
…periph net parameters

Result for versionned parameters against master :
<img width="1184" height="248" alt="Capture d’écran du 2026-04-29 17-28-23" src="https://github.com/user-attachments/assets/d8491363-a91d-4152-82b4-621fae830e82" />
(show dedup is still working as expected)

For periph parameters : 
<img width="1061" height="130" alt="Capture d’écran du 2026-04-29 17-30-57" src="https://github.com/user-attachments/assets/ce60ac36-2e20-4ad4-9370-e4d57827e6f5" />

<img width="932" height="217" alt="image" src="https://github.com/user-attachments/assets/8c11c6e7-af43-4e70-8a07-1e9b14e7cbf8" />
