### PR TITLE
Cleanup dead code

### DIFF
--- a/common/source/docs/common-beagle-bone-blue.rst
+++ b/common/source/docs/common-beagle-bone-blue.rst
@@ -449,7 +449,7 @@ Paste the following script
         server.bind(("", PORT_ANY))
         server.listen(1)
         port = server.getsockname()[1]
-        advertise_service(server, "BBBlue-MAVLink", service_id = service_uuid, service_classes = [servi$
+        advertise_service(server, "BBBlue-MAVLink", service_id = service_uuid, service_classes = [SERIAL_PORT_CLASS], profiles = [SERIAL_PORT_PROFILE])
         client, client_info = server.accept()
         receive_thread = threading.Thread(target=receive, args=(client, master))
         send_thread = threading.Thread(target=send, args=(client, master))

--- a/update.py
+++ b/update.py
@@ -138,8 +138,6 @@ WIKI_NAME_TO_VEHICLE_NAME = {
     'blimp': 'Blimp',
 }
 
-# GIT_REPO = ''
-
 PARAMETER_SITE = {
     'rover': 'APMrover2',
     'copter': 'ArduCopter',
@@ -160,7 +158,6 @@ LOGMESSAGE_SITE = {
 
 N_BACKUPS_RETAIN = 10
 
-VERBOSE = False
 # Global HTTP session for connection reuse and caching
 _http_session = None
 
@@ -245,8 +242,6 @@ def fetch_url(fetchurl: str, fpath: Optional[str] = None, verbose: bool = True) 
     info(f"Fetching {fetchurl}")
     # For larger files or when cache fails, use streaming download with progress
     session = get_http_session()
-
-    total_size = 0
 
     total_size = 0
 


### PR DESCRIPTION
remove some dead variables from update.py
fix bluetooth serial example on bbblue that trigger a sphinx build warning (code from https://pybluez.readthedocs.io/en/latest/api/advertise_service.html, it was probably using service_uuid before, but SERIAL_PORT_CLASS is simpler)

tested locally. CI validate the change on update.py and bblue fix