### PR TITLE
Checkers rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,11 @@ repos:
         entry: python scripts/check_youtube_timestamps.py
         language: python
         types: [rst]
+
+  - repo: local
+    hooks:
+      - id: check-ref-directives
+        name: Check ref directive formatting
+        entry: python scripts/check_ref_directives.py
+        language: python
+        types: [rst]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,8 @@ repos:
       - id: rst-literal-block-spacing
         name: Check ReST literal block spacing
         entry: python scripts/check_rst_literal_blocks.py
-        language: system
-        files: '\.rst$'
+        language: python
+        types: [rst]
 
   - repo: local
     hooks:

--- a/scripts/check_ref_directives.py
+++ b/scripts/check_ref_directives.py
@@ -4,8 +4,9 @@
 Two rules are enforced:
   1. No alphanumeric/underscore/colon character directly before ``:ref:``
      (missing space before the role).
-  2. No space between a closing :ref: backtick and a punctuation character
-     ``.``, ``,`` or ``:``  (trailing space before punctuation).
+  2. No whitespace between ``:ref:`` and its opening backtick.
+  3. No space between a closing ``:ref:`` backtick and a punctuation character
+     ``.``, ``,`` or ``:``.  (trailing space before punctuation).
 
 """
 
@@ -15,7 +16,8 @@ import re
 import sys
 
 CHARACTER_BEFORE_RE = re.compile(r"[a-zA-Z0-9_:]:ref:")
-CHARACTER_AFTER_RE = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
+CHARACTER_AFTER_RE = re.compile(r":ref:[^`]")
+SPACE_BEFORE_PUNCT_RE = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
 
 
 def check_file(path: pathlib.Path) -> list[str]:
@@ -31,7 +33,11 @@ def check_file(path: pathlib.Path) -> list[str]:
             )
         if CHARACTER_AFTER_RE.search(line):
             errors.append(
-                f'{path}:{i}: remove space between :ref: and following punctuation'
+                f'{path}:{i}: remove whitespace between :ref: and its opening backtick'
+            )
+        if SPACE_BEFORE_PUNCT_RE.search(line):
+            errors.append(
+                f'{path}:{i}: remove space between :ref: closing backtick and punctuation'
             )
     return errors
 

--- a/scripts/check_ref_directives.py
+++ b/scripts/check_ref_directives.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Check formatting around :ref: directives that Sphinx does not warn about.
+
+Two rules are enforced:
+  1. No alphanumeric/underscore/colon character directly before ``:ref:``
+     (missing space before the role).
+  2. No space between a closing :ref: backtick and a punctuation character
+     ``.``, ``,`` or ``:``  (trailing space before punctuation).
+
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+
+CHARACTER_BEFORE_RE = re.compile(r"[a-zA-Z0-9_:]:ref:")
+CHARACTER_AFTER_RE = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
+
+
+def check_file(path: pathlib.Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        return [f"{path}: UnicodeDecodeError: {exc}"]
+    for i, line in enumerate(lines, start=1):
+        if CHARACTER_BEFORE_RE.search(line):
+            errors.append(
+                f'{path}:{i}: remove character directly before :ref: directive'
+            )
+        if CHARACTER_AFTER_RE.search(line):
+            errors.append(
+                f'{path}:{i}: remove space between :ref: and following punctuation'
+            )
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check :ref: directive formatting in RST files"
+    )
+    parser.add_argument("files", nargs="+", help="RST files to check")
+    args = parser.parse_args()
+
+    all_errors: list[str] = []
+    for file_name in args.files:
+        path = pathlib.Path(file_name)
+        if path.suffix.lower() != ".rst":
+            continue
+        all_errors.extend(check_file(path))
+
+    if all_errors:
+        print("Invalid :ref: directive formatting detected:")
+        print("\n".join(all_errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_checkers.py
+++ b/scripts/tests/test_checkers.py
@@ -9,6 +9,8 @@ from unittest.mock import patch
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
+import check_ref_directives  # noqa: E402
+import check_rst_literal_blocks  # noqa: E402
 import check_youtube_timestamps  # noqa: E402
 
 
@@ -117,6 +119,136 @@ class TestCheckYoutubeTimestamps(unittest.TestCase):
         errors = check_youtube_timestamps.check_file(path)
         self.assertEqual(len(errors), 1)
         self.assertIn("UnicodeDecodeError", errors[0])
+
+
+class TestCheckRefDirectives(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_valid_ref(self):
+        path = _rst(self.tmp, "valid.rst", "See :ref:`some-label` for details.\n")
+        self.assertEqual(check_ref_directives.check_file(path), [])
+
+    def test_char_before_ref(self):
+        path = _rst(self.tmp, "before.rst", "Seex:ref:`some-label` for details.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove character directly before", errors[0])
+
+    def test_special_char_before_ref_not_caught(self):
+        path = _rst(self.tmp, "ampersand.rst", "See (:ref:`some-label`) for details.\n")
+        self.assertEqual(check_ref_directives.check_file(path), [])
+
+    def test_space_before_ref_is_valid(self):
+        path = _rst(self.tmp, "space_before.rst", "See :ref:`some-label` for details.\n")
+        self.assertEqual(check_ref_directives.check_file(path), [])
+
+    def test_space_after_ref(self):
+        path = _rst(self.tmp, "after.rst", "See :ref: `some-label` for details.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove whitespace", errors[0])
+
+    def test_char_after_ref(self):
+        path = _rst(self.tmp, "char_after.rst", "See :ref:x`some-label` for details.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove whitespace", errors[0])
+
+    def test_space_before_period(self):
+        path = _rst(self.tmp, "punct_period.rst", "See :ref:`some-label` .\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove space between", errors[0])
+
+    def test_space_before_comma(self):
+        path = _rst(self.tmp, "punct_comma.rst", "See :ref:`some-label` , and more.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove space between", errors[0])
+
+    def test_space_before_colon(self):
+        path = _rst(self.tmp, "punct_colon.rst", "See :ref:`some-label` : details.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("remove space between", errors[0])
+
+    def test_no_space_before_period_valid(self):
+        path = _rst(self.tmp, "valid_punct.rst", "See :ref:`some-label`.\n")
+        self.assertEqual(check_ref_directives.check_file(path), [])
+
+    def test_unicode_error(self):
+        path = self.tmp / "bad.rst"
+        path.write_bytes(b"See :ref:`label` \xff.\n")
+        errors = check_ref_directives.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("UnicodeDecodeError", errors[0])
+
+    def test_main_valid(self):
+        path = _rst(self.tmp, "valid.rst", "See :ref:`some-label` for details.\n")
+        with patch("sys.argv", ["check_ref_directives", str(path)]):
+            self.assertEqual(check_ref_directives.main(), 0)
+
+    def test_main_invalid(self):
+        path = _rst(self.tmp, "invalid.rst", "Seex:ref:`some-label` for details.\n")
+        with patch("sys.argv", ["check_ref_directives", str(path)]):
+            self.assertEqual(check_ref_directives.main(), 1)
+
+    def test_non_rst_skipped(self):
+        path = self.tmp / "errors.txt"
+        path.write_text("See&:ref:`some-label` for details.\n", encoding="utf-8")
+        with patch("sys.argv", ["check_ref_directives", str(path)]):
+            self.assertEqual(check_ref_directives.main(), 0)
+
+
+class TestCheckRstLiteralBlocks(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_valid_literal_block(self):
+        path = _rst(self.tmp, "valid.rst", "Some text.\n\n::\n\n    code here\n")
+        self.assertEqual(check_rst_literal_blocks.check_file(path), [])
+
+    def test_missing_blank_before(self):
+        path = _rst(self.tmp, "before.rst", "Some text.\n::\n\n    code here\n")
+        errors = check_rst_literal_blocks.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("blank line before", errors[0])
+
+    def test_missing_blank_after(self):
+        path = _rst(self.tmp, "after.rst", "Some text.\n\n::\n    code here\n")
+        errors = check_rst_literal_blocks.check_file(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("blank line after", errors[0])
+
+    def test_missing_blank_both(self):
+        path = _rst(self.tmp, "both.rst", "Some text.\n::\n    code here\n")
+        errors = check_rst_literal_blocks.check_file(path)
+        self.assertEqual(len(errors), 2)
+
+    def test_main_valid(self):
+        path = _rst(self.tmp, "valid.rst", "Some text.\n\n::\n\n    code here\n")
+        with patch("sys.argv", ["check_rst_literal_blocks", str(path)]):
+            self.assertEqual(check_rst_literal_blocks.main(), 0)
+
+    def test_main_invalid(self):
+        path = _rst(self.tmp, "invalid.rst", "Some text.\n::\n\n    code here\n")
+        with patch("sys.argv", ["check_rst_literal_blocks", str(path)]):
+            self.assertEqual(check_rst_literal_blocks.main(), 1)
+
+    def test_non_rst_skipped(self):
+        path = self.tmp / "errors.txt"
+        path.write_text("Some text.\n::\n    code here\n", encoding="utf-8")
+        with patch("sys.argv", ["check_rst_literal_blocks", str(path)]):
+            self.assertEqual(check_rst_literal_blocks.main(), 0)
 
 
 if __name__ == "__main__":

--- a/update.py
+++ b/update.py
@@ -954,30 +954,6 @@ def check_imports():
     debug("Imports OK")
 
 
-def check_ref_directives():
-    '''check formatting around ref directive that sphinx does not warn about'''
-    character_before_ref_tag = re.compile(r"[a-zA-Z0-9_:]:ref:")
-    character_after_ref_tag = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
-
-    # don't check "common="" files in vehicle wikis
-    skipped_files = set()
-    for wiki in ALL_WIKIS:
-        skipped_files.update(glob.glob(f'{wiki}/source/docs/common-*.rst'))
-    wiki_glob = set(glob.glob("**/*.rst", recursive=True))
-    files_to_check = wiki_glob.difference(skipped_files)
-    for f in files_to_check:
-        with open(f, "r", encoding='utf-8') as file:
-            try:
-                for i, line in enumerate(file.readlines()):
-                    if character_before_ref_tag.search(line):
-                        error(f'Remove character before ref directive in "{f}" on line number {i+1}')
-                    if character_after_ref_tag.search(line):
-                        error(f'Remove character after ref directive in "{f}" on line number {i+1}')
-            except UnicodeDecodeError as ex:
-                print(f"UnicodeError in {f}: ", ex)
-                sys.exit(1)
-
-
 def create_features_pages(site):
     '''for each vehicle, write out a page containing features for each
     supported board'''
@@ -1217,7 +1193,6 @@ class WikiUpdater:
         building_time = now.strftime("%Y-%m-%d-%H-%M-%S")
 
         check_imports()
-        check_ref_directives()
 
         info("=== Step 1: Creating features pages ===")
         info(f"Time elapsed so far: {time.time() - tstart:.2f} seconds")

--- a/update.py
+++ b/update.py
@@ -59,6 +59,7 @@ from sphinx.application import Sphinx
 
 import rst_table
 from frontend.scripts import get_discourse_posts
+from scripts.check_ref_directives import check_file as check_ref_directives_file
 from scripts.dedupe_params import dedupe_periph_net_parameters
 
 if sys.version_info < (3, 8):
@@ -1052,27 +1053,17 @@ def check_imports():
 
 
 def check_ref_directives():
-    '''check formatting around ref directive that sphinx does not warn about'''
-    character_before_ref_tag = re.compile(r"[a-zA-Z0-9_:]:ref:")
-    character_after_ref_tag = re.compile(r"(:ref:`.*?`[_]{0,2}) ([\.,:])")
-
+    '''check formatting around ref directive that sphinx does not warn about.
+    Same check as the check-ref-directives pre-commit hook, run here as a
+    warning so local builds still report it.'''
     # don't check "common="" files in vehicle wikis
     skipped_files = set()
     for wiki in ALL_WIKIS:
         skipped_files.update(glob.glob(f'{wiki}/source/docs/common-*.rst'))
     wiki_glob = set(glob.glob("**/*.rst", recursive=True))
-    files_to_check = wiki_glob.difference(skipped_files)
-    for f in files_to_check:
-        with open(f, "r", encoding='utf-8') as file:
-            try:
-                for i, line in enumerate(file.readlines()):
-                    if character_before_ref_tag.search(line):
-                        error(f'Remove character before ref directive in "{f}" on line number {i+1}')
-                    if character_after_ref_tag.search(line):
-                        error(f'Remove character after ref directive in "{f}" on line number {i+1}')
-            except UnicodeDecodeError as ex:
-                print(f"UnicodeError in {f}: ", ex)
-                sys.exit(1)
+    for f in sorted(wiki_glob.difference(skipped_files)):
+        for err in check_ref_directives_file(Path(f)):
+            error(err)
 
 
 def create_features_pages(site):


### PR DESCRIPTION
move check-ref-directives from update.py to pre-commit (gain 6s on build)
add another check on :ref: directives.
Add unittitest for both rst checks
make both rst check use pre-commit venv to run and not system one's.

tested locally with pre-commit run --all-files (all passed) and CI validate this also