### PR TITLE
update.py: print feature missing in build_option as warning

### DIFF
--- a/update.py
+++ b/update.py
@@ -172,6 +172,11 @@ def debug(str_to_print: str) -> None:
     logger.debug(str_to_print)
 
 
+def warning(str_to_print: str) -> None:
+    """Warning output."""
+    logger.warning(str_to_print)
+
+
 def error(str_to_print) -> None:
     """Show and count the errors."""
     logger.error(f"{str_to_print}")
@@ -1018,7 +1023,9 @@ def create_features_page(features, build_options_by_define, vehicletype):
                 build_options = build_options_by_define[feature]
             except KeyError:
                 # mismatch between build_options.py and features.json
-                error(f"feature {feature} ({platform_key},{vehicletype}) not in build_options.py")
+                # Doesn't report as error as we could have delay between updating
+                # build_options.py (from ardupilot repo master branch) and features.json (from firmwares server build result)
+                warning(f"feature {feature} ({platform_key},{vehicletype}) not in build_options.py")
                 continue
             if feature_in:
                 some_list = sorted_platform_features_in


### PR DESCRIPTION
https://github.com/ArduPilot/ardupilot_wiki/commit/a7f43a14a779189127df7cc98e10f688e246f27a changed some to logging lib. So past progress() usage have been upgrade to error() that is count and reported at the end of the build

the feature matching on build_option.py could fails on update since features list is build on firmware building and upload on firmware server whereas build_option.py is get from ardupilot repository main branch directly. So there could some delay until the feature are updated leading to such report : 
```
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (Here4FC,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED (Here4FC,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (HWH7,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED (HWH7,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (IFLIGHT_2RAW_H7,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED (IFLIGHT_2RAW_H7,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (JFB100,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED (JFB100,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (JFB110,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AP_MAVLINK_RALLY_POINT_PROTOCOL_ENABLED (JFB110,Blimp) not in build_options.py
[update.py]: [ERROR]: feature AC_POLYFENCE_FENCE_POINT_PROTOCOL_SUPPORT (JHEM_JHEF405,Blimp) not in build_options.py
```
Therefore only marking this as warning is enough, it shouldn't block the wiki build nor be an issue. Still worth reporting in case something slip on ardupilot repo.