### PR TITLE
Copter: fix loiter mode video link

### DIFF
--- a/copter/source/docs/loiter-mode.rst
+++ b/copter/source/docs/loiter-mode.rst
@@ -8,7 +8,9 @@ Loiter Mode automatically attempts to maintain the current location, heading and
 
 A good GPS lock, :ref:`low magnetic interference on the compass <common-diagnosing-problems-using-logs_compass_interference>` and :ref:`low vibrations <common-diagnosing-problems-using-logs_vibrations>` are all important in achieving good loiter performance.
 
-..  youtube:: yVAnBQkNJdY&t=261s
+For a visual demonstration, please `see 4:21 in the below video <https://youtu.be/yVAnBQkNJdY?t=261>`__
+
+..  youtube:: yVAnBQkNJdY
     :width: 100%
 
 Controls


### PR DESCRIPTION
This fixes the link to the Copter Loiter mode video and closes issue https://github.com/ArduPilot/ardupilot_wiki/issues/7731

I've built this locally and it looks OK to me.