### PR TITLE
rover: clean up boat-configuration, mention sea GPS

### DIFF
--- a/rover/source/docs/boat-configuration.rst
+++ b/rover/source/docs/boat-configuration.rst
@@ -12,10 +12,25 @@ Boats can also be controlled with the standard Rover firmware.  To specify that 
 The special features for Boats include:
 
 - Boats appear as boats on the ground station
-- In :ref:`Auto <auto-mode>`, :ref:`Guided <guided-mode>`, :ref:`RTL <rtl-mode>` and :ref:`SmartRTL <smartrtl-mode>` modes the vehicle will attempt to maintain its position even after it reaches its destination
-- :ref:`Thrusters <thrusters>`
-- :ref:`Echosounders <common-underwater-sonars-landingpage>` for underwater mapping
+
+- :ref:`Sailboat support <sailboat-home>`
+
 - :ref:`Loiter mode <loiter-mode>` for holding position
-- :ref:`ReefMaster for bathymetry <reefmaster-for-bathymetry>`
-- :ref:`Torqeedo electric motors <common-torqeedo>`
+
+    - In :ref:`Auto <auto-mode>`, :ref:`Guided <guided-mode>`, :ref:`RTL <rtl-mode>` and :ref:`SmartRTL <smartrtl-mode>` modes the vehicle will attempt to maintain its position even after it reaches its destination
+
+- :ref:`Sea-level GPS filtering <GPS_NAVFILTER>`
+
+    - Not intended for use in water bodies at elevation (e.g. lakes/rivers on mountains)
+
 - :ref:`Vectored Thrust <rover-vectored-thrust>` can be enabled to improve steering response on boats which use the steering servo to aim the motors
+
+- Underwater-rated motors
+
+    - :ref:`Blue Robotics thrusters <thrusters>`
+    - :ref:`Torqeedo electric motors <common-torqeedo>`
+
+- Underwater map generation
+
+    - :ref:`Echosounders <common-underwater-sonars-landingpage>` for underwater mapping
+    - :ref:`ReefMaster for bathymetry <reefmaster-for-bathymetry>`


### PR DESCRIPTION
- Grouped together related features
- Moved autopilot functionalities to the top
- Mentioned sea-level-focused GPS-filtering functionality
- Mentioned sailboats

<img width="725" height="586" alt="Screenshot 2026-05-09 at 2 15 30 am" src="https://github.com/user-attachments/assets/6d4c74b1-77aa-4fd1-b57d-abe39ea2d561" />