### PR TITLE
Sub: document existing MOT_FV_CPLNG_K behaviour

### DIFF
--- a/sub/source/docs/sub-frames.rst
+++ b/sub/source/docs/sub-frames.rst
@@ -22,6 +22,8 @@ Key to axis: R = Roll, P = Pitch, Y = Yaw, Z= Depth, F = Forward, L = Lateral
 
 .. note:: Configurations lacking one or more controllable axes rely on proper CG and ballast to maintain earth-frame stability in that axis.
 
+.. note:: The Vectored frame has a :ref:`MOT_FV_CPLNG_K <MOT_FV_CPLNG_K>` parameter that can be adjusted to limit hydrodynamic coupling between the vertical and (direction-dependent) "rear" horizontal thrusters, at the expense of reduced forward/backward thrust capacity while moving quickly up or down.
+
 Frames
 ======
 


### PR DESCRIPTION
The [specificity of this feature](https://github.com/ArduPilot/ardupilot/pull/33076) upsets me a bit, but docs should reflect the way things are, so here we find ourselves 🤷‍♂️ 

<img width="734" height="182" alt="Screenshot 2026-05-16 at 6 51 18 am" src="https://github.com/user-attachments/assets/084021e5-3755-4c4a-9f4c-6d0d5024e760" />
