### PR TITLE
Add Matek mLRS RC receiver link to documentation

### DIFF
--- a/common/source/docs/common-uavcan-peripherals.rst
+++ b/common/source/docs/common-uavcan-peripherals.rst
@@ -149,6 +149,7 @@ RC Receivers/Adapters
     :maxdepth: 1
 
     AnyLeaf ELRS RC + telemetry <https://www.anyleaf.org/elrs-rx-can>
+    Matek mLRS RC + MAVLink CAN receiver, mR900-30C <https://www.mateksys.com/?portfolio=mr900-30c>
     Matek CAN-L4-RC adapter <http://www.mateksys.com/?portfolio=can-l4-rc>
 
 Gimbals


### PR DESCRIPTION
title says it. add the Matek mLRS RC + MAVLink CAN receiver, mR900-30C, to the DroneCAN receiver list.