### PR TITLE
Copter: document FOLLOW_TARGET for Follow mode

### DIFF
--- a/copter/source/docs/follow-mode.rst
+++ b/copter/source/docs/follow-mode.rst
@@ -9,6 +9,8 @@ Follow Mode
 
 When switched into Follow, the vehicle will attempt to follow another vehicle (or anything publishing its position) at a specified offset.  The vehicle lead vehicle's position must be published to the vehicle in Follow mode using a telemetry system.
 
+Although Follow mode can use standard ``global-position-int`` MAVLink messages from the lead vehicle, it generally works better if the lead vehicle publishes a ``FOLLOW_TARGET`` MAVLink message. This can be done by running the `follow-target-send.lua <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_Scripting/applets/follow-target-send.lua>`__ Lua script on the lead vehicle.
+
 The altitude is maintained with the altitude hold controller so the vehicle will attempt to hold its current altitude when the sticks are placed with 10% of mid-throttle. It will climb or descend at up to 2.5m/s (this speed is adjustable with the :ref:`PILOT_SPD_UP<PILOT_SPD_UP>` and :ref:`PILOT_SPD_DN<PILOT_SPD_DN>` parameters). The acceleration used to establish these speeds is set by :ref:`PILOT_ACC_Z<PILOT_ACC_Z>`.
 
 The following parameters can be used to tune Follow Mode's performance:


### PR DESCRIPTION
This updates the Copter Follow Mode wiki page to mention that, although Follow mode can use standard position messages from the lead vehicle, it generally works better when the lead vehicle publishes FOLLOW_TARGET using the follow-target-send.lua script.

Closes #7698