### PR TITLE
4.8:/33005/Improve Flip Mode information

### DIFF
--- a/copter/source/docs/flip-mode.rst
+++ b/copter/source/docs/flip-mode.rst
@@ -4,18 +4,35 @@
 Flip Mode
 =========
 
-Vehicle will flip on its roll or pitch axis depending upon the pilot's roll and pitch stick position in flight mode's which allow this (ACRO/ALTHOLD/STABILIZE...and,of course, FLIP mode). Vehicle will increase throttle rapidly as it starts to flip. Once the flip is completed, canceled, or times out, the original flight mode the vehicle was in will be restored. The flip will end at the entry attitude.
+Vehicle will perform a full-rotation flip.
+The pilot can control the direction of flip using gentle deflection of the roll or pitch stick.
+What to expect:
 
-The vehicle will not flip again until the switch is brought low and back to high, if on an :ref:`Auxiliary Switch <common-auxiliary-functions>`, or if the mode channel switch is changed to another mode and back to FLIP.
+- Flip will happen fast (~1 sec).
+- Vehicle will increase throttle rapidly as it starts to flip.
+- Vehicle does a full-rotation flip (passing through upside-down).
+- Vehicle attempts to end the flip at the starting altitude.
+- After the flip ends (successful or canceled), the vehicle's previous flight mode will be restored.
+
+The vehicle will not flip again until the controls are reset (see below).
 
 .. warning:: Give yourself at least 10m of altitude before trying flip for the first time!
 
+
 Flip Mode Controls
 ==================
-The mode may be entered either by an :ref:`Auxiliary Switch <common-auxiliary-functions>`, or by changing flight mode to FLIP.
+Flip Mode can only be entered from modes which permit it (Acro, AltHold, FlowHold, Stabilize).
 
-- The direction of the flip defaults to ROLL LEFT, but if the RC Pitch stick is moved slightly back or forward, it will flip on the pitch axis, back or forward, respectively. If the RC Pitch stick is neutral but the RC ROLL is pushed slightly right, it will flip rolling to the right.
-- During the flip the throttle is managed to attempt to neither gain or lose altitude. It is only an attempt!
-- You may abort the flip by moving the pitch or roll stick as if to command near full stick in that axis. The Flip will immediately halt **at whatever attitude it is currently at** and return to the previous flight mode at the pilot's throttle stick input.
-- As the flip is completing, it will briefly increase throttle to try to recover any lost altitude. Again, this is an approximation. Once completed (entry attitude re-attained), the previous flight mode is returned to (if not entered by an AUX switch). It will not flip again until the Aux Switch is lowered and raised again, if used, or FLIP flight mode re-entered. If entered via a flight mode switch, you will need to change mode out of FLIP, to another mode, and then back again if another flip is desired,
+The mode may be entered either by an RC :ref:`Auxiliary Switch <common-auxiliary-functions>` or by changing flight mode to FLIP.
+A spring-loaded entry switch (RC Aux or mode-switch) is recommended, so that pilot must hold it while flipping.
 
+- The direction of the flip defaults to ROLL LEFT.
+- If the RC Pitch stick is moved slightly back or forward, it will flip on the pitch axis, back or forward, respectively.
+- If the RC Pitch stick is neutral but the RC Roll stick is pushed slightly right, it will flip rolling to the right.
+- In addition to mode-changing out of FLIP, you may abort the flip by:
+
+  - Moving the pitch or roll stick to an extreme value in any direction.
+  - Switching the RC Aux switch to LOW.
+
+- If aborted these ways, the flip will immediately halt **at whatever attitude it is currently at** and return to the previous flight mode.
+- To do another flip, because every flip automatically mode-switches away at its end, pilot must 'exit the first flip' (via RC Aux or mode-switch) before initiating the next.


### PR DESCRIPTION
This accompanies the PRs resolving issue https://github.com/ArduPilot/ardupilot/issues/32491 .
It satisfies the WikiNeeded label from PR https://github.com/ArduPilot/ardupilot/pull/33005 .

This was tested by rendering the new content locally, it looks as expected:
<img width="936" height="948" alt="image" src="https://github.com/user-attachments/assets/d59fbe59-a1ee-4aa1-ae49-fa0946919150" />
