### PR TITLE
Update to state dual IMU in brotherhobbyh743

### DIFF
--- a/common/source/docs/common-brotherhobbyh743.rst
+++ b/common/source/docs/common-brotherhobbyh743.rst
@@ -10,7 +10,7 @@ The BROTHERHOBBYH743 is a flight controller produced by `BROTHERHOBBY <https://w
 Features
 ========
 * STM32H743 microcontroller
-* ICM42688P IMU
+* Dual ICM42688P IMU
 * SPL06 barometer
 * AT7456E OSD
 * 12V 3A BEC; 5V 3A BEC


### PR DESCRIPTION
NOTE: The README in the hwdef is also doesn't mention the dual IMU. Should I fix it?

RESEARCH
I looked on the manufacturers website -https://www.brotherhobbystore.com/products/returner-3-8s-h743-betaflight-flight-controller

The hwdef files https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/BROTHERHOBBYH743/hwdef.dat line 193 # two IMUs
IMU Invensensev3 SPI:imu1 ROTATION_PITCH_180_YAW_270 IMU Invensensev3 SPI:imu2 ROTATION_ROLL_180
IMU BMI088 SPI:bmi088_a SPI:bmi088_g ROTATION_PITCH_180 IMU BMI088 SPI:bmi088_a2 SPI:bmi088_g2 ROTATION_PITCH_180 define HAL_DEFAULT_INS_FAST_SAMPLE 3