### PR TITLE
Clarify Copter Land auto-disarm and landing detection conditions

### DIFF
--- a/copter/source/docs/land-mode.rst
+++ b/copter/source/docs/land-mode.rst
@@ -20,8 +20,7 @@ features:
    .. image:: ../images/Land_DescentSpeed2.png
        :target: ../_images/Land_DescentSpeed2.png
 
--  Upon reaching the ground the copter will automatically shut-down the
-   motors and disarm the copter if the pilot's throttle is at minimum.
+-  After landing is detected, the copter will automatically shut down the motors and disarm.
 
 .. note::
 
@@ -29,7 +28,7 @@ features:
    approximately one second:
 
    - Motors are commanded to their lower limit by the vertical position controller
-   - Throttle is at minimum 
+   - The attitude controller's throttle mix is at minimum 
    - No large angle is being requested (roll/pitch target < 15°)
    - No large angle error exists (attitude error < 30°)
    - The airframe is not accelerating downward > 1m/s/s ( >2 m/s/s if Weight on Wheels feature is enabled)


### PR DESCRIPTION
### Solved Problem

The Land Mode documentation describes the pilot's throttle being at minimum as a condition for automatic disarming and landing detection.

However, Land mode disarms after the landing detector reports `land_complete` and the motors reach `GROUND_IDLE`:

* [ModeLand::gps_run()](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_land.cpp#L880-L883)
* [ModeLand::nogps_run()](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/mode_land.cpp#L952-L956)

The landing detector does not use pilot input throttle. Instead, it separately checks the motor lower limit and the attitude controller's throttle mix:

* [Input throttle limitation](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/land_detector.cpp#L954-L965)
* [Throttle-related landing checks](https://github.com/ArduPilot/ardupilot/blob/master/ArduCopter/land_detector.cpp#L1043-L1047)

### Solution

Clarify that the copter automatically shuts down and disarms after landing is detected, and replace the ambiguous “Throttle is at minimum” condition with “The attitude controller's throttle mix is at minimum.”

### Test coverage

Documentation-only change, verified against the current Copter Land mode and landing detector implementations.
