### PR TITLE
Fix scaling for Q_P_D_ACC_I and Q_P_D_ACC_P . Also add note for old parameters (before Plane 4.7)

### DIFF
--- a/plane/source/docs/quadplane-vtol-tuning-process.rst
+++ b/plane/source/docs/quadplane-vtol-tuning-process.rst
@@ -212,10 +212,15 @@ This test will allow to test the altitude controller and ensure the stability of
 
 3. Set these parameters on ground and preferably disarm  (A confident pilot could set them in flight with GCS):
 
-  - :ref:`Q_P_D_ACC_I<Q_P_D_ACC_I>` to 2 x :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
-  - :ref:`Q_P_D_ACC_P<Q_P_D_ACC_P>` to :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
+  - :ref:`Q_P_D_ACC_I<Q_P_D_ACC_I>` to 0.2 x :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
+  - :ref:`Q_P_D_ACC_P<Q_P_D_ACC_P>` to 0.1 x :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
 
- If the QuadPlane in QHOVER starts to move up and down, the vertical position and velocity controllers may need to be reduced by 50%. These values are: ``Q_P_POSZ_P`` and :ref:`Q_P_D_VEL_P<Q_P_D_VEL_P>`.
+.. note:: In Plane 4.6 and earlier these parameters were named ``Q_P_ACCZ_I`` and ``Q_P_ACCZ_P`` and were scaled 10x larger:
+
+  - ``Q_P_ACCZ_I`` to 2 x :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
+  - ``Q_P_ACCZ_P`` to :ref:`Q_M_THST_HOVER <Q_M_THST_HOVER>`
+
+ If the QuadPlane in QHOVER starts to move up and down, the vertical position and velocity controllers may need to be reduced by 50%. These values are: :ref:`Q_P_D_POS_P<Q_P_D_POS_P>` and :ref:`Q_P_D_VEL_P<Q_P_D_VEL_P>`.
 
 .. note:: If the :ref:`Q_M_THST_HOVER<Q_M_THST_HOVER>` learned should be ~0.3-0.6. Higher values indicate that insufficient thrust is available, either due to motor system design, obstructed prop air flow by the fuselage or wings, or excessive yaw bias (see next section)
 


### PR DESCRIPTION
I had a "near crash" with 4.7beta6. I think the documentation needs to be updated.

I'm quite certain that instead of
 
Q_P_D_ACC_I to 2 x Q_M_THST_HOVER
Q_P_D_ACC_P to Q_M_THST_HOVER

it needs to be changed to
 
Q_P_D_ACC_I to 0.2 x Q_M_THST_HOVER
Q_P_D_ACC_P to 0.1 xQ_M_THST_HOVER

to correct for scaling in Plane 4.7 when 
 Q_P_ACCZ_P / Q_P_ACCZ_I / Q_P_ACCZ_D are renamed (and rescaled) to Q_P_D_ACC_P/Q_P_D_ACC_I/Q_P_D_ACC_D

I apply the change and flight test it. It works as expected.