### PR TITLE
Dev: Remove Ubuntu version specification in SITL

### DIFF
--- a/dev/source/docs/setting-up-sitl-on-linux.rst
+++ b/dev/source/docs/setting-up-sitl-on-linux.rst
@@ -5,7 +5,7 @@ Setting up SITL on Linux
 ========================
 
 This page describes how to setup the :ref:`SITL (Software In The Loop) <sitl-simulator-software-in-the-loop>` on Linux. The specific
-commands were tested on Ubuntu from 12.10 to 18.04.
+commands were tested on Ubuntu Linux.
 
 Overview
 ========


### PR DESCRIPTION
Remove the Ubuntu version specifier, as the current one refers to a (very!) old Ubuntu version range.