### PR TITLE
Move Advanced user tools to archived

### DIFF
--- a/common/source/docs/common-appendix.rst
+++ b/common/source/docs/common-appendix.rst
@@ -13,7 +13,6 @@ the wiki.
 
     Abbreviations <common-abbreviations>
     Acknowledgments <common-acknowledgments>
-    Advanced user tools (downloads) <common-downloads_advanced_user_tools>
     Commercial Support <common-commercial-support>
     Contact Us <common-contact-us>
     Developer tools (downloads) <common-downloads_developer_tools>

--- a/common/source/docs/common-archived-topics.rst
+++ b/common/source/docs/common-archived-topics.rst
@@ -134,5 +134,6 @@ value to users with old hardware.
     Visual Odometry with OpenKai and ZED <common-zed>
 [/site]
 
+    Advanced user tools (downloads) <common-downloads_advanced_user_tools>
 
 [copywiki destination="copter,plane,rover,dev,sub"]

--- a/common/source/docs/common-downloads_advanced_user_tools.rst
+++ b/common/source/docs/common-downloads_advanced_user_tools.rst
@@ -1,8 +1,8 @@
 .. _common-downloads_advanced_user_tools:
 
-==============================
-DOWNLOADS: Advanced User Tools
-==============================
+========================================
+Archived: DOWNLOADS: Advanced User Tools
+========================================
 
 The advanced users tools `can be downloaded from here <https://download.ardupilot.org/downloads/wiki/advanced_user_tools/>`__.
 
@@ -426,4 +426,4 @@ Since we want you to have a great experience, please make sure that you do all o
   The software and hardware we provide is only for use in unmanned vehicles.
 
 
-[copywiki destination="copter,plane,rover,sub,blimp,planner,planner2,antennatracker,dev,mavproxy,ardupilot"]
+[copywiki destination="copter,plane,rover,dev,sub"]


### PR DESCRIPTION
Those tools are old and deprecated, we shouldn't link them in normal wiki but in archived