### PR TITLE
4.8:32771/document VTOL landing descent throttle mix change

### DIFF
--- a/plane/source/docs/quadplane-auto-mode.rst
+++ b/plane/source/docs/quadplane-auto-mode.rst
@@ -79,6 +79,8 @@ Versions 4.1 and later
 
 By default a NAV_VTOL_LAND will remain in fixed mode at the current altitude, until close to the landing point, execute an "airbraking" maneuver to reduce speed, then transition to VTOL, navigate precisely to the landing point, and descend as in QLAND to a landing. This allows setting the NAV_VTOL_LAND point any distant away from the last waypoint without having to worry about excessive time in VTOL mode.
 
+.. note:: In Plane 4.8 and later, attitude control is no longer prioritised over vertical speed control during the descent phase of a VTOL landing (as it was in 4.7 and earlier). A rapid descent on a quadplane often leads to poor attitude control, and applying more power to attitude does not fix it; slowing the descent does. Good descent rate control depends on an accurate hover throttle estimate, so make sure :ref:`Q_M_THST_HOVER<Q_M_THST_HOVER>` is correct and see the recommendation in :ref:`quadplane-vtol-tuning-process` to disable hover throttle learning after initial setup.
+
 If :ref:`Q_OPTIONS<Q_OPTIONS>` bit 16 is set to disable the fixed wing approach phase, then it will immediately transition to VTOL when the command is executed and navigate to the landing point in VTOL mode. This requires the careful setup of the last waypoint before this command to avoid a long path to the landing point while in VTOL mode.
 
 If :ref:`Q_OPTIONS<Q_OPTIONS>` bit 4 is set, then even if bit 16 is set, the vehicle will execute the fixed wing approach and loiter to altitude, described above in the previous section, before changing to VTOL mode. If bit 16 is also set, then when the vehicle switches to VTOL mode, it will attempt to do the airbrake maneuver and QLAND for that final segment.

--- a/plane/source/docs/quadplane-vtol-tuning-process.rst
+++ b/plane/source/docs/quadplane-vtol-tuning-process.rst
@@ -224,6 +224,8 @@ This test will allow to test the altitude controller and ensure the stability of
 
 .. note:: If the :ref:`Q_M_THST_HOVER<Q_M_THST_HOVER>` learned should be ~0.3-0.6. Higher values indicate that insufficient thrust is available, either due to motor system design, obstructed prop air flow by the fuselage or wings, or excessive yaw bias (see next section)
 
+.. note:: Once a good hover throttle value has been learned it is recommended to set :ref:`Q_M_HOVER_LEARN<Q_M_HOVER_LEARN>` = 0 to disable further learning. Typical quadplane flight profiles rarely include a steady hover, so learning may not trigger for many flights, and when it does, lift from the wings can produce a very poor hover throttle estimate. An accurate :ref:`Q_M_THST_HOVER<Q_M_THST_HOVER>` is important for good descent rate control during VTOL landings.
+
 Step 8: Yaw Bias
 ----------------
 


### PR DESCRIPTION
Documents the behaviour change from ArduPilot/ardupilot#32771 (Plane 4.8 and later): attitude control is no longer prioritised over vertical speed control during the descent phase of a VTOL landing. A rapid descent on a quadplane often leads to poor attitude control, and the correct recovery is to slow the descent rather than put more power into attitude (see ArduPilot/ardupilot#32759 for the analysis).

Changes:
- `quadplane-auto-mode.rst`: note in the NAV_VTOL_LAND section describing the new 4.8 descent behaviour and pointing at the hover throttle recommendation.
- `quadplane-vtol-tuning-process.rst`: recommendation to set Q_M_HOVER_LEARN = 0 once a good hover throttle value has been learned, since typical quadplane flight profiles rarely include a steady hover and wing lift can corrupt the learned value, and an accurate Q_M_THST_HOVER is important for VTOL landing descent control.
