### PR TITLE
build_parameters.py: simplify nosearch marking for versionned files

### DIFF
--- a/build_parameters.py
+++ b/build_parameters.py
@@ -636,7 +636,7 @@ def generate_rst_files(commits_to_checkout_and_parse):
         file_out = open(dest_file, "w")
         found_original_title = False
         if "latest" not in version_tag:
-            file_out.write(':orphan:\n\n')
+            file_out.write(':orphan:\n:nosearch:\n\n')
 
         for line in file_in:
             if (re.match("(^.. _)(.*):$", line)) and ("latest" not in version_tag):

--- a/scripts/extensions/sphinx_skip_versioned_params.py
+++ b/scripts/extensions/sphinx_skip_versioned_params.py
@@ -52,16 +52,6 @@ def skip_versioned_labels(app: Sphinx, env: BuildEnvironment, docname: str) -> N
             logger.debug(f"Skipped {len(labels_to_remove)} labels for versioned file: {docname}")
 
 
-def skip_versioned_from_search(app: Sphinx, pagename: str, templatename: str,
-                               context: dict, doctree) -> None:
-    """
-    Exclude versioned parameter pages from search index to reduce index size.
-    """
-    if is_versioned_param_file(pagename):
-        # Mark page to be excluded from search
-        context['nosearch'] = True
-
-
 def env_get_outdated_handler(app: Sphinx, env: BuildEnvironment,
                              added: set, changed: set, removed: set) -> list:
     """
@@ -69,7 +59,7 @@ def env_get_outdated_handler(app: Sphinx, env: BuildEnvironment,
     Logs statistics about versioned parameter files being processed.
 
     Note: This event only allows ADDING documents to rebuild, not removing them.
-    The actual optimization happens via label skipping and search exclusion.
+    The actual optimization happens via label skipping in skip_versioned_labels().
 
     Returns an empty list (no additional documents to rebuild).
     """
@@ -86,21 +76,7 @@ def env_get_outdated_handler(app: Sphinx, env: BuildEnvironment,
 def setup(app: Sphinx) -> dict:
     """Setup the Sphinx extension."""
 
-    # Hook after document is read to remove labels
-    app.connect('doctree-read', lambda app, doctree: None)  # Placeholder
     app.connect('env-get-outdated', env_get_outdated_handler)
-
-    # Hook to skip search indexing for versioned files
-    app.connect('html-page-context', skip_versioned_from_search)
-
-    # Use source-read to track which files are versioned params
-    def mark_versioned_file(app, docname, source):
-        if is_versioned_param_file(docname):
-            if not hasattr(app.env, '_versioned_param_files'):
-                app.env._versioned_param_files = set()
-            app.env._versioned_param_files.add(docname)
-
-    app.connect('source-read', mark_versioned_file)
 
     # After reading, clean up labels
     app.connect('doctree-resolved', lambda app, doctree, docname:


### PR DESCRIPTION
<img width="1218" height="894" alt="image" src="https://github.com/user-attachments/assets/395d6739-5a50-4cb0-8a6d-41de90655bbb" />

Sphinx is doing weird stuff as including all versionned parameters into search, this PR remove the versionned parameter from the search, we should use only the latest parameter file.