### PR TITLE
Common/Dev: rename README Battery Monitor heading to Battery Monitoring

### DIFF
--- a/dev/source/docs/readme_file.rst
+++ b/dev/source/docs/readme_file.rst
@@ -22,7 +22,7 @@ Every autopilot board port should include a Readme.md file explaining the board'
 - WIFI module (if applicable)
 - :ref:`GPIOs <readme-intro>`
 - :ref:`RSSI/Airspeed/Analog Pins <readme-rssi>`
-- :ref:`Battery Monitor <readme-batt>`
+- :ref:`Battery Monitoring <readme-batt>`
 - :ref:`Compass <readme-compass>`
 - :ref:`Firmware <readme-firmware>`
 - :ref:`Loading Firmware <readme-loading>`
@@ -143,8 +143,8 @@ If an analog RSSI, general purpose analog inputs, or Airspeed pin is defined, gi
 
 .. _readme-batt:
 
-Battery Monitor
-===============
+Battery Monitoring
+==================
 If a battery monitor is defined in the hwdef, its default parameter and voltage range info should be provided. If DroneCAN or SMBus type, info about its setup.
 
 Example:

--- a/misc/readme_template.md
+++ b/misc/readme_template.md
@@ -161,7 +161,7 @@ If the ARSPD pin is used for analog airspeed  input. Set ARSPD_PIN to 92. Set AR
 |MAIN(8)       | 108        |
 
 
-## Battery Monitor
+## Battery Monitoring
 
 The board has a internal voltage sensor and connections on the ESC connector for an external current sensor input.
 The voltage sensor can handle up to 6S LiPo batteries.


### PR DESCRIPTION
## Summary
- The README template (`misc/readme_template.md`) and HWDEF Readme.md Guide (`dev/source/docs/readme_file.rst`) use the heading "Battery Monitor", but nearly all existing board README pages in the wiki use "Battery Monitoring".
- Renames the heading in both reference files to "Battery Monitoring" to match existing convention, so new-board PR reviews stay consistent with what's already in the wiki.

## Test plan
- [x] `sphinx-build` on `dev/source/docs/readme_file.rst` produces no warnings (RST underline length verified)
- [x] Diffed against current `master` to confirm only the intended heading changes