### PR TITLE
common: future-wiki-changes: add SaamPixV1_1, CyberX-v10, AMOV Flycore, ORBITH743v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code local tooling (commands, settings) - never part of the upstream wiki
+/.claude/
+
 # Common files except under Common
 /*/source/docs/common-*
 !/common/source/docs/common-*

--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -15,6 +15,10 @@ New Board Support
 - PilotGaeaSH7V1-bdshot, see https://github.com/ArduPilot/ardupilot_wiki/pull/7687
 - PrinciploT H7 Pi , see https://github.com/ArduPilot/ardupilot_wiki/pull/7694
 - SkyDroid-S3, see https://github.com/ArduPilot/ardupilot_wiki/pull/7791
+- SaamPixV1_1, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
+- CyberX-v10, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
+- AMOV Flycore, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
+- ORBITH743v2, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
Lists the four new boards added in #7872 on the Future Wiki Changes page:

- SaamPixV1_1
- CyberX-v10
- AMOV Flycore
- ORBITH743v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)