### PR TITLE
common: future-wiki-changes: list GPILOT P1 and SIYI UniFC 6 PICO

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -19,6 +19,8 @@ New Board Support
 - CyberX-v10, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
 - AMOV Flycore, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
 - ORBITH743v2, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
+- GPILOT P1, see https://github.com/ArduPilot/ardupilot_wiki/pull/7877
+- SIYI UniFC 6 PICO, see https://github.com/ArduPilot/ardupilot_wiki/pull/7877
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
## Summary
- Add GPILOT P1 and SIYI UniFC 6 PICO to the New Board Support list in common-future-wiki-changes.rst, referencing wiki PR #7877.