### PR TITLE
4.8:33169/Yaw-during-landing

### DIFF
--- a/copter/source/docs/auto-mode.rst
+++ b/copter/source/docs/auto-mode.rst
@@ -66,6 +66,13 @@ hard mounted camera on it) as the copter flies the mission.  The
 autopilot will attempt to retake yaw control as the vehicle passes the
 next waypoint.  The :ref:`AUTO_OPTIONS <AUTO_OPTIONS>` param can be set to always ignore pilot yaw input.
 
+While the mission is executing a RTL, LAND, or guided command, pilot yaw
+availability is instead controlled by that flight mode's own setting
+rather than :ref:`AUTO_OPTIONS<AUTO_OPTIONS>`: :ref:`RTL_OPTIONS<RTL_OPTIONS>`
+and :ref:`LAND_REPOSITION<LAND_REPOSITION>` for RTL and LAND commands (see
+:ref:`rtl-mode` and :ref:`land-mode`), and :ref:`GUID_OPTIONS<GUID_OPTIONS>`
+for a guided command (see :ref:`ac2_guidedmode`).
+
 Ending a Mission
 ================
 

--- a/copter/source/docs/land-mode.rst
+++ b/copter/source/docs/land-mode.rst
@@ -8,7 +8,7 @@ LAND Mode attempts to bring the copter straight down and has these
 features:
 
 -  descends at :ref:`LAND_SPD_HIGH_MS<LAND_SPD_HIGH_MS>`, if non-zero, (or :ref:`WP_SPD_DN <WP_SPD_DN>` if zero) using the regular Altitude Hold controller.
--  the pilot can reposition the vehicle using the pitch and roll sticks unless the :ref:`LAND_REPOSITION <LAND_REPOSITION>` parameter is changed to "0". The throttle stick has no effect by default, although high throttle can cancel landing if enabled via :ref:`PILOT_THR_BHV<PILOT_THR_BHV>`.
+-  the pilot can reposition the vehicle using the pitch, roll, and yaw sticks unless the :ref:`LAND_REPOSITION <LAND_REPOSITION>` parameter is changed to "0", in which case position and yaw input are both ignored. The throttle stick has no effect by default, although high throttle can cancel landing if enabled via :ref:`PILOT_THR_BHV<PILOT_THR_BHV>`.
 -  if a rangefinder is being used, or :ref:`TERRAIN_ENABLE<TERRAIN_ENABLE>` =1 and terrain data is available, the descent speed will then switch to :ref:`LAND_SPD_MS<LAND_SPD_MS>` at :ref:`LAND_ALT_LOW_M<LAND_ALT_LOW_M>` altitude (default is 10m) above ground until landing occurs. If neither terrain data or rangefinder data is available, then altitude above HOME will be used for the speed switch point (if reached).
 
    .. image:: ../images/Land_DescentSpeed1.png
@@ -59,6 +59,10 @@ features:
 -  If the vehicle does not have GPS lock the horizontal control will be
    as in stabilize mode, so the pilot can control the roll and pitch lean
    angle of the copter, unless the :ref:`LAND_REPOSITION<LAND_REPOSITION>` parameter is set to 0.
+-  :ref:`LAND_REPOSITION<LAND_REPOSITION>` also controls whether the pilot's yaw
+   stick is accepted while landing. This applies not only in LAND mode but
+   also during the final descent stage of :ref:`RTL <rtl-mode>` and during
+   LAND commands executed within a mission in :ref:`Auto mode <auto-mode>`.
 
 
 .. warning::

--- a/copter/source/docs/rtl-mode.rst
+++ b/copter/source/docs/rtl-mode.rst
@@ -76,6 +76,15 @@ Options (User Adjustable Parameters)
    -  2 = Face Next Waypoint except for RTL (i.e. during RTL vehicle
       will remain pointed at its last heading)
 
+-  :ref:`RTL_OPTIONS <RTL_OPTIONS>`:
+   A bitmask of options that modify RTL mode behaviour.
+
+   -  Bit 2 (value "4"), "Ignore Pilot Yaw", stops the pilot's yaw stick
+      from overriding the autopilot's yaw control while RTL is flying back
+      to the return point. During the final descent/landing stage of RTL,
+      pilot yaw control instead follows the :ref:`LAND_REPOSITION<LAND_REPOSITION>`
+      setting (see :ref:`land-mode`) regardless of this option.
+
 -  :ref:`LAND_SPD_MS<LAND_SPD_MS>`:
    The descent speed for the final stage of landing in centimeters per
    second.


### PR DESCRIPTION
## Summary

Documents the behaviour change from ArduPilot/ardupilot#33169, which fixed pilot yaw input being ignored/consumed inconsistently during landing:

- `LAND_REPOSITION` now also gates the pilot's yaw stick, not just position, while landing (LAND mode, RTL's final descent, and mission LAND commands).
- `RTL_OPTIONS`' "Ignore Pilot Yaw" bit is now documented, including that it's overridden by `LAND_REPOSITION` during RTL's final descent/land stage.
- `AUTO_OPTIONS`' yaw-ignore bit is now documented as being overridden by the sub-mode's own setting (`RTL_OPTIONS`/`LAND_REPOSITION` or `GUID_OPTIONS`) while a mission runs an RTL, LAND, or guided command.

