### PR TITLE
4.8:19844/RC_override_option

### DIFF
--- a/common/source/docs/common-auxiliary-functions.rst
+++ b/common/source/docs/common-auxiliary-functions.rst
@@ -458,7 +458,10 @@ Other functions are:
     Winch Control                        | Controls the speed and direction of the winch. Low: takeup,
                                          | Middle: stop, High: unreel.
     RC Override Enable                   | This is a 3-position switch that enables (high) or disables (low)
-                                         | the use of RC overrides from the Ground Control Station.
+                                         | the use of RC overrides from the Ground Control Station. Instead
+                                         | of using this switch to disable overrides, :ref:`RC_OPTIONS<RC_OPTIONS>`
+                                         | bit 14 can be set to automatically clear overrides whenever the
+                                         | pilot moves the RC sticks, see :ref:`common_rc_options`.
     Learn Cruise                         | This starts the cruise speed and the throttle learning sequence
                                          | on Rover when switched to high. See :ref:`rover-tuning-throttle-and-speed`.
     Clear Waypoints                       Clears currently loaded mission waypoints.

--- a/common/source/docs/common-rc-options.rst
+++ b/common/source/docs/common-rc-options.rst
@@ -25,6 +25,7 @@ RC Options
 11                                      Use Link Quality instead of RSSI for RX signal strength
 12                                      Annotate flight mode with * on disarm
 13                                      Use 420kbaud for ELRS protocol
+14                                      Clear GCS RC overrides on any RC stick input
 =================================       =========
 
 for example, to set this option to ignore receiver failsafe bits, you would set bit 2, or a value of "4" (2^2=4). This may be useful when using ground station control beyond the range of the RC system which can set its receiver's outputs to trim values upon RC signal loss, but still has a failsafe bit in the protocol which would otherwise force an RC failsafe to occur.


### PR DESCRIPTION
## Summary
- Documents new `RC_OPTIONS` bit 14 (`CLEAR_OVERRIDES_BY_RC`) added in ArduPilot/ardupilot#19844, which lets the pilot clear an active GCS RC override by moving the RC sticks
- Notes on the "RC Override Enable" aux function (46) page that this new option is an automatic alternative to toggling the aux switch

Related: ArduPilot/ardupilot#19844