### PR TITLE
common: future-wiki-changes: list RC override clear option and yaw-during-landing

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -33,12 +33,14 @@ New Peripheral Support
 New Features
 ============
 
+- Option to clear GCS RC overrides on RC stick input, see https://github.com/ArduPilot/ardupilot_wiki/pull/7880
 
 [site wiki="plane"]
 - Rangefinder engagement distance, see https://github.com/ArduPilot/ardupilot_wiki/pull/7559
 [/site]
 [site wiki="copter"]
 - Ability to abort flip using aux switch low, see https://github.com/ArduPilot/ardupilot_wiki/pull/7759
+- Pilot yaw input now also gates during landing (LAND_REPOSITION), see https://github.com/ArduPilot/ardupilot_wiki/pull/7879
 [/site]
 [site wiki="rover"]
 


### PR DESCRIPTION
## Summary
- Adds RC override auto-clear option (all wikis), see https://github.com/ArduPilot/ardupilot_wiki/pull/7880
- Adds pilot yaw gating during landing (Copter only), see https://github.com/ArduPilot/ardupilot_wiki/pull/7879