### PR TITLE
Common: XFRobot C-20T setup instruction fixes

### DIFF
--- a/common/source/docs/common-caddx-gimbal.rst
+++ b/common/source/docs/common-caddx-gimbal.rst
@@ -2,14 +2,16 @@
 
 [copywiki destination="plane,copter,rover,sub"]
 
-=============
-CADDX Gimbals
-=============
+=============================
+CADDX / XFRobot C-20T Gimbals
+=============================
 
-`CADDX <https://caddxfpv.com/products/caddxfpv-gm1-gm2-gm3.html>`__ GM1, GM2, GM3 gimbals are small 1, 2 and 3-axis gimbals weighing between 16g and 46g and can be paired with 19mm x 19mm FPV cameras. The gimbal mounted camera is always stabilized against short term movements in all axes.
+`CADDX <https://caddxfpv.com/products/caddxfpv-gm1-gm2-gm3.html>`__ GM1, GM2, GM3 and `XFRobot C-20T <https://www.aliexpress.com/store/1104563332>`__ gimbals are small 1, 2 and 3-axis gimbals weighing between 16g and 46g and can be paired with 19mm x 19mm FPV cameras. The gimbal mounted camera is always stabilized against short term movements in all axes.
 
 .. image:: ../../../images/caddxfpv-gimbal.png
     :target: https://caddxfpv.com/products/caddxfpv-gm1-gm2-gm3.html
+
+These instructions provide various links to the CADDX website but the same resources can also be found on the XFRobot site.  Please refer to the :ref:`XFRobot C-20T <common-xfrobot-gimbal>` wiki page for the XFRobot links.
 
 .. warning::
 

--- a/common/source/docs/common-cameras-and-gimbals.rst
+++ b/common/source/docs/common-cameras-and-gimbals.rst
@@ -24,7 +24,7 @@ gimbals in which ArduPilot controls the stabilisation. Some gimbals also integra
 -  :ref:`ADTi cameras and gimbals <common-adti-cameras-and-gimbals>`
 -  :ref:`AVT CM41/CM62 Gimbal/Cameras <common-avt-gimbal>`
 -  :ref:`Brushless PWM <common-brushless-pwm-gimbal>` - brushless gimbals that accept PWM or SBUS input for angle control
--  :ref:`CADDX GM1, GM2, GM3 gimbals <common-caddx-gimbal>`
+-  :ref:`CADDX GM1, GM2, GM3 / XFRobot C-20T gimbals <common-caddx-gimbal>`
 -  :ref:`DJI RS2 and RS3-Pro gimbals <common-djirs2-gimbal>`
 -  :ref:`Gremsy Mio, Pixy, S1, T3, T7 and ZIO <common-gremsy-pixyu-gimbal>` - high quality 3-axis gimbals
 -  :ref:`Servo Gimbals <common-camera-gimbal>` — older-style servo-driven gimbal where ArduPilot provides stabilisation

--- a/common/source/docs/common-xfrobot-gimbal.rst
+++ b/common/source/docs/common-xfrobot-gimbal.rst
@@ -9,6 +9,10 @@ XFRobot Gimbals
 .. image:: ../../../images/xfrobot-gimbal.png
     :target: https://www.allxianfei.com/en/uav-payloads/
 
+.. note::
+
+    The XFRobot C-20T is the same as the :ref:`CADDX GM3 <common-caddx-gimbal>` and may be setup using those instructions
+
 .. warning::
 
     Support for these gimbals is available in ArduPilot 4.7 (and higher)
@@ -44,12 +48,12 @@ If using the XFRobot C-20T, connect the gimbal's serial port to one of the autop
     :target: ../_images/xfrobot-autopilot-serial-c20t.png
     :width: 450px
 
-Connect with a ground station and set the following parameters.  The params below assume the autopilot's telem2 port is used
+Connect with a ground station, set the following parameters and reboot the autopilot.  The params below assume the autopilot's telem2 port is used
 
 - :ref:`SERIAL2_PROTOCOL <SERIAL2_PROTOCOL>` to 8 ("Gimbal")
 - :ref:`SERIAL2_BAUD <SERIAL2_BAUD>` to "115", "250", "500" or "1000" (the gimbal auto detects the baudrate)
 - :ref:`CAM1_TYPE <CAM1_TYPE>` to "4" ("Mount")
-- :ref:`MNT1_TYPE <MNT1_TYPE>` to "14" ("XFRobot") and reboot the autopilot
+- :ref:`MNT1_TYPE <MNT1_TYPE>` to "14" ("XFRobot") for most gimbals, "13" ("CADDX") for the C-20T
 - :ref:`MNT1_ROLL_MIN <MNT1_ROLL_MIN>` to -50
 - :ref:`MNT1_ROLL_MAX <MNT1_ROLL_MAX>` to 50
 - :ref:`MNT1_PITCH_MIN <MNT1_PITCH_MIN>` to -90 (down)


### PR DESCRIPTION
This improves the CADDX and XFRobot wiki pages to make it clear that the XFRobot C-20T should be setup using the CADDX camera gimbal driver.

I've done two things:

1. Fixed the XFRobot page so that it specifies that the MNTx_TYPE parameter is the CADDX value for the C-20T
2. changed the title of the CADDX page to make it clear that it also covers the XFRobot C-20T.
3. added notes to both pages referring to the other

This might be overkill as the 1st page listed above is probably sufficient to help users get the XFRobot C-20T setup correctly but I also think it may be helpful for users to realise they are the same product.  While this leads to some duplication and potential confusion from users as to which set of instructions they should follow, I think in practice either set of instructions will work and perhaps its unavoidable because both the CADDX and XFRobot each have their own stores, setup instructions, user manuals, firmwares and configuration apps.

This is in response to [this 4.7 discussion](https://discuss.ardupilot.org/t/xfrobot-gimbal-support/132467/12) where a user was misled by the existing instuctions.

I've built this locally and it looks OK to me.