### PR TITLE
rover: loiter mode: describe LOIT_TYPE

### DIFF
--- a/rover/source/docs/loiter-mode.rst
+++ b/rover/source/docs/loiter-mode.rst
@@ -20,5 +20,20 @@ The way this mode works is:
 
 .. image:: ../images/loiter-mode-algorithm.png
 
+The way the boat turns to return to the target is controlled by :ref:`LOIT_TYPE<LOIT_TYPE>`:
+
+- "0" (the default) allows the boat to drive either forwards or backwards, whichever requires
+  less rotation. This normally holds position with the least movement, but means the boat's
+  heading is not predictable.
+- "1" always turns the bow towards the target and drives forwards. Use this if the boat handles
+  or is instrumented poorly in reverse, or if a bow mounted sensor or camera must face the
+  direction of travel.
+- "2" always turns the stern towards the target and drives in reverse. This keeps the bow
+  pointing away from the target, which can be useful to hold the boat's stern heading into the current or wind.
+
+.. note:: :ref:`LOIT_TYPE<LOIT_TYPE>` only affects how the boat behaves once it has strayed
+   outside :ref:`LOIT_RADIUS<LOIT_RADIUS>`. Within the radius the boat simply drifts regardless
+   of this setting.
+
 
 .. tip:: In order to obtain the optimum performance, the ESC deadband should be small. The :ref:`MOT_THR_MIN<MOT_THR_MIN>` can be used to compensate for ESC deadband. See this :ref:`section<rover-motor-and-servo-min-throttle>` for details.


### PR DESCRIPTION
Fixes #7664

The Loiter Mode page described `LOIT_RADIUS` but never mentioned `LOIT_TYPE`, so there was nothing explaining when to force the bow or the stern towards the target.

Adds a description of the three values, plus a note that `LOIT_TYPE` only matters once the boat has strayed outside `LOIT_RADIUS` (inside the radius it just drifts regardless).