### PR TITLE
common: object avoidance: cover AIS for boats

### DIFF
--- a/common/source/docs/common-object-avoidance-landing-page.rst
+++ b/common/source/docs/common-object-avoidance-landing-page.rst
@@ -4,9 +4,9 @@
 Object Avoidance
 ================
 
-ArduPilot supports several kinds of object avoidance. Avoidance of Airborne Vehicles (ADSB) and Object Avoidance (Object/Ground/Ceiling).
+ArduPilot supports several kinds of object avoidance. Avoidance of Airborne Vehicles (ADSB), of manned boats (AIS) and Object Avoidance (Object/Ground/Ceiling).
 
-Supported types vary with vehicle (Plane only supports ADSB). Some kinds of avoidance require external hardware, such as ADSB receivers or  Rangefinders.
+Supported types vary with vehicle (Plane only supports ADSB). Some kinds of avoidance require external hardware, such as ADSB receivers, AIS receivers or  Rangefinders.
 
 Avoidance Strategies
 ====================
@@ -19,6 +19,20 @@ ADSB Avoidance
 ===============
 
 - :ref:`Airborne Vehicles (ADSB)<common-ads-b-receiver>`
+
+[/site]
+
+[site wiki="rover"]
+
+AIS Avoidance
+=============
+
+A boat fitted with an AIS receiver feeds the positions of nearby manned vessels into the
+object avoidance database, so the path planners listed below route around them in the same
+way as any other obstacle. Note that AIS messages arrive infrequently, so a much longer
+:ref:`OA_DB_EXPIRE<OA_DB_EXPIRE>` is required than for other obstacle sources.
+
+- :ref:`Manned Boats (AIS)<common-ais>`
 
 [/site]
 


### PR DESCRIPTION
Fixes #7663

The Object Avoidance landing page listed ADSB avoidance for Copter and Plane but never mentioned AIS, even though the AIS page already documents that AIS vessel positions are pushed into the object avoidance database.

Adds a rover-only AIS Avoidance section linking to the AIS page, and mentions AIS in the page intro. The `OA_DB_EXPIRE` caveat is called out here too since it is easy to miss and the failure mode (database forgetting a vessel between AIS messages) is not obvious.