### PR TITLE
copter: fix stale PSC_JERK_NE param reference in brake-mode.rst

### DIFF
--- a/common/source/docs/common-param-name-changes.rst
+++ b/common/source/docs/common-param-name-changes.rst
@@ -125,9 +125,9 @@ were renamed to use consistent NED-style naming. This affects Copter/Sub
    * - PSC_VELXY_P / _I / _D / _IMAX / _FLTE / _FLTD / _FF
      - PSC_NE_VEL_P / _I / _D / _IMAX / _FLTE / _FLTD / _FF
    * - PSC_JERK_XY
-     - PSC_JERK_NE
+     - PSC_NE_JERK
    * - PSC_JERK_Z
-     - PSC_JERK_D
+     - PSC_D_JERK
 
 .. note:: For QuadPlane, replace the ``PSC_`` prefix above with ``Q_P_``
    (e.g. ``Q_P_NE_POS_P``).

--- a/copter/source/docs/brake-mode.rst
+++ b/copter/source/docs/brake-mode.rst
@@ -10,7 +10,7 @@ the pilot. This mode requires a valid position estimate.
 
 Brake mode is subject to acceleration and angle limits imposed by the
 position and attitude controllers. For more aggressive braking, you can
-also try increasing :ref:`PSC_JERK_NE <PSC_JERK_NE>`. As an example use case, a value of 15
+also try increasing :ref:`PSC_NE_JERK <PSC_NE_JERK>`. As an example use case, a value of 15
 to 30 works well for a small copter.
 
 Overview


### PR DESCRIPTION
## Summary....due to PR33843 parm renames
- Upstream renamed `PSC_JERK_NE` to `PSC_NE_JERK` (and `PSC_JERK_D` to `PSC_D_JERK`) to match the rest of the `PSC_` NED-axis-naming convention used elsewhere (`PSC_NE_POS_P`, `PSC_D_POS_P`, etc).
- `copter/source/docs/brake-mode.rst` still referenced the old `PSC_JERK_NE` label via `:ref:`, which no longer exists in current parameter metadata.
- Because CI (`update.py`, no `--fast`) does a fresh parameter fetch on every clean checkout, this produces a Sphinx "undefined label" warning on every PR's CI run — and `update.py` treats any warning as fatal (`build_one()` exits on `app._warncount > 0`), independent of any `-W` flag. Local builds don't hit this because they typically reuse a cached `Parameters.rst` from before the rename.
- Also corrected the two stale entries in `common/source/docs/common-param-name-changes.rst` that pointed at the old intermediate name.

I am going to break convention here and merge this ASAP instead of tagging to 4.8.....since its small, and pretty esoteric (not many users even know about these params, much less modify them) and it will be backported to 4.7 on the next dot release...I will just move into backports note when I merge this

## Test plan
- [ ] CI build passes (no more "undefined label: 'psc_jerk_ne'" warning)
- [ ] `PSC_NE_JERK` resolves correctly on the built brake-mode page