### PR TITLE
4.8/33832/copter: document optional AltHold build option

### DIFF
--- a/copter/source/docs/altholdmode.rst
+++ b/copter/source/docs/altholdmode.rst
@@ -22,6 +22,25 @@ Automatic altitude hold is a feature of many other flight modes
 :ref:`Sport <sport-mode>`, etc) so the
 information here pertains to those modes as well.
 
+Disabling AltHold in Source Builds
+==================================
+
+AltHold is included in Copter firmware by default. When building Copter
+from source, the AltHold flight mode can be excluded using the
+``MODE_ALTHOLD`` build option:
+
+.. code-block:: bash
+
+    ./waf configure --board <board> --disable-MODE_ALTHOLD --disable-MODE_BRAKE
+    ./waf copter
+
+This removes only the AltHold flight mode. Altitude control used by other
+flight modes remains available.
+
+Brake mode depends on AltHold, so ``MODE_BRAKE`` must also be disabled
+when AltHold is excluded. A build with Brake enabled and AltHold disabled
+will stop with a configuration error.
+
 .. note::
 
    The autopilot uses a barometer which measures air pressure


### PR DESCRIPTION
### Summary

Documents the optional Copter AltHold build configuration introduced by   https://github.com/ArduPilot/ardupilot/pull/33832 .

The AltHold documentation now explains how to exclude the AltHold flight mode from a source build:

```bash
./waf configure --board <board> --disable-MODE_ALTHOLD --disable-MODE_BRAKE
./waf copter
```

### Description

This update clarifies that:

- AltHold remains enabled by default.
- Disabling `MODE_ALTHOLD` removes only the AltHold flight mode.
- Altitude-control functionality used by other flight modes remains available.
- Brake mode depends on AltHold, so `MODE_BRAKE` must also be disabled when AltHold is excluded.
- A build with Brake enabled and AltHold disabled stops with a configuration error.

### Testing

Built the Copter documentation with:

```bash
python3 update.py --site copter --fast
```

The HTML build completed successfully. The remaining two Sphinx warnings are pre-existing warnings caused by the fast build omitting the generated parameter and log-message pages.

Verified the generated content in:

```text
copter/build/html/docs/altholdmode.html
```
