### PR TITLE
4.8:33638/common: document Rangefinder TEMP_SRC option

### DIFF
--- a/common/source/docs/common-temperature-sensor.rst
+++ b/common/source/docs/common-temperature-sensor.rst
@@ -70,6 +70,18 @@ Then set (examples shown for first sensor):
 
 - :ref:`TEMP1_TYPE<TEMP1_TYPE>` = 6 (DroneCAN)
 
+Rangefinder Temperature
+=======================
+
+A temperature sensor can supply its reading to a :ref:`rangefinder <common-rangefinder-landingpage>` instance. This is intended for rangefinders that have no onboard temperature sensor, and provides the foundation for future temperature-based distance corrections (for example, ultrasonic speed-of-sound compensation).
+
+- :ref:`TEMP1_SRC<TEMP1_SRC>` = 9 (Rangefinder) designates that this temperature sensor's reading will be supplied to a rangefinder.
+- :ref:`TEMP1_SRC_ID<TEMP1_SRC_ID>` selects the rangefinder instance. For example, a value of ``1`` supplies the reading to ``RNGFND1``.
+
+.. note:: The temperature represents the surrounding medium (air or water) in which the rangefinder operates, **not** the internal temperature of the rangefinder hardware.
+
+The supplied value is logged in the ``RFND`` message (``Temp`` field) for the selected instance.
+
 Logging/OSD
 ===========
 


### PR DESCRIPTION
## Summary

Documents the **Rangefinder** option for `TEMPx_SRC` and `TEMPx_SRC_ID` introduced in ArduPilot/ardupilot#33638.

This PR adds a **Rangefinder Temperature** section to the Temperature Sensor documentation, explaining:

* How to configure a temperature sensor to supply readings to a rangefinder using `TEMP1_SRC = 9` (`Rangefinder`).
* How `TEMP1_SRC_ID` selects the target rangefinder instance (for example, `1` → `RNGFND1`).
* That the reported temperature represents the surrounding medium (air or water), **not** the rangefinder's internal hardware temperature.
* That the feature provides the foundation for future temperature-based distance corrections, such as speed-of-sound compensation for ultrasonic rangefinders. No distance correction is currently applied.
* That the supplied temperature is recorded in the `RFND` log message (`Temp` field).

The documentation reflects the behavior implemented in ArduPilot/ardupilot#33638 and clarifies the intended use and configuration of the feature.

Related: ArduPilot/ardupilot_wiki#19844