### PR TITLE
common: remove dead dronetrack.org link from Web Apps page

### DIFF
--- a/common/source/docs/common-web-apps.rst
+++ b/common/source/docs/common-web-apps.rst
@@ -12,9 +12,6 @@ Below is the list of known applications (in alphabetical order).
 .. image:: ../../../images/webapps_titleimage2.jpg
     :target: ../_images/webapps_titleimage2.jpg
 
-`dronetrack.org <http://www.dronetrack.org/>`__ - Real-Time tracking and
-sharing of flight paths
-
 `EXmaps.com <https://www.exmaps.com/>`__ - online flight logbook made for
 the ArduPilot system. Just drag and drop log files for post flight
 analysis and cumulative flight time


### PR DESCRIPTION
dronetrack.org's domain is parked/for sale, so the link on the (already-archived) Web Apps page is dead.

Fixes #3155