### PR TITLE
4.8:33761/KakuteH7-Wing

### DIFF
--- a/common/source/docs/common-kakuteh7wing.rst
+++ b/common/source/docs/common-kakuteh7wing.rst
@@ -16,7 +16,7 @@ Specifications
     - AT7456E OSD
 
 -  **Sensors**
-    - ICM42688 Acc/Gyro
+    - ICM42688 or LSM6DSV Acc/Gyro
     - BMP280 barometer\
 
 -  **Power**


### PR DESCRIPTION
Documents LSM6DSV as an alternate IMU option on KakuteH7-Wing, per ardupilot PR https://github.com/ArduPilot/ardupilot/pull/33761.