### PR TITLE
4.8:33435/AET-H743-Air

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -102,6 +102,7 @@ Closed Hardware
     AIRBRAINH743 <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/AIRBRAINH743/README.md>
     Airvolute DroneCore <common-airvolute-DroneCore-Suite>
     AET-H743-Basic <common-AET-H743-Basic>
+    AET-H743-Air <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/AET_H743_Air/README.md>
     AnyleafH7 <common-anyleafh7>
     AocodaRC H743Dual <common-aocoda-h743dual>
     ARK FPV <common-ark-fpv>


### PR DESCRIPTION
Adds AET-H743-Air to the Closed Hardware autopilot board list, linking to its README.md.

Ref: https://github.com/ArduPilot/ardupilot/pull/33435