### PR TITLE
dev: document MAVLink fence/rally upload, log download, calibration

### DIFF
--- a/dev/source/docs/mavlink-calibration.rst
+++ b/dev/source/docs/mavlink-calibration.rst
@@ -1,0 +1,162 @@
+.. _mavlink-calibration:
+
+==================
+Sensor Calibration
+==================
+
+This page explains how MAVLink can be used by a ground station or companion computer to trigger sensor calibrations. The user wiki pages for these procedures are here: :ref:`accelerometer <copter:common-accelerometer-calibration>`, :ref:`compass <copter:common-compass-calibration-in-mission-planner>`, :ref:`radio <copter:common-radio-control-calibration>`.
+
+.. note::
+
+   The vehicle must be disarmed before starting a calibration. If
+   armed, ``MAV_CMD_PREFLIGHT_CALIBRATION`` replies with a "Disarm to
+   allow calibration" status text and is rejected, and
+   ``MAV_CMD_DO_START_MAG_CAL`` replies with "Disarm to allow compass
+   calibration". ``MAV_CMD_DO_ACCEPT_MAG_CAL`` and
+   ``MAV_CMD_DO_CANCEL_MAG_CAL`` have no armed-state check.
+
+Simple calibrations
+--------------------
+
+Gyro, barometer, board-level (trim) and simple accelerometer calibrations are each triggered with a single `MAV_CMD_PREFLIGHT_CALIBRATION <https://mavlink.io/en/messages/common.html#MAV_CMD_PREFLIGHT_CALIBRATION>`__ sent within a `COMMAND_INT <https://mavlink.io/en/messages/common.html#COMMAND_INT>`__ (or ``COMMAND_LONG``). Only one of the fields below should be non-zero in a given message.
+
+.. raw:: html
+
+   <table border="1" class="docutils">
+   <tbody>
+   <tr>
+   <th>Command Field</th>
+   <th>Type</th>
+   <th>Description</th>
+   </tr>
+   <tr>
+   <td><strong>param1</strong></td>
+   <td>float</td>
+   <td>1: gyro calibration</td>
+   </tr>
+   <tr>
+   <td><strong>param2</strong></td>
+   <td>float</td>
+   <td>magnetometer calibration — see below</td>
+   </tr>
+   <tr>
+   <td><strong>param3</strong></td>
+   <td>float</td>
+   <td>1: barometer (and airspeed, if fitted) calibration</td>
+   </tr>
+   <tr>
+   <td>param4</td>
+   <td>float</td>
+   <td>positive value: sets an internal "RC calibrating" flag that blocks arming (arming check fails with "RC calibrating") while true; zero/negative clears it — but only when param1 and param3 are both 0. ArduPilot does not itself run an RC endpoint calibration routine in response to this field. See note below</td>
+   </tr>
+   <tr>
+   <td><strong>x</strong> (param5)</td>
+   <td>int32_t</td>
+   <td>Accelerometer calibration action:
+
+   1: full 6-position calibration (see below)
+
+   2: board-level/trim calibration
+
+   4: simple (single position) accelerometer calibration
+
+   76: force-accept the existing accelerometer calibration as valid, without re-running it
+   </td>
+   </tr>
+   <tr>
+   <td>y (param6)</td>
+   <td>int32_t</td>
+   <td>Vehicle-specific: Copter — 1: CompassMot calibration. Rover — 1: windvane direction calibration, 2: windvane speed calibration. Sub — 1: rejected (MAV_RESULT_UNSUPPORTED), CompassMot is not supported. Plane, AntennaTracker and Blimp: not used.</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td>z (param7)</td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   </tbody>
+   </table>
+
+.. note::
+
+   ``x``/``y`` are ``int32_t`` fields of ``COMMAND_INT``, not ``float``. When
+   this command is sent as ``COMMAND_LONG`` instead, its float param5/param6
+   are cast directly to ``x``/``y`` on receipt.
+
+.. note::
+
+   ArduPilot does not itself run an RC endpoint calibration routine in
+   response to param4 — see the :ref:`radio calibration page
+   <copter:common-radio-control-calibration>` for how RC calibration
+   actually works. The "RC calibrating" flag it does set/clear is
+   only actually evaluated when param1 and param3 are both 0 — a
+   command that also triggers a gyro (param1=1) or barometer
+   (param3=1) calibration returns before reaching the param4 check,
+   so param4 has no effect in that same message. In practice this
+   means: combining a gyro or barometer calibration with param4=0
+   will **not** clear a flag left set by an earlier command — a
+   separate command with param1=0, param3=0 and param4 ≤ 0 (or a
+   reboot) is required to clear it. Conversely, an unrelated
+   accelerometer-calibration command (param5/``x`` set, param1=0,
+   param3=0) with param4 left at its default of 0 **will** clear the
+   flag, even in the middle of an in-progress RC calibration.
+
+ArduPilot only implements one action for the magnetometer's param2
+field: a value of 76 force-accepts the existing compass calibration as
+valid without re-running it (useful after a parameter reload that
+cleared the calibration-valid flags). The MAVLink spec also defines a
+value of 1 to *start* a magnetometer calibration via this same
+command, but ArduPilot does not implement that path — sending param2 =
+1 alone returns ``MAV_RESULT_UNSUPPORTED``. Use the dedicated
+:ref:`compass calibration commands <mavlink-calibration_compass-calibration>` below to actually start a mag calibration.
+
+Full 6-position accelerometer calibration
+------------------------------------------
+
+Sending ``MAV_CMD_PREFLIGHT_CALIBRATION`` with x (param5) = 1 starts
+the interactive full accelerometer calibration, which requires the
+vehicle to be placed in each of 6 orientations in turn. ArduPilot
+drives this using `MAV_CMD_ACCELCAL_VEHICLE_POS <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_ACCELCAL_VEHICLE_POS>`__:
+
+.. note::
+
+   Before starting the position wizard, ArduPilot first runs a gyro
+   calibration internally. If that gyro calibration fails (for
+   example the vehicle is being handled or vibrating), the whole
+   command fails immediately with ``MAV_RESULT_FAILED`` and no
+   ``MAV_CMD_ACCELCAL_VEHICLE_POS`` is ever sent — a GCS that has
+   already shown a "place vehicle LEVEL" prompt and is waiting for
+   that message will wait forever unless it also handles this failure
+   result.
+
+- ArduPilot sends this command *to the GCS* with param1 set to the position it wants next (`ACCELCAL_VEHICLE_POS <https://mavlink.io/en/messages/ardupilotmega.html#ACCELCAL_VEHICLE_POS>`__: 1=LEVEL, 2=LEFT, 3=RIGHT, 4=NOSEDOWN, 5=NOSEUP, 6=BACK), which the GCS should show to the user
+- once the vehicle has been placed in that position (and is stationary), the GCS sends the same command *back to the vehicle* with the same param1 value to confirm that position is ready and trigger capture of that orientation's data
+- ArduPilot then either requests the next position, or ends the calibration by sending ``MAV_CMD_ACCELCAL_VEHICLE_POS`` with param1 = 16777215 (success) or 16777216 (failed)
+
+.. _mavlink-calibration_compass-calibration:
+
+Compass (magnetometer) calibration
+-------------------------------------
+
+Compass calibration uses three dedicated commands rather than
+``MAV_CMD_PREFLIGHT_CALIBRATION``. Each is sent within a
+``COMMAND_INT``/``COMMAND_LONG`` with a bitmask of which compasses to
+act on in param1 (0 means all):
+
+- `MAV_CMD_DO_START_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_START_MAG_CAL>`__ — start calibration. param2 = retry on failure (0/1), param3 = autosave without waiting for ``MAV_CMD_DO_ACCEPT_MAG_CAL`` (0/1), param4 = delay in seconds before starting, x (param5) = autoreboot when done (0/1)
+- `MAV_CMD_DO_ACCEPT_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_ACCEPT_MAG_CAL>`__ — accept/save a completed calibration (only needed if autosave was not requested)
+- `MAV_CMD_DO_CANCEL_MAG_CAL <https://mavlink.io/en/messages/ardupilotmega.html#MAV_CMD_DO_CANCEL_MAG_CAL>`__ — cancel a running calibration
+
+While a compass calibration is running, ArduPilot streams `MAG_CAL_PROGRESS <https://mavlink.io/en/messages/ardupilotmega.html#MAG_CAL_PROGRESS>`__ messages showing each compass's ``completion_pct``. Both ``MAG_CAL_PROGRESS`` and ``MAG_CAL_REPORT`` (below) are sent as part of the ``EXTRA3`` telemetry stream, so a GCS/companion computer that has that stream's rate set to 0 will not see them, and calibration will appear to hang even though it is progressing normally.
+
+.. note::
+
+   ``MAG_CAL_REPORT`` is not a one-shot message. Once a compass finishes calibrating, ArduPilot has no "already reported" latch — it keeps re-sending that compass's ``MAG_CAL_REPORT`` at the ``EXTRA3`` stream rate rather than sending it just once. Its ``cal_status`` field gives the fit result (success/failed), and a separate ``autosaved`` field indicates whether the calibration has actually been saved to the compass's offset parameters (true if autosave was requested via ``MAV_CMD_DO_START_MAG_CAL``'s param3, or after ``MAV_CMD_DO_ACCEPT_MAG_CAL`` is sent) — the two are independent, so a compass can report a successful fit that has not yet been saved. A client that treats the first ``MAG_CAL_REPORT`` as a single completion event should still expect further copies of it to keep arriving.
+
+**Example**
+
+The example commands below can be copy-pasted into MAVProxy (aka SITL) to test these commands. Before running these commands enter, "module load message"
+
+- ``message COMMAND_LONG 0 0 241 0 1 0 0 0 0 0 0`` — gyro calibration
+- ``message COMMAND_LONG 0 0 241 0 0 0 1 0 0 0 0`` — barometer calibration
+- ``message COMMAND_LONG 0 0 241 0 0 0 0 0 4 0 0`` — simple accelerometer calibration
+- ``message COMMAND_LONG 0 0 42424 0 0 0 1 0 0 0 0`` — start compass calibration (autosave)

--- a/dev/source/docs/mavlink-commands.rst
+++ b/dev/source/docs/mavlink-commands.rst
@@ -10,24 +10,26 @@ ArduPilot supports the `MAVLink protocol <https://mavlink.io/en/>`__ for communi
     :maxdepth: 1
 
     MAVLink Basics <mavlink-basics>
-    Request Data From The AutoPilot <mavlink-requesting-data>
-    Get and Set Parameters <mavlink-get-set-params>
-    Copter Commands (Guided Mode) <copter-commands-in-guided-mode>
-    Plane Commands (Guided Mode) <plane-commands-in-guided-mode>
-    Rover Commands (Guided Mode) <mavlink-rover-commands>
-    Get and Set Home and/or EKF origin <mavlink-get-set-home-and-origin>
     Arm and Disarm <mavlink-arming-and-disarming>
-    Get and Set FlightMode <mavlink-get-set-flightmode>
     Camera Commands <mavlink-camera>
+    Copter Commands (Guided Mode) <copter-commands-in-guided-mode>
+    Get and Set FlightMode <mavlink-get-set-flightmode>
+    Get and Set Home and/or EKF origin <mavlink-get-set-home-and-origin>
+    Get and Set Parameters <mavlink-get-set-params>
     Gimbal / Camera Mount <mavlink-gimbal-mount>
+    Log Download <mavlink-log-download>
     MAVFTP <mavlink-mavftp>
+    MAVLink Routing <mavlink-routing-in-ardupilot>
     Mission Upload/Download <mavlink-mission-upload-download>
     Move a Servo <mavlink-move-servo>
     Non-GPS Position Estimation <mavlink-nongps-position-estimation>
+    Plane Commands (Guided Mode) <plane-commands-in-guided-mode>
     Precision Landing <mavlink-precision-landing>
     RC Input (aka Pilot Input) <mavlink-rcinput>
+    Request Data From The AutoPilot <mavlink-requesting-data>
+    Rover Commands (Guided Mode) <mavlink-rover-commands>
+    Sensor Calibration <mavlink-calibration>
     Winch Commands <mavlink-winch>
-    MAVLink Routing <mavlink-routing-in-ardupilot>
     Other Commands <mavlink-other-commands>
 
 Complete lists of Messages

--- a/dev/source/docs/mavlink-log-download.rst
+++ b/dev/source/docs/mavlink-log-download.rst
@@ -1,0 +1,58 @@
+.. _mavlink-log-download:
+
+============
+Log Download
+============
+
+This page explains how MAVLink can be used by a ground station or companion computer to list and download the vehicle's :ref:`onboard dataflash logs <copter:common-logs>`.
+
+.. note::
+
+   The vehicle must be disarmed before log download will be accepted.  If armed, ArduPilot replies with a "Disarm for log download" status text and ignores the request.
+
+.. note::
+
+   :ref:`MAVFTP <mavlink-mavftp>` is a much faster way to download logs if it is supported by both ends of the link, since it is not limited to the small chunk sizes used by the LOG_* messages below.
+
+Listing available logs
+-----------------------
+
+Send a `LOG_REQUEST_LIST <https://mavlink.io/en/messages/common.html#LOG_REQUEST_LIST>`__ with ``start``/``end`` set to the range of log ids to list (0/0xffff for all). ArduPilot replies with one `LOG_ENTRY <https://mavlink.io/en/messages/common.html#LOG_ENTRY>`__ per log in that range, each giving the log's ``id``, ``size`` (bytes, may be approximate) and ``time_utc`` (0 if not available). If there are no logs at all, a single ``LOG_ENTRY`` with ``id`` = 0 and ``num_logs`` = 0 is sent instead.
+
+Downloading a log
+------------------
+
+Send a `LOG_REQUEST_DATA <https://mavlink.io/en/messages/common.html#LOG_REQUEST_DATA>`__ with the desired log's ``id`` (from ``LOG_ENTRY`` above), an ``ofs`` (byte offset into the log) and a ``count`` (number of bytes wanted). ArduPilot replies with one or more `LOG_DATA <https://mavlink.io/en/messages/common.html#LOG_DATA>`__ messages, each carrying up to 90 bytes of log data starting at the requested offset.
+
+To download a whole log, send ``LOG_REQUEST_DATA`` with increasing ``ofs`` until the full ``size`` reported in the log's ``LOG_ENTRY`` has been received — this is the reliable way to know a download is complete. Only one ``LOG_REQUEST_DATA`` may be outstanding on a link at a time: ArduPilot silently ignores any further ``LOG_REQUEST_DATA`` it receives while a previous one is still being serviced, so a client must wait for each request to finish (or time out) before sending the next — pipelining several requests at once does not work.
+
+.. warning::
+
+   Do not rely on a trailing zero-``count`` ``LOG_DATA`` to detect end-of-log. ArduPilot only sends one when the requested ``ofs`` is already at or beyond the log's ``size``; a final chunk that exactly fills the requested byte range is not followed by one. Treating ``count == 0`` as the completion signal will hang at close to 100% on any log whose size is not an exact multiple of 90 bytes.
+
+Any chunk missed (for example after a lost message) can be re-requested afterwards with another ``LOG_REQUEST_DATA`` for just that offset range.
+
+Erasing all logs
+-----------------
+
+Send a `LOG_ERASE <https://mavlink.io/en/messages/common.html#LOG_ERASE>`__ message (only ``target_system``/``target_component`` fields) to erase all onboard logs. This cannot be undone and cannot be limited to a single log.
+
+Ending a log transfer
+----------------------
+
+ArduPilot automatically closes its read of the current log once a ``LOG_REQUEST_DATA`` request has been fully satisfied, so `LOG_REQUEST_END <https://mavlink.io/en/messages/common.html#LOG_REQUEST_END>`__ does not need to be sent after a normal, complete download. Its main use is to cancel/abort an in-progress transfer early (for example if the GCS no longer wants the rest of a log).
+
+.. note::
+
+   Sending a further ``LOG_REQUEST_DATA`` with an invalid log id does **not** cancel a transfer that is already in progress — while a transfer is active, ArduPilot ignores any additional ``LOG_REQUEST_DATA`` it receives on that link (see below). The invalid-id request is only actioned, ending the (nonexistent) transfer, when no transfer is currently running.
+
+**Example**
+
+MAVProxy's built-in ``log`` module (loaded by default) provides higher
+level commands that handle the ``LOG_REQUEST_LIST``/``LOG_REQUEST_DATA``
+exchange above automatically:
+
+- ``log list`` — list available logs
+- ``log download <lognumber> <filename>`` — download a single log to a file
+- ``log download all`` — download all logs
+- ``log erase`` — erase all logs

--- a/dev/source/docs/mavlink-mission-upload-download.rst
+++ b/dev/source/docs/mavlink-mission-upload-download.rst
@@ -110,3 +110,88 @@ The example commands below can be copy-pasted into MAVProxy (aka SITL) to test t
 +------------------------------------------------------+---------------------------+
 | ``message COMMAND_LONG 0 0 193 0 1 0 0 0 0 0 0``     | continue / resume mission |
 +------------------------------------------------------+---------------------------+
+
+Fence and Rally Point Upload/Download
+-------------------------------------
+
+Geofences and rally points use exactly the same message protocol
+described above (``MISSION_COUNT``, ``MISSION_ITEM_INT``,
+``MISSION_REQUEST_INT``, ``MISSION_ACK``, etc). The only difference is
+that the ``mission_type`` field of each message is set to
+`MAV_MISSION_TYPE_FENCE (1) <https://mavlink.io/en/messages/common.html#MAV_MISSION_TYPE_FENCE>`__
+or `MAV_MISSION_TYPE_RALLY (2) <https://mavlink.io/en/messages/common.html#MAV_MISSION_TYPE_RALLY>`__
+instead of the default ``MAV_MISSION_TYPE_MISSION (0)``. Fences and
+rally points are uploaded, downloaded and cleared independently of the
+main mission and of each other.
+
+.. note::
+
+   ``mission_type`` is a MAVLink 2 extension field. ArduPilot rejects
+   fence/rally *upload or download* (``MISSION_COUNT``,
+   ``MISSION_REQUEST_LIST``, ``MISSION_REQUEST_INT``,
+   ``MISSION_WRITE_PARTIAL_LIST``, etc) attempted over a MAVLink 1
+   connection with a "Need mavlink2 for item transfer" status text;
+   only the main mission (``MAV_MISSION_TYPE_MISSION``) works for
+   those over MAVLink 1.
+
+.. warning::
+
+   ``MISSION_CLEAR_ALL`` is **not** covered by that MAVLink 2 check.
+   A MAVLink 1 client sending ``MISSION_CLEAR_ALL`` with
+   ``mission_type`` set to ``MAV_MISSION_TYPE_FENCE`` or
+   ``MAV_MISSION_TYPE_RALLY`` will silently erase the stored geofence
+   or rally points.
+
+The user wiki pages for :ref:`Fence Setup <copter:common-geofencing-landing-page>` and :ref:`Rally Points <copter:common-rally-points>` explain these features from a GCS-user's perspective.
+
+Fence items
+~~~~~~~~~~~
+
+Each fence ``MISSION_ITEM_INT`` commonly uses one of the following
+commands:
+
+- `MAV_CMD_NAV_FENCE_RETURN_POINT <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_FENCE_RETURN_POINT>`__ — Plane only (there can be only one): destination used after a fence breach when :ref:`FENCE_ACTION <plane:FENCE_ACTION>` is ``GUIDED`` or ``GUIDED_THROTTLE_PASS`` and :ref:`FENCE_RET_RALLY <plane:FENCE_RET_RALLY>` is 0; if ``FENCE_RET_RALLY`` is 1, Plane instead heads to the nearest rally point or home. Not used for the RTL/Autoland fence actions, and not used at all on Copter
+- `MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION>`__ — one vertex of an inclusion polygon (vehicle must stay inside); at least 3 required, each with param1 set to the total vertex count of that polygon
+- `MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION>`__ — one vertex of an exclusion polygon (vehicle must stay outside)
+- `MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_FENCE_CIRCLE_INCLUSION>`__ — circular area the vehicle must stay inside (param1 = radius in metres)
+- `MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_FENCE_CIRCLE_EXCLUSION>`__ — circular area the vehicle must stay outside (param1 = radius in metres)
+
+.. note::
+
+   All vertices of one polygon must be uploaded contiguously, with an
+   identical param1 (vertex count) value on every item; a differing
+   item type or param1 value appearing mid-polygon is rejected with a
+   "Received incorrect vertex type" status text, and finishing with
+   fewer vertices than param1 promised is rejected with "Unexpected
+   vertex count"/"Incorrect item count". Circle and return-point items
+   are likewise rejected if they interrupt a polygon's vertex run.
+
+ArduPilot also supports ``MAV_CMD_NAV_FENCE_HOME_CIRCLE_INCLUSION``
+(5005) — a circular inclusion fence centered on home rather than a
+fixed point; if home moves, the fence moves with it.
+
+.. note::
+
+   The MAVLink spec defines an "inclusion group" field (param2) on the
+   polygon/circle-inclusion commands, intended to let the vehicle
+   require being inside just one of several independent inclusion
+   areas. ArduPilot does not currently read or store this field — all
+   inclusion areas are combined into a single group.
+
+   By default, when more than one inclusion area is defined, the
+   vehicle must be inside *all* of them at once (their intersection).
+   Setting bit 1 of :ref:`FENCE_OPTIONS <copter:FENCE_OPTIONS>`
+   switches this to a union instead, so the vehicle only needs to be
+   inside at least one inclusion area.
+
+Rally items
+~~~~~~~~~~~
+
+Each rally point ``MISSION_ITEM_INT`` uses `MAV_CMD_NAV_RALLY_POINT <https://mavlink.io/en/messages/common.html#MAV_CMD_NAV_RALLY_POINT>`__, with the location given in the item's x/y/z fields (latitude/longitude in degrees ×1e7, altitude in metres, per the mission item's chosen frame). Multiple rally points may be defined; ArduPilot considers the nearest valid rally point when RTL-ing, subject to the :ref:`RALLY_INCL_HOME <copter:RALLY_INCL_HOME>` and :ref:`RALLY_LIMIT_KM <copter:RALLY_LIMIT_KM>` parameters, and will fall back to home if no rally point qualifies.
+
+**Example**
+
+Using MAVProxy/SITL, which understands the ``mission_type`` field:
+
+- ``fence list`` — download and list the fence
+- ``rally list`` — download and list rally points


### PR DESCRIPTION
Fill the three remaining gaps identified in #1884's "much more detail of how ArduPilot vehicles can be controlled using MAVlink" request:

- mavlink-mission-upload-download.rst: new section explaining that fence and rally points reuse the same mission-item protocol via the mission_type field (MAV_MISSION_TYPE_FENCE / _RALLY, MAVLink 2 only), plus the MAV_CMD_NAV_FENCE_* / MAV_CMD_NAV_RALLY_POINT item types and how ArduPilot selects a rally point on RTL.
- mavlink-log-download.rst (new): LOG_REQUEST_LIST/LOG_ENTRY, LOG_REQUEST_DATA/LOG_DATA, LOG_ERASE, LOG_REQUEST_END, including the disarm-required behaviour, why a trailing zero-count LOG_DATA isn't a reliable end-of-transfer signal, and a pointer to MAVFTP as the faster alternative.
- mavlink-calibration.rst (new): MAV_CMD_PREFLIGHT_CALIBRATION (gyro/baro/trim/simple-accel/force-save, and which fields ArduPilot actually implements vs. the MAVLink spec's superset), the interactive full 6-position accel cal handshake via MAV_CMD_ACCELCAL_VEHICLE_POS, and compass calibration via MAV_CMD_DO_START_MAG_CAL/_ACCEPT_/_CANCEL_ plus MAG_CAL_PROGRESS/_REPORT.

Both new pages added to the MAVLink Interface toctree. Content verified against the ardupilot firmware source (GCS_Common.cpp, AP_Compass_Calibration.cpp, MissionItemProtocol_Fence.cpp, AP_Logger_MAVLinkLogTransfer.cpp, AP_Logger_File.cpp, AP_Rally.cpp), not just the MAVLink message/command names, including a Codex-assisted second-pass review that caught several spec-vs-actual-behaviour mismatches (unimplemented fence inclusion groups, unimplemented PREFLIGHT_CALIBRATION mag-start path, RC-calibrating param4, rally selection depending on RALLY_INCL_HOME/RALLY_LIMIT_KM, LOG_REQUEST_END semantics).

Fixes #1884