### PR TITLE
rover: document Wheel Rate Control (WRC_ parameters)

### DIFF
--- a/rover/source/docs/balance_bot-tuning.rst
+++ b/rover/source/docs/balance_bot-tuning.rst
@@ -4,6 +4,45 @@
 Tuning the Balance Bot
 ======================
 
+.. _balance_bot-tuning-wrc:
+
+Tuning Wheel Rate Control
+=========================
+
+For Balance bots, the wheel encoders can also be used to
+close a rate-control loop around each side's throttle output, instead
+of just feeding position/velocity estimation as described in
+:ref:`wheel-encoder`. A PID controller converts the desired wheel
+rotation rate into the actual throttle output sent to the motor, using
+the corresponding wheel encoder as feedback. This can improve tracking
+of the commanded speed and turn rate, particularly if the left and
+right motors/wheels don't behave identically.
+
+This only applies to the ``SERVOx_FUNCTION`` = 73 (Throttle Left) and
+74 (Throttle Right) skid-steering outputs, and requires the
+corresponding wheel encoder(s) (:ref:`WENC_TYPE <WENC_TYPE>` for the
+left wheel, :ref:`WENC2_TYPE <WENC2_TYPE>` for the right wheel) to
+already be enabled. See :ref:`wheel-encoder` for how to connect and
+configure the encoders.
+
+.. note::
+
+   "Enabled" here only means the encoder's type is set to something
+   other than "None" -- it is not a health check. A disconnected,
+   stalled, or reverse-wired encoder will still be treated as
+   available, and can cause the rate controller to drive the throttle
+   to a wrong or saturated output. Confirm each wheel's reported rate
+   looks correct (e.g. via ``WHEEL_DISTANCE`` or the WENC log message)
+   before enabling and tuning wheel rate control.
+
+- set :ref:`WRC_ENABLE <WRC_ENABLE>` to 1 to enable wheel rate control
+- set :ref:`WRC_RATE_MAX <WRC_RATE_MAX>` to the wheel's maximum rotation rate in radians/sec (this single value is shared by both wheels; a 100% throttle request is treated as this rate). Leaving this at 0 does not disable the feature -- it makes the controller target a rate of zero for every throttle request instead, fighting the vehicle to a stop. Use :ref:`WRC_ENABLE <WRC_ENABLE>` = 0 to actually disable wheel rate control.
+- tune the left wheel's controller using the :ref:`WRC_RATE_P <WRC_RATE_P>`, :ref:`WRC_RATE_I <WRC_RATE_I>`, :ref:`WRC_RATE_D <WRC_RATE_D>`, :ref:`WRC_RATE_FF <WRC_RATE_FF>`, :ref:`WRC_RATE_IMAX <WRC_RATE_IMAX>` and :ref:`WRC_RATE_FILT <WRC_RATE_FILT>` parameters
+- tune the right wheel's controller using the equivalent :ref:`WRC2_RATE_P <WRC2_RATE_P>`, :ref:`WRC2_RATE_I <WRC2_RATE_I>`, :ref:`WRC2_RATE_D <WRC2_RATE_D>`, :ref:`WRC2_RATE_FF <WRC2_RATE_FF>`, :ref:`WRC2_RATE_IMAX <WRC2_RATE_IMAX>` and :ref:`WRC2_RATE_FILT <WRC2_RATE_FILT>` parameters
+
+The left wheel's rate controller performance can be reviewed using the
+dataflash log's ``PIDW`` message (desired vs achieved rate, and the P/I/D/FF contributions), the same way the steering and throttle-speed rate controllers are reviewed via their own ``PIDS``/``PIDA`` messages. The right wheel's controller is not currently logged.
+
 Tuning Pitch Control
 ====================
 

--- a/rover/source/docs/wheel-encoder.rst
+++ b/rover/source/docs/wheel-encoder.rst
@@ -18,7 +18,7 @@ Connection and Setup
 
 - connect motor encoder's A and B outputs to the autopilot (A Pixhawk using AUX OUT 3,4,5 and 6 pins is shown for example above).
 - set those output's ``SERVOx_FUNCTION`` to -1 to allow them to be used as GPIO inputs. See :ref:`common-gpios` for more information. For the example above, set :ref:`SERVO11_FUNCTION<SERVO11_FUNCTION>`, :ref:`SERVO12_FUNCTION<SERVO12_FUNCTION>`, :ref:`SERVO13_FUNCTION<SERVO13_FUNCTION>`, and :ref:`SERVO14_FUNCTION<SERVO14_FUNCTION>` to "-1".
-- set :ref:`WENC_TYPE <WENC_TYPE>` and :ref:`WENC2_TYPE <WENC_TYPE>` to 1 to enable reading from two wheel encoders
+- set :ref:`WENC_TYPE <WENC_TYPE>` and :ref:`WENC2_TYPE <WENC2_TYPE>` to 1 to enable reading from two wheel encoders
 - set :ref:`WENC_CPR <WENC_CPR>` and :ref:`WENC2_CPR <WENC2_CPR>` to the counts-per-revolution of the encoder.  This is the number of "pings" the encoder will produce for each full revolution of the wheel
 - set :ref:`WENC_RADIUS <WENC_RADIUS>` and :ref:`WENC2_RADIUS <WENC2_RADIUS>` to the radius (in meters) of each wheel (i.e. 5cm radius would be 0.05)
 - set :ref:`WENC_POS_X <WENC_POS_X>` and :ref:`WENC_POS_Y <WENC_POS_Y>` to define the first wheel's distance from the autopilot or COG (i.e. :ref:`WENC_POS_X <WENC_POS_X>` = 0.10, :ref:`WENC_POS_Y <WENC_POS_Y>` = -0.05 means the wheel is 10cm ahead and 5cm left of the autopilot) 
@@ -42,6 +42,11 @@ Ground Testing
 The ``WHEEL_DISTANCE`` MAVLink message shows the total distance travelled by each wheel in real time.  Mission Planner's MAVLink Inspector can be used which can be opened by pressing Ctrl-F and then pushing the "MAVLink Inspector" button.
 
 .. image:: ../images/Mavlink-Inspector.jpg
+
+Wheel Rate Control
+==================
+
+For Balance bots, the wheel encoders can also be used to close a rate-control loop around each side's throttle output.  See :ref:`here for more details <balance_bot-tuning-wrc>`.
 
 DataFlash logging
 =================


### PR DESCRIPTION
Adds the last unaddressed item from #2109's Rover-4.0 checklist. The existing wheel-encoder page only covered using wheel encoders for EKF position/velocity estimation; it never mentioned AP_WheelRateControl, which uses the same encoders to close a PID rate loop around the throttleLeft/throttleRight skid-steering outputs (Rover/Log.cpp, libraries/AP_WheelEncoder/AP_WheelRateControl.cpp).

Also fixes a pre-existing typo on the same page: the WENC2_TYPE bullet linked to the WENC_TYPE anchor instead of WENC2_TYPE.

Content verified against ArduPilot firmware source, including a Codex-assisted second-pass review that caught two real gaps: the encoder "enabled" check has no health/freshness guarantee, and WRC_RATE_MAX=0 does not disable the feature (WRC_ENABLE=0 does).

Fixes #2109