### PR TITLE
common: clarify GPS_TYPE=NMEA detection and COMPASS_DISBLMSK

### DIFF
--- a/common/source/docs/common-compass-setup-advanced.rst
+++ b/common/source/docs/common-compass-setup-advanced.rst
@@ -65,6 +65,13 @@ Any one of the first three compasses can be disabled. This would leave only the 
 
       Compasses should always be enabled for Copter/Rover, but may be disabled (not recommended, if one is available) for Plane.
 
+Disabling a Compass Driver Type
+-------------------------------
+
+The above "Compass Enables" setting turns off an already-detected compass. In contrast, the :ref:`COMPASS_DISBLMSK<COMPASS_DISBLMSK>` parameter prevents ArduPilot from even probing for a particular compass *chip driver* at startup. This is a bitmask, with one bit per driver type (HMC5883, LSM303D, AK8963, BMM150, QMC5883, etc); setting a driver's bit stops that driver from being probed at all.
+
+This is mainly useful when two different compass chips would otherwise be detected at the same I2C address, causing a conflict, or a board's built-in driver for a peripheral (e.g. a DroneCAN or MSP connection) is being confused for a physical compass chip. Several individual hardware setup pages in this wiki recommend a specific :ref:`COMPASS_DISBLMSK<COMPASS_DISBLMSK>` value to resolve exactly this kind of conflict for that hardware.
+
 Orientation
 -----------
 

--- a/common/source/docs/common-positioning-landing-page.rst
+++ b/common/source/docs/common-positioning-landing-page.rst
@@ -139,6 +139,13 @@ Moving Baseline (GPS for Yaw) Capable
     Qiotek DroneCAN RTK-F9P GPS <https://www.qio-tek.com/index.php/product/qiotek-zed-f9p-rtk-and-compass-dronecan-module>
     Synerx MDU-2000 RTK + LTE GPS <common-synerex-mdu-2000>
     
+GPS Type Detection
+==================
+
+The :ref:`GPS1_TYPE<GPS1_TYPE>` (and :ref:`GPS2_TYPE<GPS2_TYPE>` for a second GPS) parameter selects which protocol/driver ArduPilot uses to talk to the GPS connected to that instance's serial port. The default, "AUTO" (1), automatically probes most common protocols (u-Blox, SBP/SBP2, SiRF, ERB) and uses whichever one responds.
+
+.. warning:: "AUTO" does **not** probe for the NMEA protocol (or the closely related HemisphereNMEA, UnicoreNMEA and AllyStar protocols). If a GPS only outputs standard NMEA sentences, :ref:`GPS1_TYPE<GPS1_TYPE>` (and/or :ref:`GPS2_TYPE<GPS2_TYPE>`) must be set specifically to "5" (NMEA); with it left at "AUTO" the GPS will never be detected.
+
 GPS Auto Configuration
 ======================
 


### PR DESCRIPTION
Fills the two remaining real gaps from #2110's Copter-4.0 checklist:

- common-positioning-landing-page.rst: new "GPS Type Detection" section. Verified in AP_GPS.cpp's _detect_instance() that AUTO mode probes u-Blox/SBP/SBP2/SiRF/ERB but the NMEA (and HemisphereNMEA/ UnicoreNMEA/AllyStar) detection branch has no `type == GPS_TYPE_AUTO` clause -- an NMEA-only GPS is never found unless GPS1_TYPE/GPS2_TYPE is explicitly set to 5.
- common-compass-setup-advanced.rst: new "Disabling a Compass Driver Type" section explaining COMPASS_DISBLMSK (a per-chip-driver probe disable, distinct from the existing "Compass Enables" section which only disables an already-detected compass), for the I2C-address/ driver-conflict scenarios that hardware pages already tell users to set it for without ever explaining what it does.

The remaining checklist item (supporting two external compasses) was judged already covered by the existing Compass Ordering and Priority section.

Fixes #2110