### PR TITLE
4.8:33281/ARK FPV

### DIFF
--- a/common/source/docs/common-ark-fpv.rst
+++ b/common/source/docs/common-ark-fpv.rst
@@ -150,6 +150,8 @@ POWER AUX - 3 Pin JST-GH
      - VBAT IN/OUT
      - 5.5V-54V
 
+The 12V pin is gated by a BEC enable pin mapped to RELAY1, which is **on by default** (:ref:`RELAY1_DEFAULT<RELAY1_DEFAULT>` = 1). To change the default to off, set :ref:`RELAY1_DEFAULT<RELAY1_DEFAULT>` = 0. To make it controllable from the transmitter, set :ref:`RELAY1_FUNCTION<RELAY1_FUNCTION>` = 1 (Relay) and assign :ref:`RCx_OPTION<RC7_OPTION>` = 28 (Relay1 On/Off) to the desired switch channel. The VBAT pin is a direct battery pass-through and is not controlled by firmware.
+
 
 CAN - 4 Pin JST-GH
 ------------------
@@ -247,6 +249,8 @@ VTX - 6 Pin JST-GH
   5     USART2_RX_(SBUS)       3.3V
   6     GND                    GND
  ===== ====================== =========
+
+The 12V pin is gated by a BEC enable pin mapped to RELAY1, which is **on by default** (:ref:`RELAY1_DEFAULT<RELAY1_DEFAULT>` = 1). To change the default to off, set :ref:`RELAY1_DEFAULT<RELAY1_DEFAULT>` = 0. To make it controllable from the transmitter, set :ref:`RELAY1_FUNCTION<RELAY1_FUNCTION>` = 1 (Relay) and assign :ref:`RCx_OPTION<RC7_OPTION>` = 28 (Relay1 On/Off) to the desired switch channel.
 
 SPI (OSD or IMU) - 8 Pin JST-SH
 -------------------------------


### PR DESCRIPTION
Documents the ARK FPV POWER AUX / VTX 12V output behaviour introduced in https://github.com/ArduPilot/ardupilot/pull/33281: on by default via `RELAY1_DEFAULT`=1, how to change the default, and how to make it transmitter-controllable via `RELAY1_FUNCTION`/`RCx_OPTION`=28.