### PR TITLE
4.8:33237/ZeroOneX6

### DIFF
--- a/common/source/docs/common-zeroonex6-air.rst
+++ b/common/source/docs/common-zeroonex6-air.rst
@@ -32,7 +32,8 @@ Features:
   * IMU1: ICM45686 (With vibration isolation)
   * IMU2- ICM45686 (No vibration isolation)
   * IMU constant temperature heating (1W heating power)
-  * Baros: 2 x ICP20100
+  * Baros: 2 x ICP20100 (V1)
+  * V2: SPL06 and BMP581 baros
   * Magnetometer: IST8310 magnetometer
 
 Pinout

--- a/common/source/docs/common-zeroonex6.rst
+++ b/common/source/docs/common-zeroonex6.rst
@@ -31,7 +31,8 @@ Features:
          - IMU2-BMI088(With vibration isolation)
          - IMU3-IIM42653(No vibration isolation)
    - Baros:
-      - Two barometers:2 x ICP20100
+      - Two barometers: 2 x ICP20100 (V1)
+      - V2: SPL06 and BMP581 baros
       - Magnetometer: Built-in RM3100 magnetometer
 
 - **Interfaces**


### PR DESCRIPTION
Documents the new baro support added in https://github.com/ArduPilot/ardupilot/pull/33237: ZeroOneX6/X6 Pro and ZeroOneX6 Air+ V2 boards use SPL06 and BMP581 baros in place of the dual ICP20100 used on V1.