### PR TITLE
common: list BATT_MONITOR values for smart battery types

### DIFF
--- a/common/source/docs/common-smart-battery-landingpage.rst
+++ b/common/source/docs/common-smart-battery-landingpage.rst
@@ -6,10 +6,12 @@ Smart Batteries
 
 ArduPilot supports several types of "smart battery" that communicate using `SMBus <https://en.wikipedia.org/wiki/System_Management_Bus>`__:
 
-- the `Solo battery <https://www.amazon.com/Solo-Smart-Battery-Rechargeable-Lithium/dp/B01LWAAMV3>`__
-- Maxell
-- :ref:`Royote<common-smart-battery-rotoye>`
-- Generic support for SUI3 and SUI6 SMBus batteries
+- the `Solo battery <https://www.amazon.com/Solo-Smart-Battery-Rechargeable-Lithium/dp/B01LWAAMV3>`__ (:ref:`BATT_MONITOR <BATT_MONITOR>` = 5)
+- Maxell (:ref:`BATT_MONITOR <BATT_MONITOR>` = 16)
+- :ref:`Royote<common-smart-battery-rotoye>` (:ref:`BATT_MONITOR <BATT_MONITOR>` = 19)
+- Generic SUI3 and SUI6 SMBus batteries (:ref:`BATT_MONITOR <BATT_MONITOR>` = 13 and 14 respectively)
+- NeoDesign SMBus batteries (:ref:`BATT_MONITOR <BATT_MONITOR>` = 15)
+- Generic SMBus battery (:ref:`BATT_MONITOR <BATT_MONITOR>` = 7)
 
 While not yet very common, smart batteries are easier to attach and detach from the vehicle and are capable of providing more information on the state of the battery including capacity, individual cell voltages, temperature, etc.
 


### PR DESCRIPTION
NeoDesign (BATT_MONITOR=15) wasn't mentioned on the smart battery
landing page at all, and SUI3/SUI6 (13/14) had no BATT_MONITOR value
given. Checked AP_BattMonitor_SMBus_SUI.cpp and
AP_BattMonitor_SMBus_NeoDesign.cpp: both use standard internal-I2C
SMBus wiring like the other types already listed here, so the
existing "Setup through Mission Planner" section's generic
BATT_MONITOR/BATT_I2C_BUS instructions already cover them -- no
separate connection diagram is needed.

Did not attempt dedicated pages (as originally proposed in the issue)
since the requested format (title image, connection diagram) needs
real product photos not available here. Also filled in the existing
BATT_MONITOR values for Solo/Maxell/Rotoye/generic-SMBus while in
here.

Fixes #2820