### PR TITLE
common: mention APD ESCs on the ESCs and Motors page

### DIFF
--- a/common/source/docs/common-escs-and-motors.rst
+++ b/common/source/docs/common-escs-and-motors.rst
@@ -37,6 +37,8 @@ capabilities will vary with each individual ESC model. Some ESCs have specialize
 explain the required ArduPilot setup to utilize the protocols, telemetry, and setup programs that various ESCs utilize.
 See :ref:`common-esc-guide` for a guide to terminology.
 
+`APD (Advanced Power Drives) <https://powerdrives.net/>`__ is an ArduPilot partner whose ESCs run their own proprietary firmware and use the standard PWM and :ref:`DShot <common-dshot-escs>` protocols covered below.
+
 Protocols
 ---------
 


### PR DESCRIPTION
Fixes #4410. APD is an ArduPilot partner, previously only listed as a
sponsor logo on common-partners.rst -- no mention on the actual
ESCs/Motors page. Confirmed (ArduPilot forum, powerdrives.net docs)
APD ESCs use their own proprietary firmware but standard PWM/DShot
protocols, already fully covered by common-brushless-escs.rst and
common-dshot-escs.rst.