### PR TITLE
dev: document pymavlink MAVFTP reference implementation and perf note

### DIFF
--- a/dev/source/docs/mavlink-mavftp.rst
+++ b/dev/source/docs/mavlink-mavftp.rst
@@ -13,3 +13,12 @@ Common uses for using MAVFTP include:
 - :ref:`Uploading firmware to the autopilot <common-install-sdcard>`
 - :ref:`Uploading Lua scripts <copter:common-lua-scripts>`
 - Fast download of parameters, :ref:`onboard logs <copter:common-logs>`, mission command files and :ref:`rally points <copter:common-rally-points>` and :ref:`terrain data <copter:terrain-following>`
+
+Reference Implementation
+========================
+
+`pymavlink <https://github.com/ArduPilot/pymavlink>`__ includes a known-working MAVFTP client, `mavftp.py <https://github.com/ArduPilot/pymavlink/blob/master/mavftp.py>`__ (with its opcode definitions in `mavftp_op.py <https://github.com/ArduPilot/pymavlink/blob/master/mavftp_op.py>`__), usable both as a Python library and as a standalone command-line tool. It is a good reference for testing a new GCS/companion computer implementation against, or for scripting bulk MAVFTP transfers directly.
+
+.. warning::
+
+   Implementing only the request/reply sequence described in the MAVLink specification above will work, but will be slow. pymavlink's implementation gets much better throughput by pipelining requests rather than waiting for each reply before sending the next request: reads use ``OP_BurstReadFile`` to stream multiple chunks per request rather than one chunk per ``OP_ReadFile``/reply round-trip, and writes keep a backlog of several in-flight, unacknowledged chunks (a small sliding window, similar in spirit to TCP) instead of sending one ``OP_WriteFile`` and waiting for its ack before sending the next. A GCS/companion computer implementation aiming for good performance should do the same rather than implementing a strict one-request-then-wait-for-reply loop.


### PR DESCRIPTION
Fixes #4688. The page was only 15 lines (link to spec + list of uses)
with neither of the two things the issue asked for:

- a link to a known-working implementation for developers to test
  against (pymavlink's mavftp.py/mavftp_op.py)
- a warning that the bare MAVLink spec sequence isn't sufficient for
  good performance

Checked pymavlink/mavftp.py directly: it pipelines reads via
OP_BurstReadFile instead of one OP_ReadFile per reply, and keeps a
backlog of several in-flight unacknowledged write chunks (write_qsize/
max_backlog settings) instead of a strict request-then-wait loop.
Named both concretely in the warning rather than just saying
"optimisations exist".