### PR TITLE
common: clarify AP_Periph RNGFNDx_MIN/MAX must be set on both sides

### DIFF
--- a/common/source/docs/common-ap-periph-usage-examples.rst
+++ b/common/source/docs/common-ap-periph-usage-examples.rst
@@ -34,7 +34,14 @@ To use rangefinders, follow the instructions at  :ref:`DroneCAN Setup Advanced<c
 
 .. note:: The orientation of the rangefinder (RNGFND1_ORIENT) must be set to 0 on the adaptor node.
 
-.. note:: The RNGFNDx_ADDR ArduPilot parameter must be set above 0 and be equal to the number set on the DroneCAN adapter node.
+.. note:: The ArduPilot-side ``RNGFNDx_ADDR`` parameter must match the ``RNGFNDx_ADDR`` set on the DroneCAN adapter node. Both default to 0, which works fine for a single rangefinder; if multiple DroneCAN rangefinders are used, give each one a distinct address (matched on both sides) so ArduPilot can tell them apart.
+
+.. note::
+
+   ``RNGFNDx_MIN`` and ``RNGFNDx_MAX`` need to be set to matching values on *both* the adaptor node and in ArduPilot's own flight code parameters -- they are used for different things on each side, so setting them in only one place is not enough:
+
+   - the adaptor node's MIN/MAX are used to set the rangefinder's reported status in the DroneCAN message (range too low, too high, or OK), which ArduPilot's flight code then just reads
+   - ArduPilot's own MIN/MAX are used for other purposes, for example the arming check that requires :ref:`RNGFNDx_MAX<copter:RNGFND1_MAX>` to be at least :ref:`RTL_ALT<copter:RTL_ALT_M>` when :ref:`RTL_ALT_TYPE<copter:RTL_ALT_TYPE>` = 1 (Terrain)
 
 PWM or DShot Output Node
 ========================

--- a/common/source/docs/common-uavcan-setup-advanced.rst
+++ b/common/source/docs/common-uavcan-setup-advanced.rst
@@ -108,7 +108,7 @@ DroneCAN LEDs are enabled by setting bit 5 in the :ref:`NTF_LED_TYPES<NTF_LED_TY
 DroneCAN Rangefinder configuration
 ==================================
 
-Set ``RNGFNDx_TYPE`` = 24 to enable DroneCAN rangefinder type. Rangefinder data received over DroneCAN will only be used if the received sensor_id matches the parameter ``RNGFNDx_ADDR``. For AP_Periph firmware based adaptor nodes, this value is 0, so ``RNGFNDx_ADDR`` must be set to 0. Other DroneCAN rangefinders may differ. See also :ref:`DroneCAN Adaptor Node<common-uavcan-adapter-node>` instructions.
+Set ``RNGFNDx_TYPE`` = 24 to enable DroneCAN rangefinder type. Rangefinder data received over DroneCAN will only be used if the received sensor_id matches the parameter ``RNGFNDx_ADDR``. For AP_Periph firmware based adaptor nodes, this is the node's own ``RNGFNDx_ADDR`` parameter, which defaults to 0 -- so the ArduPilot-side ``RNGFNDx_ADDR`` should also be left at 0 unless the adaptor node's address has been changed (e.g. to distinguish multiple rangefinders), in which case both sides must match. See also :ref:`DroneCAN Adaptor Node<common-uavcan-adapter-node>` instructions.
 
 DroneCAN Options
 ================


### PR DESCRIPTION
Fixes #6008. common-ap-periph-usage-examples.rst's "Rangefinder Setup"
section (the page rmackay9 couldn't recall the location of) already
covered RNGFND1_ORIENT and RNGFNDx_ADDR but never mentioned that
RNGFNDx_MIN/MAX need to be set to matching values on both the adaptor
node and the flight controller, since they're used for different
purposes on each side (adaptor node: sets the DroneCAN message's
range-status field; flight controller: used elsewhere, e.g. the
RTL_ALT_TYPE=Terrain arming check). Verified the arming check
direction against AP_Arming_Copter.cpp.

Also fixed the param names, which were stale (RNGFNDx_MIN_CM/MAX_CM
in the original issue text; current params are RNGFNDx_MIN/MAX,
verified against AP_RangeFinder_Params.cpp).

While in this section, fixed a direct contradiction found between
this page ("RNGFNDx_ADDR must be set above 0") and
common-uavcan-setup-advanced.rst ("RNGFNDx_ADDR must be set to 0" for
AP_Periph nodes). Verified against AP_RangeFinder_DroneCAN.cpp and
Tools/AP_Periph/rangefinder.cpp: both sides default to ADDR=0 and
just need to match; reworded both pages consistently.