### PR TITLE
copter: add UAVLAS ULS-XCopter-G2 to precision landing devices

### DIFF
--- a/copter/source/docs/precision-landing-and-loiter.rst
+++ b/copter/source/docs/precision-landing-and-loiter.rst
@@ -8,6 +8,7 @@ Copter supports **Precision Landing** and **Precision Loiter**, which use an ext
 
 Precision Landing is supported via MAVLink `LANDING_TARGET <https://mavlink.io/en/messages/common.html#LANDING_TARGET>`__ messages
 sent from a companion computer such as :ref:`BlueOS <precision-landing-blueos>`, the `Landmark system <https://landmarklanding.com/products/landmark-precision-landing-system>`__,
+the :ref:`UAVLAS ULS-XCopter-G2 <precision-landing-uavlas>` infra-red beacon kit,
 or using the `IR-LOCK sensor <https://irlock.com/products/ir-lock-sensor-precision-landing-kit>`__, `beacon <https://irlock.com/products/markone-beacon-v3-0-beta>`__,
 and a :ref:`rangefinder <common-rangefinder-landingpage>`.
 
@@ -31,6 +32,7 @@ Available Systems
     BlueOS Precision Landing Extension <precision-landing-blueos>
     IR-LOCK Sensor & Beacon <precision-landing-irlock>
     Landmark Precision Landing System <precision-landing-landmark>
+    UAVLAS ULS-XCopter-G2 <precision-landing-uavlas>
 
 
 Quick Start

--- a/copter/source/docs/precision-landing-uavlas.rst
+++ b/copter/source/docs/precision-landing-uavlas.rst
@@ -1,0 +1,20 @@
+.. _precision-landing-uavlas:
+
+=====================
+UAVLAS ULS-XCopter-G2
+=====================
+
+Overview
+=========
+
+The `UAVLAS ULS-XCopter-G2 <https://store.uavlas.com/products/uls-xcopter-g2-landing-kit-uls-xcopter-tx-g2-uls-xcopter-rx-g2>`__ is an infra-red positioning beacon kit consisting of a ground-based transmitter and a lightweight receiver unit fitted to the vehicle, used to provide centimeter-level accuracy for landing and hovering over a target.
+
+Where to Buy
+============
+
+The `ULS-XCopter-G2 landing kit <https://store.uavlas.com/products/uls-xcopter-g2-landing-kit-uls-xcopter-tx-g2-uls-xcopter-rx-g2>`__ can be purchased from `store.uavlas.com <https://store.uavlas.com/>`__.
+
+Documentation
+=============
+
+See `UAVLAS's own ArduPilot integration guide <https://docs.uavlas.com/docs/uls-xcopter/integration/ardupilot-integration/>`__ for setup instructions. Per that guide, ArduCopter 4.3.3 or higher is required.


### PR DESCRIPTION
Fixes #6870. Confirmed via UAVLAS's own ArduPilot integration guide
(docs.uavlas.com) that ULS-XCopter-G2 uses the standard MAVLink
LANDING_TARGET protocol already documented on the umbrella page
(same mechanism as BlueOS/Landmark), and requires ArduCopter 4.3.3+.
Added as a lightweight gateway page (overview, where to buy, link to
the vendor's own setup guide), matching the existing pattern for
Landmark/BlueOS -- no custom ArduPilot-side setup instructions needed
since it's a standard LANDING_TARGET sender.

Did not address the issue's secondary "OpenMV camera" mention: found
no existing OpenMV precision-landing documentation or verifiable
integration detail to point to (only OpenMV optical-flow content
exists), so left that out rather than assert unverified specifics.