### PR TITLE
common: future-wiki-changes: list CUAV-X25-MEGA

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -23,6 +23,7 @@ New Board Support
 - SIYI UniFC 6 PICO, see https://github.com/ArduPilot/ardupilot_wiki/pull/7877
 - SimpliFly H7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7915
 - AET-H743-Air, see https://github.com/ArduPilot/ardupilot_wiki/pull/7918
+- CUAV-X25-MEGA, see https://github.com/ArduPilot/ardupilot_wiki/pull/7944
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
Add CUAV-X25-MEGA to the New Board Support list, referencing #7944.