### PR TITLE
Copter: mention AltHold for Save Trim

### DIFF
--- a/copter/source/docs/autotrim.rst
+++ b/copter/source/docs/autotrim.rst
@@ -58,7 +58,7 @@ Save trim involves essentially transferring your radio transmitter's trims into 
 .. image:: ../images/MP_SaveTrim_Ch7.png
     :target: ../_images/MP_SaveTrim_Ch7.png
 
-3. With your CH7 switch in the off (Low) position, fly your copter in Stabilize or AltHold mode and use your transmitter's roll and pitch trim to get it flying level and use your transmitters's roll and pitch trim to get it flying level
+3. With your CH7 switch in the off (Low) position, fly your copter in Stabilize or AltHold mode and use your transmitter's roll and pitch trim to get it flying level
 
 4. Land and put your throttle to zero
 

--- a/copter/source/docs/autotrim.rst
+++ b/copter/source/docs/autotrim.rst
@@ -58,7 +58,7 @@ Save trim involves essentially transferring your radio transmitter's trims into 
 .. image:: ../images/MP_SaveTrim_Ch7.png
     :target: ../_images/MP_SaveTrim_Ch7.png
 
-3. With your CH7 switch in the off (Low) position, fly your copter in Stabilize mode and use your transmitters's roll and pitch trim to get it flying level
+3. With your CH7 switch in the off (Low) position, fly your copter in Stabilize or AltHold mode and use your transmitter's roll and pitch trim to get it flying level and use your transmitters's roll and pitch trim to get it flying level
 
 4. Land and put your throttle to zero
 


### PR DESCRIPTION
## Summary

Update the Copter Save Trim instructions to state that the procedure can be performed in either Stabilize or AltHold mode.

## Motivation

The current documentation mentions only Stabilize mode, while Save Trim also works in AltHold mode. This change aligns the user instructions with the supported behavior.

## Testing

Documentation-only change. Reviewed the updated RST sentence for clarity and consistency.

Fixes #7952