### PR TITLE
Copter: Fix deprecated auxiliary channels link in Simple and Super Simple Modes docs

### DIFF
--- a/copter/source/docs/simpleandsuper-simple-modes.rst
+++ b/copter/source/docs/simpleandsuper-simple-modes.rst
@@ -111,7 +111,7 @@ both pilot and vehicle pointing in the same direction.
 Selecting the modes from a transmitter
 ======================================
 
-The transmitter’s :ref:`auxiliary channels <channel-7-and-8-options>` can
+The transmitter’s :ref:`auxiliary channels <common-auxiliary-functions>` can
 be set-up to enable selection of Simple mode, Super Simple mode or both.
 Only one auxiliary channel should be set for these modes, and this
 channel will override the simple/super-simple options selected on the


### PR DESCRIPTION
**Description**
The "auxiliary channels" link on the Copter "Simple and Super Simple Modes" documentation page was pointing to `channel-7-and-8-options.html#channel-7-and-8-options`, which is archived/deprecated. 

This PR updates the link to point to the current `common-auxiliary-functions.html` documentation to ensure users are directed to the correct setup instructions.

**Changes made**
- Modified `copter/source/docs/simpleandsuper-simple-modes.rst` to update the `:ref:` link from `<channel-7-and-8-options>` to `<common-auxiliary-functions>`.

fixes #7950 