### PR TITLE
Fix archived links

### DIFF
--- a/common/source/docs/common-buzzer.rst
+++ b/common/source/docs/common-buzzer.rst
@@ -14,7 +14,7 @@ A buzzer (or Tone Alarm) can be used to audibly indicate status changes for the 
 .. image:: ../../../images/buzzer.jpg
     :target: ../_images/buzzer.jpg
 
-If an output capable of producing PWM is used with a passive piezo, it can play various :ref:`sounds <common-sounds-pixhawkpx4>` including the Arming sound, Mode Change sound, and Lost Vehicle Alarms (search for "Lost Copter Alarm" on :ref:`this page <channel-7-and-8-options>`, "Lost Plane" in the RCx_OPTION, for example, :ref:`RC5_OPTION <RC5_OPTION>`, or "Lost Rover" in the :ref:`Auxiliary Functions <common-auxiliary-functions>`).
+If an output capable of producing PWM is used with a passive piezo, it can play various :ref:`sounds <common-sounds-pixhawkpx4>` including the Arming sound, Mode Change sound, and Lost Vehicle Alarm (search for "Lost Vehicle Alarm" in the :ref:`Auxiliary Functions <common-auxiliary-functions>`).
 
 .. note:: in order to use a passive piezo buzzer to play the musical notification tones, the autopilot firmware must have defined that capability to a pin with a timer in its build definition. This is not a capability that the user can add by parameter setup, unlike the use of an active single tone buzzer by designating any GPIO capable pin with :ref:`NTF_BUZZ_PIN<NTF_BUZZ_PIN>`.
 

--- a/common/source/docs/common-electro-permanent-magnet-gripper.rst
+++ b/common/source/docs/common-electro-permanent-magnet-gripper.rst
@@ -83,9 +83,9 @@ bring the switch high and then return the switch to neutral.
 To release the cargo, momentarily bring the switch low and then return
 it to neutral.
 
-Note: the :ref:`Copter Ch7/Ch8 switch <copter:channel-7-and-8-options>`
-includes options for the EPM but these unfortunately do not function
-properly.
+Note: the :ref:`Copter auxiliary switch <copter:common-auxiliary-functions>`
+Gripper option can be assigned to the EPM but these unfortunately do
+not function properly.
 
 Note: it is also possible (if using an older style, non ppm-sum
 receiver) to directly connect one signal wire from the receiver to the

--- a/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
+++ b/common/source/docs/common-rc-transmitter-flight-mode-configuration.rst
@@ -67,7 +67,7 @@ the following:
 -  When finished press the **Save Modes** button.
 [/site]
 [site wiki="copter"]
-(Copter) Some modes can also be invoked from the :ref:`auxiliary switches <copter:channel-7-and-8-options>`
+(Copter) Some modes can also be invoked from the :ref:`auxiliary switches <copter:common-auxiliary-functions>`
 (a.k.a. ch7, ch8 option switches). For example, to set a dedicated
 switch for RTL.
 [/site]

--- a/common/source/docs/common-zed.rst
+++ b/common/source/docs/common-zed.rst
@@ -73,7 +73,7 @@ Flight testing
 ==============
 
 - Setup the vehicle with AltHold and Loiter flight modes
-- Setup an :ref:`auxiliary switch <channel-7-and-8-options>` to enable/disable object avoidance and move switch to the off position.  Alternatively set :ref:`PRX1_TYPE <PRX1_TYPE>` to 0.  This helps ensure the vehicle will not backaway from objects in AltHold mode which could surprise the pilot.
+- Setup an :ref:`auxiliary switch <common-auxiliary-functions>` to enable/disable object avoidance and move switch to the off position.  Alternatively set :ref:`PRX1_TYPE <PRX1_TYPE>` to 0.  This helps ensure the vehicle will not backaway from objects in AltHold mode which could surprise the pilot.
 - Attempt to arm and take-off in Loiter mode
 
 DataFlash logging

--- a/copter/source/docs/landing-gear.rst
+++ b/copter/source/docs/landing-gear.rst
@@ -63,7 +63,7 @@ following parameters:
 
    MissionPlanner: Landing Gear Configuration
 
-Set an :ref:`auxiliary switch <channel-7-and-8-options>` to "Landing Gear" in order to enable manual control (i.e. set CH7_OPT or CH8_OPT to "29")
+Set an :ref:`auxiliary switch <common-auxiliary-functions>` to "Landing Gear" in order to enable manual control (i.e. set the desired channel's ``RCx_OPTION`` parameter, for example :ref:`RC7_OPTION <RC7_OPTION>`, to "29")
 
 When the switch is in the "low" position the gear will be deployed, "high" will be retracted, "middle" is a neutral position that will not change the gear's state.
 

--- a/copter/source/docs/terrain-following-manual-modes.rst
+++ b/copter/source/docs/terrain-following-manual-modes.rst
@@ -19,7 +19,7 @@ Setup and Configuration
 - Connect a downward facing rangefinder(for floor/ground tracking) and/or an upward facing rangefinder (for ceiling tracking) :ref:`lidar or sonar <common-rangefinder-landingpage>` to the vehicle. 
 
 - Which is being used is configured by the :ref:`SURFTRAK_MODE<SURFTRAK_MODE>` parameter or by: 
-- An :ref:`auxiliary switch <common-auxiliary-functions>` (function "75"), or  :ref:`channel-7-and-8-options`, can be configured to turn on/off use of the rangefinder.
+- An :ref:`auxiliary switch <common-auxiliary-functions>` (function "75") can be configured to turn on/off use of the rangefinder.
 - the :ref:`SURFTRAK_TC<SURFTRAK_TC>` parameter controls the smoothing of the surface data. Increase if you are moving fast and getting perturbations in the flight path. Conversely, it can be lower to make the vehicle more responsive to the rangefinder data.
 
 .. warning::

--- a/copter/source/docs/zigzag-mode.rst
+++ b/copter/source/docs/zigzag-mode.rst
@@ -11,7 +11,7 @@ ZigZag mode is a semi-autonomous mode designed to make it easier for a pilot to 
 
 The way it works is:
 
-- A two or three position :ref:`auxiliary switch <channel-7-and-8-options>` is set to 61 / "ZigZag SaveWP" (i.e. :ref:`RC7_OPTION <RC7_OPTION>` = 61)
+- A two or three position :ref:`auxiliary switch <common-auxiliary-functions>` is set to 61 / "ZigZag SaveWP" (i.e. :ref:`RC7_OPTION <RC7_OPTION>` = 61)
 - The pilot arms the vehicle and takes off.  The vehicle will fly just like :ref:`Loiter <loiter-mode>`
 - The vehicle is flown manually to one side of the field and then the auxiliary switch is moved to the highest or lowest position (it doesn't matter which) to record that side
 - The vehicle is flown to the other side of the field and the switch is moved to the opposite position


### PR DESCRIPTION
## Summary

`copter/source/docs/channel-7-and-8-options.rst` was archived (superseded by `common-auxiliary-functions.rst`), but 8 files across the common and copter docs still linked to it. This retargets those references.

## Changes

- `common-buzzer.rst` — retargeted, and simplified an outdated per-vehicle "Lost Copter/Plane/Rover Alarm" naming to the current unified "Lost Vehicle Alarm"
- `common-prearm-safety-checks.rst` — retargeted
- `common-rc-transmitter-flight-mode-configuration.rst` — retargeted
- `common-zed.rst` — retargeted
- `common-electro-permanent-magnet-gripper.rst` — retargeted
- `copter/terrain-following-manual-modes.rst` — removed a redundant duplicate link to the same target
- `copter/landing-gear.rst` — retargeted, and updated stale `CH7_OPT`/`CH8_OPT` param mentions to the current `RCx_OPTION` naming
- `copter/zigzag-mode.rst` — retargeted

`simpleandsuper-simple-modes.rst` also has two stale references to the same archived page, but is deliberately **not** touched here — PR #7957 already covers one of the two spots (line 114) and a follow-up fix for the missed second spot (line 30) will be pushed to that PR directly.

## Testing

Built the copter site with `update.py --fast --site copter`; build succeeded with no ref/warning output, and spot-checked the rendered HTML to confirm every retargeted `:ref:` resolves to `common-auxiliary-functions.html`.