### PR TITLE
dev/common: fill in gaps found re-triaging old issues

### DIFF
--- a/common/source/docs/common-telemetry-xbee.rst
+++ b/common/source/docs/common-telemetry-xbee.rst
@@ -38,6 +38,14 @@ With the CTS and RTS pins disconnected the BRD_SER1_RTSCTS (if using Telem1) or
 BRD_SER2_RTSCTS (if using Telem2) should be set to zero (after making the change
 the autopilot will need to be restarted).
 
+.. tip::
+
+   Some XBee modules can brick on power-up if telemetry data arrives
+   too soon. If you experience this, try increasing
+   :ref:`MAV_TELEM_DELAY<MAV_TELEM_DELAY>`, which delays the start of
+   radio telemetry by the given number of seconds; values in the
+   20-30 second range have worked for some users.
+
 .. image:: ../../../images/Telemetry_XBee_MPSetup.jpg
     :target: ../_images/Telemetry_XBee_MPSetup.jpg
 

--- a/dev/source/docs/using-sitl-for-ardupilot-testing.rst
+++ b/dev/source/docs/using-sitl-for-ardupilot-testing.rst
@@ -68,6 +68,27 @@ The frame type can also be changed with the ``-f`` parameter.
 
     sim_vehicle.py -v ArduPlane -f quadplane --console --map
 
+Starting a virtual AntennaTracker alongside the vehicle
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the ``-T`` flag to also launch a virtual AntennaTracker instance
+together with the main vehicle:
+
+::
+
+    sim_vehicle.py -v ArduCopter -T --console --map
+
+The AntennaTracker simulator (`SIM_Tracker.cpp
+<https://github.com/ArduPilot/ardupilot/blob/master/libraries/SITL/SIM_Tracker.cpp>`__)
+can simulate either position or on/off servos, but not rate servos.
+
+A real AntennaTracker can also be pointed at a purely virtual (SITL)
+vehicle instead of a simulated tracker: connect the real
+AntennaTracker's radio to the SITL machine as a :ref:`real serial
+device
+<using-sitl-for-ardupilot-testing_using_real_serial_devices>` on one
+of the vehicle's UARTs, and it will track the virtual vehicle's
+simulated position just as it would a real one.
 
 Frame Types:
 ~~~~~~~~~~~~
@@ -169,6 +190,8 @@ Adding Simulated Peripherals into the Simulation
 ------------------------------------------------
 
 See :ref:`adding_simulated_devices`
+
+.. _using-sitl-for-ardupilot-testing_using_real_serial_devices:
 
 Using real serial devices
 -------------------------


### PR DESCRIPTION
## Summary

Two small doc gaps found while re-checking old open issues against current wiki content — both were partially addressed already but missing the specific piece the reporter/asker needed.

- **#93** asked for two things: (1) how to start a virtual AntennaTracker in SITL, and (2) how to point a real AntennaTracker at a virtual SITL vehicle. Only (2) was documented. Added the missing `-T` flag section, plus a cross-link from there to the real-serial-device instructions for (2).
- **#1576** reported the XBee page was missing the `TELEM_DELAY` (now `MAV_TELEM_DELAY`) fix needed to avoid bricking some XBee modules on power-up. Added a tip with the parameter and the 20-30s range the reporter found working.

Fixes #93
Fixes #1576

## Testing

Built the dev site with `update.py --fast --site dev`; build succeeded with no warnings.