### PR TITLE
dev/plane: explain the GUIDED_ PID parameters used by GUIDED_CHANGE_HEADING

### DIFF
--- a/dev/source/docs/plane-commands-in-guided-mode.rst
+++ b/dev/source/docs/plane-commands-in-guided-mode.rst
@@ -58,6 +58,8 @@ These MAV_CMDs can be processed if packaged within a `COMMAND_INT <https://mavli
 - `MAV_CMD_GUIDED_CHANGE_ALTITUDE <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_CHANGE_ALTITUDE>`__
 - `MAV_CMD_GUIDED_CHANGE_HEADING <https://mavlink.io/en/messages/common.html#MAV_CMD_GUIDED_CHANGE_HEADING>`__
 
+.. note:: the MAV_CMD_GUIDED_CHANGE_HEADING command will use a separate set of **GUIDED_x** PID parameters to control the turn, instead of the normal L1 parameters (:ref:`NAVL1_\* <plane:NAVL1_PERIOD>`/:ref:`TECS_\* <plane:TECS_TIME_CONST>`).
+
 Position Targets
 ================
 

--- a/plane/source/docs/guided-mode.rst
+++ b/plane/source/docs/guided-mode.rst
@@ -13,3 +13,21 @@ The other major use for GUIDED mode is in :ref:`geo-fencing <geofencing>`.
 When the geo-fence is breached the aircraft will enter GUIDED mode, and
 head to the predefined geo-fence return point, where it will loiter
 until the operator takes over.
+
+Normal "fly to" navigation in GUIDED mode is flown by the same L1
+navigation controller (:ref:`NAVL1_PERIOD<NAVL1_PERIOD>`, etc) used in
+AUTO mode.
+
+A separate ``GUIDED_*`` PID set is only used if a ground
+station or companion computer sends the
+`MAV_CMD_GUIDED_CHANGE_HEADING <https://mavlink.io/en/messages/common.html#MAV_CMD_GUIDED_CHANGE_HEADING>`__
+MAVLink command to slew to a new heading.
+
+.. _plane-commands-in-guided-mode_tuning_guided_change_heading:
+
+Tuning GUIDED_CHANGE_HEADING
+============================
+
+The ``GUIDED_*`` PID parameters are a guidance-layer gain, not an attitude/rate-controller gain, and they apply *only* while ``MAV_CMD_GUIDED_CHANGE_HEADING`` has an active target: they convert the heading/course error into a demanded bank angle, which the normal roll controller then flies. They play no part in normal Guided "fly to this location" navigation, AUTO waypoint navigation (which uses :ref:`NAVL1_\* <plane:NAVL1_PERIOD>`/:ref:`TECS_\* <plane:TECS_TIME_CONST>` instead), or the other GUIDED_CHANGE_* commands.
+
+Tune the aircraft's normal roll controller first. If roll already tracks its demand well but heading changes feel too weak or too aggressive, adjust :ref:`GUIDED_P<GUIDED_P>` — higher commands more bank for a given heading error, lower softens it. :ref:`GUIDED_I<GUIDED_I>` and :ref:`GUIDED_D<GUIDED_D>` default to zero and rarely need changing.


### PR DESCRIPTION
## Summary

Issue #3471 ("Explain GUIDED_x parameters in Plane") had no body/comments beyond the title. Investigated with help from Codex tracing the actual ArduPlane source (`Parameters.h`/`.cpp`, `mode_guided.cpp`, `GCS_MAVLink_Plane.cpp`) rather than guessing from the auto-generated parameter descriptions.

Findings: the `GUIDED_` PID group (`ParametersG2.guidedHeading`) is a guidance-layer controller that is **only** active while `MAV_CMD_GUIDED_CHANGE_HEADING` has a live target. It converts heading/course-over-ground error into a demanded bank angle, which the normal fixed-wing roll controller then flies. It plays no part in:

- normal Guided "fly to this location" navigation (still the standard nav controller)
- AUTO waypoint navigation (`NAVL1_*` for lateral nav, `TECS_*` for pitch/throttle)
- the other `GUIDED_CHANGE_SPEED`/`GUIDED_CHANGE_ALTITUDE` commands
- `SET_ATTITUDE_TARGET`

Also worth noting for anyone tuning it later: because Plane calls `update_error()` rather than `update_all()` on this PID, the target is forced to zero, so `GUIDED_FF`, `GUIDED_D_FF`, and `GUIDED_FLTT` have no effective signal, and `GUIDED_NTF`/`GUIDED_NEF` notch filters are never initialized for this instance — 5 of the 13 generated parameters are inherited-but-inert for this use. Left that detail out of the wiki text itself to keep it concise, per feedback.

## Changes

- `dev/source/docs/plane-commands-in-guided-mode.rst`: new "Tuning GUIDED_CHANGE_HEADING" section explaining the above, with tuning guidance (adjust `GUIDED_P` only after the normal roll controller is solid).
- `plane/source/docs/guided-mode.rst`: short addition to the user-facing page clarifying that normal "fly to" GUIDED navigation is still flown by the L1 controller, and that `GUIDED_*` is scoped to the offboard heading-change command, pointing to the dev wiki section for details.

Fixes #3471

## Testing

Built `dev` and `plane` sites with `update.py --fast`; both succeeded with no warnings. Confirmed the cross-wiki `:ref:` from the plane page resolves to the correct dev page/anchor in the rendered HTML.