### PR TITLE
4.8:32389/OptiFlow Filter

### DIFF
--- a/common/source/docs/common-optical-flow-sensor-setup.rst
+++ b/common/source/docs/common-optical-flow-sensor-setup.rst
@@ -201,6 +201,11 @@ Setup for Normal Operation
 [site wiki="plane,copter"]
 .. note:: When Copters have an optical flow sensor enabled (along with a rangefinder) and it is specified as the only horizontal position source (e.g. ``EK3_SRCx_VELXY`` = OpticalFlow and ``EK3_SRCx_POSXY`` = None) and the vehicle is flying in a pilot controlled mode requiring a position estimate (ie Loiter or PosHold) the vehicle will not climb above the rangefinder's maximum altitude specified in ``RNGFNDx_MAX``. This is a safety mechanism because otherwise the EKF failsafe would trigger as the vehicle flew out of rangefinder range.
 
+.. note:: :ref:`EK3_OPTIONS<EK3_OPTIONS>` has two further bits relevant to optical flow, both requiring a working rangefinder:
+
+   - Bit 2 (Optflow may use terrain alt) lets flow keep working above the rangefinder's range by falling back to SRTM terrain elevation data for the height-above-ground estimate.
+   - Bit 3 (AGL KF for optflow scaling) uses a separate height estimate, fused from IMU and rangefinder data, for scaling flow velocities instead of the main EKF's vertical position state. This keeps flow scaling accurate if the main filter's altitude estimate is disturbed (ground effect, GPS outage, altitude sensor noise), which would otherwise over-scale the flow measurements and could cause the filter to diverge. It automatically reverts to the normal estimate if the rangefinder hasn't updated within the last 5 seconds.
+
 Example Video (Copter-3.4)
 ==========================
 


### PR DESCRIPTION
Bit 3 (AGL KF for optflow scaling) was added in ArduPilot/ardupilot#32389 and had no wiki coverage beyond the auto-generated parameter description. Bit 2 (terrain alt for optflow above rangefinder range) was also undocumented here, so added both together since they're both relevant to the same section.

Traced against the actual PR source (AP_NavEKF3_OptFlowFusion.cpp): bit 3 requires a working rangefinder, falls back to the normal terrainState-pd estimate if the rangefinder hasn't fused within 5 seconds, and is compiled in wherever optical flow fusion already is.