### PR TITLE
common: future-wiki-changes: list EK3_OPTIONS optical flow bits

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -40,6 +40,7 @@ New Features
 
 - Option to clear GCS RC overrides on RC stick input, see https://github.com/ArduPilot/ardupilot_wiki/pull/7880
 - Accel and gyro consistency pre-arm checks now run concurrently, see https://github.com/ArduPilot/ardupilot_wiki/pull/7921
+- EK3_OPTIONS bits for optical flow (terrain alt above rangefinder range, AGL Kalman filter for flow scaling), see https://github.com/ArduPilot/ardupilot_wiki/pull/7962
 
 [site wiki="plane"]
 - Rangefinder engagement distance, see https://github.com/ArduPilot/ardupilot_wiki/pull/7559


### PR DESCRIPTION
## Summary

Lists the optical flow EK3_OPTIONS bits (documented in #7962) on the Future Wiki Changes page, per the usual convention of tracking master-branch features here ahead of the 4.8 release.

Related: #7962 (the actual wiki documentation for these options), ArduPilot/ardupilot#32389 (the firmware PR that added bit 3)