### PR TITLE
4.8:32437/copter: document swashplate phase angle available for all types

### DIFF
--- a/copter/source/docs/dual-helicopter.rst
+++ b/copter/source/docs/dual-helicopter.rst
@@ -52,7 +52,8 @@ These are only needed for the forward swashplate if :ref:`H_SW_TYPE<H_SW_TYPE__A
 - :ref:`H_SW_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Dual>`
-- ``H_SW_H3_PHANG``
+
+:ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Dual>` can also be set for the forward swashplate to correct control coupling issues, regardless of swashplate type.
 
 These are only needed for the aft swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` is set to H3 Generic.
 
@@ -60,7 +61,8 @@ These are only needed for the aft swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` is
 - :ref:`H_SW2_H3_SV1_POS<H_SW2_H3_SV1_POS>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW2_H3_SV2_POS>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW2_H3_SV3_POS>`
-- ``H_SW2_H3_PHANG``
+
+:ref:`H_SW2_PHANG<H_SW2_PHANG>` can also be set for the aft swashplate to correct control coupling issues, regardless of swashplate type.
 
 This parameter is not used for the longitudinal configuration
 - :ref:`H_YAW_REV_EXPO<H_YAW_REV_EXPO>`
@@ -98,7 +100,8 @@ These are only needed for the left swashplate if :ref:`H_SW_TYPE<H_SW_TYPE__AP_M
 - :ref:`H_SW_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Dual>`
-- ``H_SW_H3_PHANG``
+
+:ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Dual>` can also be set for the left swashplate to correct control coupling issues, regardless of swashplate type.
 
 These are only needed for the right swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` is set to H3 Generic.
 
@@ -106,7 +109,8 @@ These are only needed for the right swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` 
 - :ref:`H_SW2_H3_SV1_POS<H_SW2_H3_SV1_POS>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW2_H3_SV2_POS>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW2_H3_SV3_POS>`
-- ``H_SW2_H3_PHANG``
+
+:ref:`H_SW2_PHANG<H_SW2_PHANG>` can also be set for the right swashplate to correct control coupling issues, regardless of swashplate type.
 
 This parameter is not used for the longitudinal configuration
 
@@ -143,7 +147,8 @@ These are only needed for the left swashplate if :ref:`H_SW_TYPE<H_SW_TYPE__AP_M
 - :ref:`H_SW_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Dual>`
-- ``H_SW_H3_PHANG``
+
+:ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Dual>` can also be set for the left swashplate to correct control coupling issues, regardless of swashplate type.
 
 These are only needed for the right swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` is set to H3 Generic.
 
@@ -151,7 +156,8 @@ These are only needed for the right swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` 
 - :ref:`H_SW2_H3_SV1_POS<H_SW2_H3_SV1_POS>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW2_H3_SV2_POS>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW2_H3_SV3_POS>`
-- ``H_SW2_H3_PHANG``
+
+:ref:`H_SW2_PHANG<H_SW2_PHANG>` can also be set for the right swashplate to correct control coupling issues, regardless of swashplate type.
 
 These parameters are not used for the intermeshing configuration
 
@@ -190,7 +196,8 @@ These are only needed for the counter clockwise swashplate if :ref:`H_SW_TYPE<H_
 - :ref:`H_SW_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Dual>`
-- ``H_SW_H3_PHANG``
+
+:ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Dual>` can also be set for the counter clockwise swashplate to correct control coupling issues, regardless of swashplate type.
 
 These are only needed for the clockwise swashplate if :ref:`H_SW2_TYPE<H_SW2_TYPE>` is set to H3 Generic.
 
@@ -198,7 +205,8 @@ These are only needed for the clockwise swashplate if :ref:`H_SW2_TYPE<H_SW2_TYP
 - :ref:`H_SW2_H3_SV1_POS<H_SW2_H3_SV1_POS>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW2_H3_SV2_POS>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW2_H3_SV3_POS>`
-- ``H_SW2_H3_PHANG``
+
+:ref:`H_SW2_PHANG<H_SW2_PHANG>` can also be set for the clockwise swashplate to correct control coupling issues, regardless of swashplate type.
 
 These parameters are not used for the coaxial configuration
 

--- a/copter/source/docs/traditional-helicopter-parameter-list.rst
+++ b/copter/source/docs/traditional-helicopter-parameter-list.rst
@@ -44,6 +44,7 @@ These set up the configuration of the swashplate and collective travel.
 - :ref:`H_COL_MIN<H_COL_MIN>`
 - :ref:`H_SW_COL_DIR<H_SW_COL_DIR__AP_MotorsHeli_Single>`
 - :ref:`H_SW_LIN_SVO<H_SW_LIN_SVO__AP_MotorsHeli_Single>`
+- :ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Single>`
 
 Dual Rotor Helicopter
 =====================
@@ -64,7 +65,7 @@ If Dual Heli frame type is selected, these additional parameters for the second 
 - :ref:`H_SW2_H3_SV1_POS<H_SW2_H3_SV1_POS>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW2_H3_SV2_POS>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW2_H3_SV3_POS>`
-- ``H_SW2_H3_PHANG``
+- :ref:`H_SW2_PHANG<H_SW2_PHANG>`
 - :ref:`H_DCP_TRIM<H_DCP_TRIM>`
 - :ref:`H_YAW_REV_EXPO<H_YAW_REV_EXPO>`
 
@@ -76,14 +77,12 @@ ArduPilot allows custom swashplate servo placement for three servo swashplates. 
 - :ref:`H_SW_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Single>`
 - :ref:`H_SW_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Single>`
 - :ref:`H_SW_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Single>`
-- ``H_SW_H3_PHANG``
 
  and if :ref:`H_SW2_TYPE<H_SW2_TYPE>` = 0 (dual helis only):
 
 - :ref:`H_SW2_H3_SV1_POS<H_SW_H3_SV1_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW2_H3_SV2_POS<H_SW_H3_SV2_POS__AP_MotorsHeli_Dual>`
 - :ref:`H_SW2_H3_SV3_POS<H_SW_H3_SV3_POS__AP_MotorsHeli_Dual>`
-- ``H_SW2_H3_PHANG``
 
 Rotor Speed Control Setup
 =========================

--- a/copter/source/docs/traditional-helicopter-swashplate-setup.rst
+++ b/copter/source/docs/traditional-helicopter-swashplate-setup.rst
@@ -62,7 +62,7 @@ For the dual heli frame, the fourth servo (Servo 7) on swashplate 1 defaults to 
 Swashplate Types
 ================
 
-- H3 Generic - Allows servo positions and phase angle to be set by user.  Assumes all swashplate ball links are the same distance from the main shaft.
+- H3 Generic - Allows servo positions to be set by user.  Assumes all swashplate ball links are the same distance from the main shaft.
 
 
 - H1 non-CCPM - Servo1 is aileron, Servo 2 is elevator and Servo 3 is collective
@@ -107,6 +107,11 @@ Other swashplates types that can be supported
 
 - H3-90 - Use H4-90.  Don't use one of the servo outputs.
 
+
+Phase Angle Compensation
+=========================
+
+:ref:`H_SW_PHANG<H_SW_PHANG__AP_MotorsHeli_Single>` can be set for any swashplate type to correct control coupling issues, for example if pitching the swash forward also induces an unwanted roll.
 
 Check Proper Swashplate Movement
 ================================


### PR DESCRIPTION
ArduPilot/ardupilot#32437 renamed H_SW_H3_PHANG/H_SW2_H3_PHANG to H_SW_PHANG/H_SW2_PHANG and made phase angle compensation available for every swashplate type, not just H3 Generic.

- traditional-helicopter-swashplate-setup.rst: dropped "and phase angle" from the H3 Generic bullet, added a general Phase Angle Compensation section
- dual-helicopter.rst: moved the phase angle parameter out of each "only needed if H3 Generic" bullet list into a standalone note (4 configurations x 2 swashplates)
- traditional-helicopter-parameter-list.rst: renamed the parameter references and moved them into the general setup lists rather than the H3-only "Custom Swashplate Configuration" section

Verified against the actual PR source (AP_MotorsHeli_Swash.cpp) with a second Codex pass, which confirmed every H_SW_TYPE routes through add_servo_angle() and caught that the parameter-list page still had it misplaced in the H3-only section after the first pass.