### PR TITLE
common: correct DroneCAN pool defaults

### DIFF
--- a/common/source/docs/common-canbus-setup-advanced.rst
+++ b/common/source/docs/common-canbus-setup-advanced.rst
@@ -50,7 +50,7 @@ parameter ``CAN_Px_DRIVER``, where x is the number of the CAN port.
 The value of this parameter is the id of driver that will be associated with this
 port (interface).
 
-Each enabled bus/driver will use a block of RAM memory (not Flash) depending on the type of driver and if CANFD is enabled. For example, DroneCAN will allocate 12KB for its driver (24K if CANFD) by default, but can vary from board to board depending on its defaults, if set by its hardware definition file. The ``CAN_Dx_UC_POOL`` parameter can be used to change the pool size. Required pool size depends on bus traffic required by the attached DroneCAN peripheral and can sometimes be reduced for peripherals such as GPS or Compass, whereas peripherals such as ESCs require more bus traffic and therefore a larger pool size.
+Each enabled bus/driver will use a block of RAM memory (not Flash) depending on the type of driver and if CANFD is enabled. For the DroneCAN driver, the default pool is 8 KB (16 KB when CANFD is enabled). Board hardware definitions can override these defaults. The ``CAN_Dx_UC_POOL`` parameter can be used to change the pool size. Required pool size depends on bus traffic required by the attached DroneCAN peripheral and can sometimes be reduced for peripherals such as GPS or Compass, whereas peripherals such as ESCs require more bus traffic and therefore a larger pool size.
 
 For example, the most common setup will have one driver and all interfaces will be connected
 to it.

--- a/common/source/docs/common-uavcan-setup-advanced.rst
+++ b/common/source/docs/common-uavcan-setup-advanced.rst
@@ -50,7 +50,9 @@ DroneCAN device type is selected by:
 
 DroneCAN Setup Parameters
 =========================
-shown for the first DroneCAN driver, second driver has identical parameters
+The examples below use the first DroneCAN driver (``x=1``). If a second driver is
+enabled, use the corresponding ``CAN_D2_*`` parameters; the same parameter groups
+are available for each driver.
 
 .. image:: ../../../images/uavcan-main-settings.png
     :target: ../_images/uavcan-main-settings.png
@@ -145,7 +147,7 @@ CAN FD (Flexible Data rate)
 
 If the DroneCAN port is attached to CAN FD peripherals, setting :ref:`CAN_D1_UC_OPTION<CAN_D1_UC_OPTION>` bit 2 (+ value 4) will enable this mode. 
 
-.. note:: CAN FD requires a larger memory pool allocation than normal. Default is 24KB instead of the normal 12KB.
+.. note:: CAN FD requires a larger memory pool allocation than normal. The default is 16 KB instead of the normal 8 KB.
 
 .. _dronecan_mixed_protocols:
 


### PR DESCRIPTION
## Summary

Issue #5475 reports that the CAN startup documentation no longer matches the implementation. The documented DroneCAN memory pool sizes were stale, and the parameter group for a second driver was not explicit.

## Changes

- Correct the default DroneCAN pool size from 12 KB to 8 KB.
- Correct the CAN FD default from 24 KB to 16 KB.
- Note that board hardware definitions may override these defaults.
- Clarify that a second driver uses the corresponding `CAN_D2_*` parameters.

## Testing

- `git diff --check`
- Verified the defaults against `libraries/AP_DroneCAN/AP_DroneCAN.cpp` (`DRONECAN_NODE_POOL_SIZE` is 8192 bytes for classic CAN and 16384 bytes for CAN FD).
- Full Sphinx build was not run locally because `sphinx-build` is not available in this environment.

Related to #5475