### PR TITLE
4.8:33947/Simple Mode Fix

### DIFF
--- a/copter/source/docs/autotrim.rst
+++ b/copter/source/docs/autotrim.rst
@@ -66,6 +66,10 @@ Save trim involves essentially transferring your radio transmitter's trims into 
 
 6. Reset your transmitters roll and pitch trims back to the center and fly again and it should fly level now. If it does not repeat steps 3, 4 & 5
 
+.. note::
+
+    Save Trim also works while :ref:`Simple or Super Simple mode <simpleandsuper-simple-modes>` is enabled, but take care not to change the vehicle's heading between landing and switching CH7 high, since the trim will be saved relative to the vehicle's heading at that moment.
+
 Desktop method
 ~~~~~~~~~~~~~~
 

--- a/copter/source/docs/precision-landing-and-loiter.rst
+++ b/copter/source/docs/precision-landing-and-loiter.rst
@@ -75,6 +75,8 @@ ArduPilot's EKF assumes the landing target is stationary. Set :ref:`PLND_OPTIONS
 
 Repositioning manually by the pilot during the landing will abort the landing unless :ref:`PLND_OPTIONS <PLND_OPTIONS>` bit 1 (Allow Precision Landing after manual reposition)is set.
 
+If :ref:`Simple or Super Simple mode <simpleandsuper-simple-modes>` is enabled, the pilot's manual reposition roll/pitch input during landing is rotated the same way it is in other modes.
+
 Final landing speed may be reduced below :ref:`LAND_SPD_MS<LAND_SPD_MS>` as necessary to assure a precise touchdown.
 This can be disabled for a faster final land speed by setting :ref:`PLND_OPTIONS <PLND_OPTIONS>` bit 2.
 

--- a/copter/source/docs/simpleandsuper-simple-modes.rst
+++ b/copter/source/docs/simpleandsuper-simple-modes.rst
@@ -19,8 +19,8 @@ way the vehicle is facing and for cases when the copter is far enough
 away that it's heading is not apparent.
 
 -  "Simple" and "Super Simple" modes can be used in combination with
-   nearly all flight modes except the Acro and Drift (in these flight
-   modes the setting is ignored).
+   nearly all flight modes except Acro (in this flight mode the setting
+   is ignored).
 -  Simple Mode allows you to control the copter relative to the copters
    heading at take off and relies only on a good compass heading.
 -  Super Simple Mode allows you to control the copter relative to it's


### PR DESCRIPTION
Documents ardupilot PR https://github.com/ArduPilot/ardupilot/pull/33947, which fixes a bug where the Simple/Super Simple mode roll/pitch rotation was computed but silently discarded in most flight modes (a regression from the 4.7.0 SI-units migration), and consolidates the transform into the shared pilot-input helpers.

As a result:
- Drift mode now picks up Simple/Super Simple mode support, so it's removed from the "not supported" list on the Simple/Super Simple Modes page.
- Save Trim is confirmed to work while Simple/Super Simple mode is enabled, with a caution about not changing heading between landing and saving.
- Precision Landing's manual reposition input is now rotated too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)