### PR TITLE
Copter: point auxiliary switch docs at common-auxiliary-functions

### DIFF
--- a/copter/source/docs/autotrim.rst
+++ b/copter/source/docs/autotrim.rst
@@ -20,7 +20,7 @@ With AHRS AutoTrim the roll and pitch corrections are captured as you fly in a s
 .. image:: ../images/MP_SaveTrim_Ch7PWMCheck.png
     :target: ../_images/MP_SaveTrim_Ch7PWMCheck.png
 
-2. Set the CH7 Option to "AHRS AutoTrim" on the Software > Copter Pids screen and press the "Write Params" button.
+2. Set your chosen channel's ``RCx_OPTION`` to "AHRS AutoTrim" (182) using Mission Planner's Aux Function screen and press the "Write Params" button. See :ref:`common-auxiliary-functions` for details on assigning options to any RC channel.
 
 3. Find a wind free environment with sufficient space to fly your copter without crashing into something.
 
@@ -53,7 +53,7 @@ Save trim involves essentially transferring your radio transmitter's trims into 
 .. image:: ../images/MP_SaveTrim_Ch7PWMCheck.png
     :target: ../_images/MP_SaveTrim_Ch7PWMCheck.png
 
-2. Set the RC7 Option to Save Trim in the Config > Extended Tuning screen and press the "Write Params" button
+2. Set your chosen channel's ``RCx_OPTION`` to "Save Trim" (5) using Mission Planner's Aux Function screen and press the "Write Params" button. See :ref:`common-auxiliary-functions` for details on assigning options to any RC channel.
 
 .. image:: ../images/MP_SaveTrim_Ch7.png
     :target: ../_images/MP_SaveTrim_Ch7.png

--- a/copter/source/docs/simpleandsuper-simple-modes.rst
+++ b/copter/source/docs/simpleandsuper-simple-modes.rst
@@ -27,7 +27,7 @@ away that it's heading is not apparent.
    direction from home (i.e. where it was armed) but requires a good GPS
    position.
 -  Either mode can be assigned to a particular flight mode switch
-   position or can be enabled/disabled from the :ref:`Ch7/Ch8 switches <channel-7-and-8-options>`.
+   position or can be enabled/disabled from an :ref:`auxiliary function switch <common-auxiliary-functions>`, on any available RC channel.
 
 ..  youtube:: iGA6D2GBFIc
     :width: 100%


### PR DESCRIPTION
channel-7-and-8-options.rst is explicitly marked deprecated/archived ("3.6 and earlier"), but autotrim.rst and simpleandsuper-simple-modes.rst still linked to it (or used hardcoded CH7-only Mission Planner screen names) as if it were the current auxiliary function docs. Any RCx_OPTION can now be assigned to any RC channel, not just CH7/CH8.

- Redirects those two remaining stale references to common-auxiliary-functions.
- Drops outdated Mission Planner screen names ("Software > Copter Pids", "Config > Extended Tuning") in autotrim.rst in favor of the current Aux Function screen.

Note: this PR originally also touched 7 other pages with the same stale link, but those were already fixed upstream in fb0b061c8 while this branch was in flight, so this has been rebased down to just the two files that fix didn't cover. common-prearm-safety-checks.rst's "Ch7&Ch8 Opt cannot be same" message is intentionally left pointing at the archived page per that commit's reasoning (it can still surface on older firmware using the deprecated CH7_OPT/CH8_OPT params).

Not tied to any unreleased firmware, so no delay-merge label needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)