### PR TITLE
common: future-wiki-changes: list Copter Simple mode fix

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -49,6 +49,7 @@ New Features
 - Ability to abort flip using aux switch low, see https://github.com/ArduPilot/ardupilot_wiki/pull/7759
 - Pilot yaw input now also gates during landing (LAND_REPOSITION), see https://github.com/ArduPilot/ardupilot_wiki/pull/7879
 - MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET mission command (point gimbal at next waypoint with an offset), see https://github.com/ArduPilot/ardupilot_wiki/pull/7920
+- Simple/Super Simple mode fix: rotation now correctly applied in more flight modes, including Drift mode and during Precision Landing reposition, see https://github.com/ArduPilot/ardupilot_wiki/pull/7967
 [/site]
 [site wiki="rover"]
 


### PR DESCRIPTION
Adds the Simple/Super Simple mode fix (documented in #7967) to the Copter New Features list on the Future Wiki Changes page.

Not tied to any unreleased firmware itself (this page tracks what's coming), so no delay-merge label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)