### PR TITLE
4.8:33984/DAKEFPV IMU update

### DIFF
--- a/common/source/docs/common-dakefpvf405.rst
+++ b/common/source/docs/common-dakefpvf405.rst
@@ -12,7 +12,7 @@ Features
 ========
 
 * MCU - STM32F405 32-bit processor. 1024Kbytes Flash
-* IMU - Dual ICM42688
+* IMU - ICM42688/LSM6DSV/BMI270
 * Barometer - SPL06
 * OSD - AT7456E
 * Onboard Flash: 16MByte

--- a/common/source/docs/common-dakefpvh743pro.rst
+++ b/common/source/docs/common-dakefpvh743pro.rst
@@ -9,7 +9,7 @@ The DAKEFPV H743/H743 Pro are flight controllers produced by `DAKEFPV <https://w
 Features
 ========
 * MCU - STM32H743 32-bit processor running at 480 MHz
-* IMU - Dual ICM42688
+* IMU - Dual ICM42688/LSM6DSV/BMI270
 * Barometer - SPL06
 * OSD - AT7456E
 * Onboard Flash: 16MByte


### PR DESCRIPTION
Update the IMU line on the DAKEFPVF405 and DAKEFPVH743Pro pages to reflect the new LSM6DSV and BMI270 alternate-part IMU probes, and correct the F405 page's inaccurate 'Dual' IMU count.

ardupilot PR: https://github.com/ArduPilot/ardupilot/pull/33984