### PR TITLE
common: future-wiki-changes: list Agam MegH7, FlyFishRC F405, Lectron Pi5

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -24,6 +24,9 @@ New Board Support
 - SimpliFly H7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7915
 - AET-H743-Air, see https://github.com/ArduPilot/ardupilot_wiki/pull/7918
 - CUAV-X25-MEGA, see https://github.com/ArduPilot/ardupilot_wiki/pull/7944
+- Agam MegH7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7974
+- FlyFishRC F405, see https://github.com/ArduPilot/ardupilot_wiki/pull/7985
+- Lectron Pi5, see https://github.com/ArduPilot/ardupilot_wiki/pull/7976
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
List the new boards added in this batch under New Board Support:
- Agam MegH7: https://github.com/ArduPilot/ardupilot_wiki/pull/7974
- FlyFishRC F405: https://github.com/ArduPilot/ardupilot_wiki/pull/7975
- Lectron Pi5: https://github.com/ArduPilot/ardupilot_wiki/pull/7976