### PR TITLE
4.8:32722/DO_JUMP-counter-reset

### DIFF
--- a/dev/source/docs/mavlink-mission-upload-download.rst
+++ b/dev/source/docs/mavlink-mission-upload-download.rst
@@ -110,3 +110,91 @@ The example commands below can be copy-pasted into MAVProxy (aka SITL) to test t
 +------------------------------------------------------+---------------------------+
 | ``message COMMAND_LONG 0 0 193 0 1 0 0 0 0 0 0``     | continue / resume mission |
 +------------------------------------------------------+---------------------------+
+
+Resetting DO_JUMP Counters with MAV_CMD_DO_SET_MISSION_CURRENT
+----------------------------------------------------------------
+
+Each `DO_JUMP <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_JUMP>`__ mission item has a repeat counter that decrements each time it runs, so that it eventually stops jumping once its repeat count is used up.  These counters can be reset back to their original values, without changing the vehicle's current mission item, by sending a `COMMAND_LONG <https://mavlink.io/en/messages/common.html#COMMAND_LONG>`__ with the command, param1 and param2 fields set as specified for the `MAV_CMD_DO_SET_MISSION_CURRENT <https://mavlink.io/en/messages/common.html#MAV_CMD_DO_SET_MISSION_CURRENT>`__ command.
+
+.. raw:: html
+
+   <table border="1" class="docutils">
+   <tbody>
+   <tr>
+   <th>Command Field</th>
+   <th>Type</th>
+   <th>Description</th>
+   </tr>
+   <tr>
+   <td><strong>target_system</strong></td>
+   <td>uint8_t</td>
+   <td>System ID</td>
+   </tr>
+   <tr>
+   <td><strong>target_component</strong></td>
+   <td>uint8_t</td>
+   <td>Component ID of flight controller or just 0</td>
+   </tr>
+   <tr>
+   <td><strong>command</strong></td>
+   <td>uint16_t</td>
+   <td>MAV_CMD_DO_SET_MISSION_CURRENT=224</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>confirmation</strong></td>
+   <td>uint8_t</td>
+   <td>0</td>
+   </tr>
+   <tr>
+   <td><strong>param1</strong></td>
+   <td>float</td>
+   <td>mission item sequence number to set as current, or -1 to leave the current mission item unchanged</td>
+   </tr>
+   <tr>
+   <td><strong>param2</strong></td>
+   <td>float</td>
+   <td>1: reset the DO_JUMP repeat counters back to their original values, 0: leave the counters unchanged</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param3</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param4</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param5</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param6</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   <tr style="color: #c0c0c0">
+   <td><strong>param7</strong></td>
+   <td>float</td>
+   <td>not used</td>
+   </tr>
+   </tbody>
+   </table>
+
+.. note::
+
+    Prior to ArduPilot 4.8, the DO_JUMP counters could only be reset by also setting the current mission item (param1).  This forced a choice between resetting the counters and leaving the vehicle's position in the mission untouched.  Setting param1 to -1 removes that restriction.
+
+**Example**
+
+The example commands below can be copy-pasted into MAVProxy (aka SITL) to test this command.  Before running these commands enter, "module load message"
+
++--------------------------------------------------+----------------------------------------------------------+
+| Example MAVProxy/SITL Command                    | Description                                              |
++==================================================+==========================================================+
+| ``message COMMAND_LONG 0 0 224 0 -1 1 0 0 0 0 0``| reset DO_JUMP counters, current mission item unchanged   |
++--------------------------------------------------+----------------------------------------------------------+
+| ``message COMMAND_LONG 0 0 224 0 2 1 0 0 0 0 0`` | set current mission item to #2 and reset DO_JUMP counters|
++--------------------------------------------------+----------------------------------------------------------+


### PR DESCRIPTION
Documents the mission jump-counter reset behavior added in ArduPilot/ardupilot#32722.

Adds a new section to `dev/source/docs/mavlink-mission-upload-download.rst`, styled after the existing MAV_CMD_DO_PAUSE_CONTINUE section, covering:

- `MAV_CMD_DO_SET_MISSION_CURRENT` param1 = -1 now means "leave current mission item unchanged"
- param2 = 1 resets the DO_JUMP repeat counters back to their initial values, independent of whether the current item is also being changed
- a MAVProxy `message COMMAND_LONG` example for both use cases

Verified with a local Sphinx build of the `dev` site (clean, no warnings).