### PR TITLE
add FlyFishRC F405 to upcoming

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -24,6 +24,7 @@ New Board Support
 - SimpliFly H7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7915
 - AET-H743-Air, see https://github.com/ArduPilot/ardupilot_wiki/pull/7918
 - CUAV-X25-MEGA, see https://github.com/ArduPilot/ardupilot_wiki/pull/7944
+- FlyFishRC F405, see https://github.com/ArduPilot/ardupilot_wiki/pull/7985
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
Lists the FlyFishRC F405 under New Board Support, pointing at #7985
which adds the board page.

Relevant to #7475