### PR TITLE
common: imu-notch-filtering: fix setup-flow ordering and stale cross-links

### DIFF
--- a/common/source/docs/common-imu-fft-advanced-setup.rst
+++ b/common/source/docs/common-imu-fft-advanced-setup.rst
@@ -27,7 +27,7 @@ Instantaneous FFT's can suffer from noise and one way to reduce the noise is to 
 Post Configuration Flight and Post-Flight Analysis
 ==================================================
 
-With the dynamic harmonic notch configured perform another stable hover to check that the motor noise peak has been :ref:`eliminated <common-imu-notch-filtering-post-configuration-flight-and-post-flight-analysis>`. It is also important to check that the autopilot is not overloaded for the FFT length being used. Graph PM.Load and PM.NLon. PM.Load ideally should be below 60% and PM.NLon in the low 10's - although experimentation shows that it is possible to fly a Pixracer with an FFT length of 128 and CPU load of 90% without instability.
+With the dynamic harmonic notch configured perform another stable hover to check that the motor noise peak has been :ref:`eliminated <common-raw-imu-logging-post-configuration-flight>` (or, on slower autopilots, using the older :ref:`IMU Batch Sampler <common-imu-notch-filtering-post-configuration-flight-and-post-flight-analysis>` method). It is also important to check that the autopilot is not overloaded for the FFT length being used. Graph PM.Load and PM.NLon. PM.Load ideally should be below 60% and PM.NLon in the low 10's - although experimentation shows that it is possible to fly a Pixracer with an FFT length of 128 and CPU load of 90% without instability.
 
 Other points to check:
 

--- a/common/source/docs/common-imu-notch-filtering-helicopter-setup.rst
+++ b/common/source/docs/common-imu-notch-filtering-helicopter-setup.rst
@@ -5,7 +5,7 @@
 Traditional Helicopter Notch Filter Setup
 =========================================
 
-Perform the :ref:`Determination of Noise Frequencies <common-imu-notch-filtering-flight-and-post-flight-analysis>` analysis explained in the Throttle based setup section. From the FFT you should see spikes at the frequency of your rotor speed in Hz (RPM/60) and harmonics of that frequency.  In the image below, the rotor speed is 25hz.  Note that the next two biggest spikes occur at 50 Hz and 100 Hz.
+Determine the rotor noise frequencies using :ref:`Raw IMU Logging <common-raw-imu-logging-determination-flight>` (or, on slower autopilots, the older :ref:`IMU Batch Sampler <common-imu-notch-filtering-flight-and-post-flight-analysis>` method). From the FFT you should see spikes at the frequency of your rotor speed in Hz (RPM/60) and harmonics of that frequency.  In the image below, the rotor speed is 25hz.  Note that the next two biggest spikes occur at 50 Hz and 100 Hz.
 
 .. image:: ../../../images/imu-batchsampling-fft-mp3.png
     :target:  ../_images/imu-batchsampling-fft-mp3.png
@@ -44,4 +44,4 @@ First, ensure that the RPM 1 data is valid and scaled to the rotor speed using t
 Checking Harmonic Notch Effectiveness
 =====================================
 
-After setting up the harmonic notch, the effect on the control signal data can be checked using the instructions for :ref:`common-imu-notch-filtering-post-configuration-flight-and-post-flight-analysis`.
+After setting up the harmonic notch, the effect on the control signal data can be checked using the instructions for :ref:`Raw IMU Logging <common-raw-imu-logging-post-configuration-flight>` (or, on slower autopilots, the older :ref:`IMU Batch Sampler <common-imu-notch-filtering-post-configuration-flight-and-post-flight-analysis>` method).

--- a/common/source/docs/common-imu-notch-filtering.rst
+++ b/common/source/docs/common-imu-notch-filtering.rst
@@ -27,9 +27,9 @@ For the gyro based rate controllers, this reduces their ability to respond to fa
 Notch Filter Setup Overview
 ===========================
 
+#. :ref:`Enable the notch filter<notch_enable>`. This makes the mode-specific setup parameters visible after a reboot.
 #. Select how the notch center frequency will be controlled. See :ref:`center_freq_control`.
 #. If a static notch (not usually recommended), or :ref:`throttle-based<common-imu-notch-filtering-throttle-based-setup>` control is used, the dominant noise frequencies will need to be determined in order to setup the notch. See :ref:`notch_center_freq`.
-#. :ref:`Enable the notch filter<notch_enable>`.
 #. Setup the selected center frequency control method using :ref:`INS_HNTCH_MODE <INS_HNTCH_MODE>`. Then setup its associated parameters by reading its associated page linked in this section :ref:`center_freq_control`.
 #. After a test flight and log analysis with the notch enabled (See :ref:`notch_check`), the :ref:`number and placement of higher harmonic filters implemented can be adjusted <notch_harmonics>`, the use of the :ref:`multi-notch options<notch_options>`, or even a second harmonic notch set (:ref:`INS_HNTC2_ENABLE<INS_HNTC2_ENABLE>`) can be configured to improve noise reduction effectiveness. The web based `Filter Review Tool <https://firmware.ardupilot.org/Tools/WebTools/FilterReview/>`__ can be used to experiment with parameter changes based on the test flight log to determine best configurations without having to make iterative test flights.
 
@@ -130,4 +130,6 @@ The software notch filters used are very "spikey" being relatively narrow but go
     ESC Telemetry<common-esc-telem-based-notch>
     In-Flight FFT <common-imu-fft>
     Traditional Heli Notch Filter Setup<common-imu-notch-filtering-helicopter-setup>
+    Determining Noise Frequencies: Raw IMU Logging <common-raw-imu-logging>
+    Determining Noise Frequencies: IMU Batch Sampler <common-imu-batchsampling>
 

--- a/common/source/docs/common-raw-imu-logging.rst
+++ b/common/source/docs/common-raw-imu-logging.rst
@@ -15,12 +15,18 @@ Filter Setup Process
 
 #. Select the method that will be used for dynamically adjusting the notch(s) center frequency and do any required setup, ie if :ref:`ESC telemetry<common-esc-telemetry>` will be used make sure its setup, if Throttle based make sure your motor voltage compensation is setup (see ``Q_M_BATT_x`` params for QuadPlane or ``MOT_BAT_x`` params for Copter).
 #. :ref:`INS_RAW_LOG_OPT<INS_RAW_LOG_OPT>`: any bits set will enable raw IMU logging.  To prevent overloading the logging, especially on slower autopilot CPUs, set :ref:`INS_RAW_LOG_OPT<INS_RAW_LOG_OPT>` bit 0 and bit 3 (value = "9"). This will restrict logging to the primary gyro and log both pre and post filtering.
-#. Perform a regular flight (not just a gentle hover) of at least 30sec and :ref:`download the dataflash logs <common-downloading-and-analyzing-data-logs-in-mission-planner>`.
+#. .. _common-raw-imu-logging-determination-flight:
+
+   Perform a regular flight (not just a gentle hover) of at least 30sec and :ref:`download the dataflash logs <common-downloading-and-analyzing-data-logs-in-mission-planner>`.
+
 #. Using the `Filter Review tool <https://firmware.ardupilot.org/Tools/WebTools/FilterReview/>`__ load the log. Select a steady hover portion of the log and press "Calculate". Then you can enable one or both of the filters in the tool and experiment with the parameters(refer back to the :ref:`common-imu-notch-filtering` page for details of what each parameter means) to get the lowest noise in the estimated post-filter spectrum, especially in the lower frequencies of the control band (0-40Hz). Remember that each additional harmonic filter adds cpu computational load. Usually only two or three per filter will be sufficient.
 
 .. note:: if the FilterReview tool complains that not enough data is in the log, this usually means that logging has not been able to keep up and has dropped some packets. Either reduce the FFT window size to 512 from 1024, or, preferably, try just clearing the pre and post logging option in :ref:`INS_RAW_LOG_OPT<INS_RAW_LOG_OPT>` and retry the test flight to log only the input noise and use the estimated post-filter trace to setup the filters.
 
 #. Save those parameters and load them into the autopilot.
-#. Do another flight to confirm the filter setup. This this flight more normal flight maneuvers can be done.
+#. .. _common-raw-imu-logging-post-configuration-flight:
+
+   Do another flight to confirm the filter setup. This this flight more normal flight maneuvers can be done.
+
 #. Once verified, clear the :ref:`INS_RAW_LOG_OPT<INS_RAW_LOG_OPT>` parameter to avoid large logs from being saved unnecessarily.
 [copywiki destination="copter,plane,rover,dev,sub,planner"]


### PR DESCRIPTION
Fixes #7986

The Notch Filter Setup Overview listed steps out of order relative to the page's own sections (select method / determine frequency before the Enable step that actually reveals the relevant parameters), and the pages needed to determine noise frequencies (Raw IMU Logging, IMU Batch Sampler) lived only under the unrelated Logging section, disconnected from the notch filter setup flow.

- Reorder the Overview so Enable is step 1, matching the page's actual section order.
- Add Raw IMU Logging and IMU Batch Sampler as toctree children so they're reachable from the setup flow itself.
- Add anchors to Raw IMU Logging's determination and post-configuration-confirmation flight steps, and point the Traditional Heli and In-Flight FFT advanced setup pages at them (falling back to the legacy Batch Sampler anchors for slower autopilots) instead of only linking the legacy method.
- Fix the heli setup page's claim that its noise-frequency determination step is "explained in the Throttle based setup section" -- that section actually links to Raw IMU Logging, not the anchor this page pointed to.

## Test plan
- [x] Full copter-site Sphinx build with no new warnings
- [x] Verified new anchors resolve and are linked correctly from the Traditional Heli and FFT Advanced Setup pages