### PR TITLE
dev: archive the Morse, SCRIMMAGE and AirSim simulator pages

### DIFF
--- a/common/source/docs/common-archived-topics.rst
+++ b/common/source/docs/common-archived-topics.rst
@@ -127,6 +127,9 @@ value to users with old hardware.
     SITL Serial Mapping <sitl-serial-mapping>
     2020/2021 Roadmap <roadmap>
     Trouble Shooting Pixhawk4 Boot <troubleshooting-pixhawkpx4-boot>
+    AirSim Simulator <sitl-with-airsim>
+    Morse Simulator <sitl-with-morse>
+    SCRIMMAGE Simulator <sitl-with-scrimmage>
 [/site]
 [site wiki="copter,rover"]
 .. toctree::

--- a/dev/source/docs/simulation-2.rst
+++ b/dev/source/docs/simulation-2.rst
@@ -35,10 +35,8 @@ The most commonly used simulators are:
 -  :ref:`XPlane-10 <sitl-with-xplane>` a commercial flight simulator with a rich 3D interface   
 -  :ref:`XPlane-10 Soaring<soaring-sitl-with-xplane>` soaring on XPlane-10
 -  :ref:`RealFlight <sitl-with-realflight>` a commercial flight simulator with a rich 3D interface and ability to design custom vehicles
--  :ref:`Morse <sitl-with-morse>` a robotics simulation environment commonly used in research
 -  :ref:`Replay <testing-with-replay>` has no graphical interface but allows re-running master from a dataflash log
 -  :ref:`JSBSim <sitl-with-jsbsim>` is a sophisticated open-source plane and multicopter simulator with no graphical interface. It can be used with a wide variety of airframes.
--  :ref:`AirSim <sitl-with-airsim>` is an open-source, cross-platform simulator for drones & cars, built on Unreal Engine for physically and visually realistic simulations
 -  :ref:`PteroSim <sitl-with-pterosim>` is a UAV simulator built on Unreal Engine, providing 6-DOF flight dynamics and simulated sensors
 -  :ref:`Silent Wings Soaring<soaring-sitl-with-silentwings>` 
 -  :ref:`MATLAB and Simulink<sitl-with-MATLAB>` are numerical computing environments used for developing algorithms and plotting data developed by `MathWorks <https://www.mathworks.com/>`__.
@@ -50,7 +48,6 @@ Less often used simulators include:
 
 -  :ref:`Last Letter <using-last_letter-as-an-external-sitl-simulator>` is a simpler simulator (fixed wing only) with lower CPU requirements than most other simulators.
 -  :ref:`CRRCSim <simulation-2sitl-simulator-software-in-the-loopusing-using-the-crrcsim-simulator>` is a less commonly used simulator for fixed wing and helicopters.
--  :ref:`SCRIMMAGE <sitl-with-scrimmage>` is an open-source vehicle simulator focused on collaborative robotics
 
 List of simulators (so they can appear in the menu):
 
@@ -63,10 +60,8 @@ List of simulators (so they can appear in the menu):
     XPlane-10 <sitl-with-xplane>
     XPlane-10 Soaring<soaring-sitl-with-xplane>
     RealFlight <sitl-with-realflight>
-    Morse <sitl-with-morse>
     Replay <testing-with-replay>
     JSBSim <sitl-with-jsbsim>
-    AirSim <sitl-with-airsim>
     PteroSim <sitl-with-pterosim>
     Silent Wings Soaring<soaring-sitl-with-silentwings>
     Last Letter <using-last_letter-as-an-external-sitl-simulator>
@@ -75,7 +70,6 @@ List of simulators (so they can appear in the menu):
     Autotest Framework <the-ardupilot-autotest-framework>
     Autotest Tests <autotest-tests>
     Unit Tests <unit-tests>
-    SCRIMMAGE <sitl-with-scrimmage>
     Webots <sitl-with-webots>
     MATLAB and Simulink <sitl-with-MATLAB>
     JSON interface <sitl-with-JSON>

--- a/dev/source/docs/sitl-with-airsim.rst
+++ b/dev/source/docs/sitl-with-airsim.rst
@@ -1,12 +1,17 @@
 .. _sitl-with-airsim:
 
-======================
-Using SITL with AirSim
-======================
+================================
+Archived: Using SITL with AirSim
+================================
 
 .. warning::
 
-  This page is archived and is not being maintained anymore. AirSim integration with ArduPilot is still available and supported, but the instructions on this page might be outdated.
+    This topic is archived. Microsoft has archived the upstream AirSim project, and
+    these instructions are no longer maintained or tested against current ArduPilot
+    code. For a simulator built on Unreal Engine, use :ref:`PteroSim <sitl-with-pterosim>`
+    instead; :ref:`Webots <sitl-with-webots>` and :ref:`Gazebo <sitl-with-gazebo>` are
+    the other maintained 3D options. See :ref:`Simulation <simulation-2>` for the full
+    list of supported simulators.
 
 .. youtube:: -WfTr1-OBGQ
    :width: 100%

--- a/dev/source/docs/sitl-with-morse.rst
+++ b/dev/source/docs/sitl-with-morse.rst
@@ -1,8 +1,16 @@
 .. _sitl-with-morse:
 
-=====================
-Using SITL with Morse
-=====================
+===============================
+Archived: Using SITL with Morse
+===============================
+
+.. warning::
+
+    This topic is archived. Morse is no longer maintained, and its
+    ArduPilot simulation backend is no longer tested. Developers wanting a
+    3D robotics simulation environment should use :ref:`Webots <sitl-with-webots>`,
+    :ref:`Gazebo <sitl-with-gazebo>` or :ref:`PteroSim <sitl-with-pterosim>` instead.
+    See :ref:`Simulation <simulation-2>` for the full list of supported simulators.
 
 ..  youtube:: Zk8MYmt03-Q
     :width: 100%
@@ -13,10 +21,6 @@ environment to create a complete robotics platform.
 
 ArduPilot has a Morse SITL simulation backend that allows ArduPilot to
 control vehicles created within Morse.
-
-.. warning::
-
-    Morse is no longer maintained so we recommend developers use :ref:`AirSim <sitl-with-airsim>` or :ref:`Webots <sitl-with-webots>`.
 
 .. note::
 

--- a/dev/source/docs/sitl-with-scrimmage.rst
+++ b/dev/source/docs/sitl-with-scrimmage.rst
@@ -1,12 +1,17 @@
 .. _sitl-with-scrimmage:
 
-===================================
-Using SCRIMMAGE as a SITL simulator
-===================================
+=============================================
+Archived: Using SCRIMMAGE as a SITL simulator
+=============================================
 
 .. warning::
 
-    As for April 2026, this simulation connection hasn't been maintained for a while and may not work with the latest ArduPilot code.
+    This topic is archived. The SCRIMMAGE simulation connection has not been
+    maintained for a long time and may not work with current ArduPilot code.
+    Developers wanting a multi-vehicle simulation environment should use
+    :ref:`Webots <sitl-with-webots>`, :ref:`Gazebo <sitl-with-gazebo>` or
+    :ref:`PteroSim <sitl-with-pterosim>` instead. See :ref:`Simulation <simulation-2>`
+    for the full list of supported simulators.
 
 `Simulating Collaborative Robots in Massive Mulit-Agent Game Execution (SCRIMMAGE) <http://www.scrimmagesim.org/>`__
 provides a flexible simulation environment for the experimentation and testing of novel mobile robotics algorithms.


### PR DESCRIPTION
Fixes #8001.

None of these three belongs in the list of simulators a developer would choose from today:

- **Morse** — no longer maintained, and @rmackay9 reports no known users of the ArduPilot backend for it.
- **SCRIMMAGE** — the connection has not been maintained for a long time; its page already warned it may not work with current ArduPilot code.
- **AirSim** — Microsoft has archived the upstream project. Its page already carried a notice saying it was archived and unmaintained, yet the page was still listed among the *active* simulators and the notice claimed AirSim was "still available and supported".

### What changed

Follows the procedure in `common-wiki-editing-archiving` for all three:

- `Archived:` prefix added to each page title.
- The existing unmaintained notices replaced with a warning saying the topic is archived, pointing at maintained alternatives — Webots, Gazebo, and **PteroSim** where an Unreal Engine based simulator is wanted (which is the natural substitute for AirSim readers).
- All three removed from the simulator lists and the menu toctree on the Simulation page, and added to the `dev` section of Archived Topics — so each page stays in exactly one toctree and remains reachable via Appendix → Archived Topics.

Page content is otherwise untouched, so anyone still running one of these simulators keeps the instructions.

Prose mentions of AirSim in `gsoc-ideas-list` and `roadmap` are left alone — neither is a `:ref:` link, and `roadmap` is itself already archived.

### Questions for @rmackay9

The issue named Morse definitely and said *"We should probably do the same for the SCRIMMAGE simulator"* — I have done both, on the strength of the unmaintained warning already on the SCRIMMAGE page. AirSim was added at @Hwurzburg's request. Happy to drop any of the three if you would rather keep it in the active list.

### Testing

Clean `update.py --fast --site dev` build, zero Sphinx warnings. Verified in the rendered HTML that all three titles carry the Archived prefix, all three appear under Archived Topics, the archive warnings resolve their cross-references, and no references to any of the three remain on the Simulation page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)