### PR TITLE
plane: add airspeed calibration technique notes

### DIFF
--- a/plane/source/docs/calibrating-an-airspeed-sensor.rst
+++ b/plane/source/docs/calibrating-an-airspeed-sensor.rst
@@ -40,6 +40,11 @@ Calibration". You need to loosely cover your airspeed sensor to stop
 wind from affecting the result, then press the button. The calibration
 will take a couple of seconds.
 
+.. tip:: A short piece of foam slipped over the end of the pitot tube is the easiest way to
+   cover it. Foam blocks the wind without sealing the tube, and leaves both hands free to
+   press the calibrate button. Cupping both hands around the tube also works, but makes it
+   awkward to reach the button at the same time.
+
 .. image:: ../images/preflight.jpg
     :target: ../_images/preflight.jpg
 
@@ -51,7 +56,16 @@ pressure and your airspeed sensor.
 Next you should check that your airspeed sensor is working correctly
 before takeoff. To do that you should blow into the airspeed sensor and
 make sure that the "AS" airspeed sensor value in your HUD rises as you
-blow into it.
+blow into it. In *Mission Planner*, airspeed can also be displayed on the
+Flight Data screen's **Quick** tab, which is easier to watch than the HUD
+while you have your face at the pitot tube. Blowing into the tube should
+take the reading to 6 m/s or more; if it barely moves, suspect a blocked,
+leaking or disconnected tube.
+
+.. warning:: An airspeed of exactly 0.0 that sits there on the ground and never deviates is a
+   sign of a problem, not of a well-zeroed sensor. A working sensor shows small fluctuations
+   from air movement and sensor noise, so a permanently perfect zero usually means the sensor
+   is not being read at all.
 
 Calibrating the airspeed sensor gain
 ====================================


### PR DESCRIPTION
Addresses the documentation half of #1208.

That issue asked for a video demonstrating airspeed sensor calibration, and along the way collected practical advice from the team on how to actually do it. The video never got made — but the advice is useful on its own, and has been sitting unpublished in the issue for eight years. This puts it on the page.

Worked into the existing pre-flight and manual calibration text, not added as a separate list:

- **Covering the pitot tube.** A piece of foam over the end blocks the wind without sealing the tube and leaves both hands free for the calibrate button. Cupped hands work too, but make the button awkward to reach.
- **Checking the sensor responds.** Mission Planner's Flight Data → **Quick** tab is easier to watch than the HUD while your face is at the pitot tube, and blowing into it should take the reading to 6 m/s or more. If it barely moves, suspect a blocked, leaking or disconnected tube.
- **A permanent zero is a fault, not a good zero.** An airspeed of exactly 0.0 that never deviates usually means the sensor is not being read at all; a working sensor fluctuates slightly. This is the most valuable of the notes and the least obvious — a new user reads a rock-steady 0.00 as success.

### On the video

@rmackay9 — I'd suggest closing #1208 once this merges rather than holding it open for the video. Plenty of wiki pages could use a video, nobody has picked this one up in eight years, and an open issue whose only remaining content is "someone should film this" doesn't help users find the information. If a video does get made later it can be dropped onto the page without a tracking issue. Happy to leave the issue open instead if you'd rather.

### Testing

Clean `update.py --fast --site plane` build, zero Sphinx warnings. Checked the rendered HTML: the new tip and warning render as admonitions in the intended places.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
