### PR TITLE
common: clarify servo rail powering and require a single rail supply

### DIFF
--- a/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
+++ b/common/source/docs/common-pixhawk-wiring-and-quick-start.rst
@@ -35,6 +35,10 @@ voltage and current analog measurements produced by an optional power
 module. Information about powering the Pixhawk can be found in the topic
 :ref:`Powering the Pixhawk <common-powering-the-pixhawk>`.
 
+Note that powering Pixhawk does **not** power its servo rail. That is a
+separate supply, discussed under :ref:`Connect Motors <pixhawk-quickstart-connect-motors>`
+below.
+
 .. image:: ../../../images/pixhawkpower-port.jpg
     :target: ../_images/pixhawkpower-port.jpg
 
@@ -94,11 +98,52 @@ The topic :ref:`3DR UBlox GPS + Compass Module <common-installing-3dr-ublox-gps-
 shows how to connect to Pixhawk and include additional configuration and
 mounting information.
 
+.. _pixhawk-quickstart-connect-motors:
+
 Connect Motors
 ==============
 
 .. image:: ../../../images/pixhawk_motor_outputs.jpg
     :target: ../_images/pixhawk_motor_outputs.jpg
+
+.. warning::
+
+   Pixhawk does **not** supply power to the servo rail - the MAIN OUT pins
+   carry the signal only. ESCs draw their power from the battery, so
+   multicopter motors will run with just the signal and ground wires
+   connected. Servos will not: a plane's control surfaces, a rover's steering
+   or a gimbal will not move until the rail itself is powered, normally from
+   an ESC's BEC or from a separate BEC.
+
+   Always connect the ground wire alongside an ESC's signal wire. A signal
+   wire must never be left floating without its ground reference.
+
+   Feed the rail from a **single** source. Where several ESCs each have a
+   BEC, leave the power (red) wire connected on only one of them and remove
+   it from the rest. Two supplies wired onto the rail in parallel will fight
+   each other, and some BECs oscillate when driven that way, producing
+   switching noise that can interfere with GPS and RC reception. See
+   :ref:`General wiring recommendations <common-powering-the-pixhawk_general_wiring_recommendations>`
+   for
+   the detail, and for how to combine sources properly if you do want a
+   redundant supply.
+
+.. note::
+
+   How much voltage the servo rail will tolerate, and whether it can also
+   power the autopilot, differs between boards. Always check your board's own
+   page before wiring the rail.
+
+   On the original Pixhawk the servo rail is one of three power inputs, so it
+   can power or back up the board. But it is dangerous to power Pixhawk
+   *only* from the rail: a digital servo can drive the rail above 5.7V, at
+   which point the power selector drops the input, the FMU loses power and
+   the board reboots. Losing the FMU in flight means losing the aircraft. See
+   :ref:`Powering the Pixhawk <common-powering-the-pixhawk>`.
+
+   Most current autopilots do not work this way. Their servo rail is isolated
+   and does not power the autopilot at all, and many accept a far higher rail
+   voltage - up to 36V on some boards - to drive high-voltage servos.
 
 [site wiki="copter"]
 For Copter see :ref:`Connect ESCs and Motors <copter:connect-escs-and-motors>`.

--- a/common/source/docs/common-powering-the-pixhawk.rst
+++ b/common/source/docs/common-powering-the-pixhawk.rst
@@ -108,6 +108,8 @@ power source.
    Looking for a detailed explanation of power wiring with Pixhawk?
    `Click here for more information about connecting ESCs and servos to Pixhawk. <http://pixhawk.org/users/actuators/pwm_escs_and_servos>`__\ 
 
+.. _common-powering-the-pixhawk_general_wiring_recommendations:
+
 General wiring recommendations
 ==============================
 
@@ -133,6 +135,16 @@ General wiring recommendations
    when it is powered off the servo rail. Servos by themselves are not
    quiet enough.
 
+-  Feed the servo rail from a single source. Never wire two supplies onto
+   it in parallel - two ESC BECs, or a separate BEC alongside an ESC's BEC,
+   will never hold exactly the same voltage, so the highest one carries the
+   whole load while the others fight it. Some BECs oscillate when driven
+   that way, and the switching noise that results can interfere with GPS
+   and RC reception. Where several ESCs each have a BEC, leave the power
+   (red) wire connected on only one of them and remove it from the rest. If
+   you need a redundant supply, combine the sources through a diode-OR tie
+   bus rather than paralleling them, as described under
+   :ref:`Advanced power supply configuration <common-powering-the-pixhawk_advanced_power_supply_configuration>`.
 -  Do not connect a BEC power source to the RC IN port (black ground,
    red power and white signal wires from the receiver's PPM output are
    connected to these RC pins)
@@ -146,6 +158,8 @@ General wiring recommendations
    to the diode. The capacitor will smooth out eventual voltage ripples.
    As advised for the diode, the capacitor should be connected with as
    short wires as possible. Do not oversize the capacitor.
+
+.. _common-powering-the-pixhawk_advanced_power_supply_configuration:
 
 Advanced power supply configuration
 ===================================


### PR DESCRIPTION
Fixes #723, open since 2017: "the Pixhawk Wiring QuickStart ... does not make it clear that the servo rail is not powered by default, so your servos would not run". The approach here is the one @auturgy suggested on that issue - a note stating the rail is not powered, linking to Powering the Pixhawk.

Two related gaps in the servo rail documentation.

**1. Powering the autopilot does not power the servo rail.** This regularly surprises users whose servos or gimbal do not move after an otherwise correct wire-up, since multicopter motors *do* run with only signal and ground connected. Adds a forward note in the quick start's power section and a warning under Connect Motors (before the per-vehicle `[site]` blocks, so all sites get it), covering signal-only MAIN OUT pins and the mandatory signal ground.

Because that page is linked as a *general* wiring guide from newer board pages (`common-durandal-overview.rst`, `common-pixhackV5-overview.rst`, and the "Wiring Example using Pixhawk" entry in `common-flight-controller-wiring.rst`), the board-specific part is scoped explicitly rather than written as if it were universal. The original Pixhawk takes the servo rail as one of three power inputs, with the 5.7V selector cutoff that implies; most current autopilots isolate the rail from the autopilot and accept up to 36V, as their own pages already state.

**2. The single-supply rule, which was missing entirely.** Several ESC BECs, or a separate BEC alongside an ESC's BEC, must not be wire-ORed onto the rail. They never hold exactly the same voltage, so the highest one carries the whole load while the others fight it, and some BECs oscillate when driven that way and radiate switching noise into GPS and RC reception. The practical instruction is to leave the red wire on one ESC only.

The full explanation goes under *General wiring recommendations*, immediately next to the existing MBR1545CT tie bus section that already documented the correct way to combine two supplies but was never connected to a plain rule against paralleling them. The quick start carries the short actionable form and links there, rather than duplicating the text across two common pages.

Anchors added for both linked sections, following the page's existing naming convention.

Verified with `python3 update.py --fast --site plane`: both pages rebuild and all four cross-references resolve to real anchors in the output HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
