### PR TITLE
frontend: add Donate to the About menu

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -81,6 +81,7 @@
                         <a class="nav-link dropdown-toggle" href="#" role="button" id="dropdown01" data-bs-toggle="dropdown"
                            aria-expanded="false">ABOUT</a>
                         <ul class="dropdown-menu" aria-labelledby="dropdown01">
+                            <li><a class="dropdown-item" href="https://ardupilot.org/ardupilot/docs/common-donation.html">Donate</a></li>
                             <li><a class="dropdown-item" href="https://ardupilot.org/dev/docs/events.html">Events</a></li>
                             <li><a  class="dropdown-item"
                                href="https://ardupilot.org/dev/docs/common-history-of-ardupilot.html">History</a></li>


### PR DESCRIPTION
Fixes #2252.

The donation page has no route to it from the home page, so anyone wanting to support the project has to already know the page exists. This adds it to the About dropdown:

> **Donate** · Events · History · License · Partners · Schools · Team · Top Contributors · Volunteer

first in the menu's existing alphabetical order.

**Link target.** `/ardupilot/docs/common-donation.html`, matching the base already used by the Partners and Team entries for organisation-level pages. #2252 suggested the `/copter/docs/` URL, which works but reads oddly for a foundation page - `common-donation.rst` copies to all 11 wikis, and I checked that the `/ardupilot/`, `/dev/` and `/copter/` variants all return 200.

**Scope.** One line in `frontend/index.html`. `frontend/404.html` has no nav menu, so there is no second copy to keep in sync. I confirmed against the live https://ardupilot.org/ that its ABOUT dropdown currently matches this file exactly, so the change will appear as intended.

Note that #2252's title asks to make the page "higher profile" - a menu entry is two clicks in, so if something more prominent is wanted (footer or home page body) that would be a separate change on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
