### PR TITLE
common: rangefinder landing page: drop duplicate TFS20L entry

### DIFF
--- a/common/source/docs/common-rangefinder-landingpage.rst
+++ b/common/source/docs/common-rangefinder-landingpage.rst
@@ -70,7 +70,6 @@ Unidirectional Rangefinders
     Avionics Anonymous DroneCAN LIDAR Interface <common-avanon-laserint>
     Benewake TF02-Pro / TF03 / TFS20-L / TF-Luna / TF-Nova / TF350 <common-benewake-tf02-lidar>
     Benewake TFmini / TFmini Plus <common-benewake-tfmini-lidar>
-    Benewake TFS20L <https://en.benewake.com/TFS20L/>
     Garmin Lidar-Lite <common-rangefinder-lidarlite>
     GY-US42 Sonar <common-rangefinder-gy-us42>
     Hexsoon 24G Radar <common-rangefinder-hexsoon-24g>


### PR DESCRIPTION
The rangefinder landing page listed the TFS20-L twice:

```
Benewake TF02-Pro / TF03 / TFS20-L / TF-Luna / TF-Nova / TF350 <common-benewake-tf02-lidar>
Benewake TFmini / TFmini Plus <common-benewake-tfmini-lidar>
Benewake TFS20L <https://en.benewake.com/TFS20L/>
```

The third entry points off site, to benewake.com, for a sensor the wiki already documents on the line two rows above. It sent readers away from the wiki page that carries the actual ArduPilot setup instructions, and gave that sensor family two entries in one list.

Removed. This gets more useful with #8012, which documents the TFS20-L's own I2C driver (`RNGFND1_TYPE` = 46) on the wiki page.

The `Cygbot D1` external link a few lines below is deliberately left alone: no wiki page covers that sensor, so the external link is the only pointer to it and it is doing a job.

Built with `python3 update.py --fast --site copter` - the entry is gone, the Benewake page entry and the Cygbot link are both intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
