### PR TITLE
common: lua: correct the serialLED library documentation

### DIFF
--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -397,7 +397,7 @@ Set the length of the string with the call matching the type of LED attached. In
 
 - :code:`set_num_neopixel_rgb( chan ,  num_leds )` - As above, for a string driven in RGB mode.
 
-- :code:`set_num_profiled( chan ,  num_leds )` - Sets the number of ProfiLEDs in the string, up to 126.  A second output must have SERVOx_FUNCTION = 132 (ProfiLEDClock) assigned, otherwise this call fails.
+- :code:`set_num_profiled( chan ,  num_leds )` - Sets the number of ProfiLEDs in the string, up to 126.  A second output, in the same PWM group, must have SERVOx_FUNCTION = 132 (ProfiLEDClock) assigned, otherwise this call fails.
 
 Then set and send the colours:
 

--- a/common/source/docs/common-lua-scripts.rst
+++ b/common/source/docs/common-lua-scripts.rst
@@ -389,13 +389,21 @@ GCS (gcs:)
 Serial LED (serialLED:)
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-This library allows the control of WS8212B RGB LED strings via an output reserved for scripting and  selected by SERVOx_FUNCTION = 94 thru 109 (Script Out 1 thru 16)
+This library allows the control of RGB LED strings via an output reserved for scripting and  selected by SERVOx_FUNCTION = 94 thru 109 (Script Out 1 thru 16)
 
-- :code:`set_num_LEDs( output_number ,  number_of_LEDs )` - Sets the number_of_LEDs in the string on a servo output. output_number is servo output number 1-16 that the string is attached to with a string having <number_of_LEDs>.
+Set the length of the string with the call matching the type of LED attached. In each case :code:`chan` is the servo output number, 1 to 16, that the string is attached to. All three return true on success.
 
-- :code:`set_RGB( output_number ,  LED_number ,  r , g , b )` - Set the data for LED_number (1-32) on the string attached servo output_number (1-16) output to the r,g,b values (0-255)
+- :code:`set_num_neopixel( chan ,  num_leds )` - Sets the number of NeoPixels in the string, up to 128.
 
-- :code:`send()` - Sends the data to the LED strings
+- :code:`set_num_neopixel_rgb( chan ,  num_leds )` - As above, for a string driven in RGB mode.
+
+- :code:`set_num_profiled( chan ,  num_leds )` - Sets the number of ProfiLEDs in the string, up to 126.  A second output must have SERVOx_FUNCTION = 132 (ProfiLEDClock) assigned, otherwise this call fails.
+
+Then set and send the colours:
+
+- :code:`set_RGB( chan ,  led_index ,  red , green , blue )` - Set the colour of one LED on the string attached to output :code:`chan`.  :code:`led_index` counts from 0, and -1 sets every LED in the string.  The colour values are 0 to 255.
+
+- :code:`send( chan )` - Sends the configured values to the LED string on output :code:`chan`.
 
 
 Notify (notify:)


### PR DESCRIPTION
The `serialLED:` section of the Lua bindings page documented an API that no longer exists. A script written from it would not run.

| Page said | Actually |
|---|---|
| `set_num_LEDs( output_number , number_of_LEDs )` | no such function - it is `set_num_neopixel()`, `set_num_neopixel_rgb()` or `set_num_profiled()`, depending on LED type |
| `set_RGB( ... )` with `LED_number (1-32)` | `led_index` is **zero based**, `-1` sets the whole string, and the limit is not 32 |
| `send()` | `send( chan )` - it takes the output channel |
| "WS8212B RGB LED strings" | any RGB string: NeoPixel, NeoPixel RGB or ProfiLED |

The zero-based indexing is the one most likely to bite: a script following the old page would silently skip the first LED and run one off the end.

## The 32 LED limit

Lifting it is the outstanding checkbox on #2783 ("changed LED scripting API to allow more than 32 LEDs on a pin"). `AP_SERIALLED_MAX_LEDS` is **128**, but not uniformly - `set_num_neopixel()` and `set_num_neopixel_rgb()` accept the full 128, while `set_num_profiled()` is capped at 126 (`AP_SERIALLED_MAX_LEDS - 2`), since ProfiLED reserves two for framing. Both figures are documented rather than quoting a single number.

## Also added

`set_num_profiled()` returns false unless an output has `SERVOx_FUNCTION` = 132 (ProfiLEDClock) assigned - it checks `function_assigned(k_ProfiLED_Clock)` and bails out. That was not mentioned anywhere and is easy to hit. The function label is taken from generated `apm.pdef.xml` so it matches the GCS dropdown.

## Verification

Checked against `libraries/AP_Scripting/docs/docs.lua` (signatures and the `led_index` semantics), `libraries/AP_SerialLED/AP_SerialLED.cpp` (the limits and the clock check), and `libraries/AP_Scripting/generator/description/bindings.desc` (the declared argument ranges).

Built with `python3 update.py --fast --site copter`.

Note this does not close #2783 - its other remaining item is the R9Pilot autopilot, which has an hwdef in ArduPilot but no wiki page and no README.md in its hwdef directory, so that one needs board information rather than an edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
