### PR TITLE
4.8:33883/HGLRC H743 EVO

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -143,6 +143,7 @@ Closed Hardware
     GEPRC Taker H743 BT <common-geprc-taker-h743-bt>
     GreenSightUltraBlue <common-greensightultrablue>
     HeeWing F405/F405V2 <common-heewingf405>
+    HGLRC H743 EVO <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/HGLRC_H743_EVO/README.md>
     Holybro Kakute F4 <common-holybro-kakutef4>
     Holybro Kakute F4 Mini <common-holybro-kakutef4-mini>
     Holybro Kakute F7 AIO <common-holybro-kakutef7aio>


### PR DESCRIPTION
Adds the HGLRC H743 EVO to the Closed Hardware list in `common-autopilots.rst`, linking to the board's README.md in the ardupilot repo.

New board support added by ArduPilot/ardupilot#33883 (merged 2026-08-19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)