### PR TITLE
4.8:33349/NWBlue Pro H757

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -207,6 +207,7 @@ Closed Hardware
     MUPilot <common-MUPilot>
     NarinFC-H7/H5 <common-NarinFC-H7>
     NarinFC-X3 <common-NarinFC-X3>
+    NWBlue Pro H757 <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/NWBLUE_PROH757/README.md>
     NxtPX4v2 <common-NxtPX4v2>
     Omnibus F4 AIO/Pro <common-omnibusf4pro>
     OmnibusNanoV6 <common-omnibusnanov6>


### PR DESCRIPTION
Adds the NWBlue Pro H757 to the Closed Hardware list in `common-autopilots.rst`, linking to the board's README.md in the ardupilot repo.

New board support added by ArduPilot/ardupilot#33349 (merged 2026-08-26). The board is a 30x30mm multirotor controller built around the CubePilot CubeNode H7 module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)