### PR TITLE
common: future-wiki-changes: list HGLRC H743 EVO and NWBlue Pro H757

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -27,6 +27,8 @@ New Board Support
 - Agam MegH7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7974
 - FlyFishRC F405, see https://github.com/ArduPilot/ardupilot_wiki/pull/7985
 - Lectron Pi5, see https://github.com/ArduPilot/ardupilot_wiki/pull/7976
+- HGLRC H743 EVO, see https://github.com/ArduPilot/ardupilot_wiki/pull/8016
+- NWBlue Pro H757, see https://github.com/ArduPilot/ardupilot_wiki/pull/8017
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
Lists the two new boards added in this batch on the "what's coming" page, each pointing at its own board PR:

- HGLRC H743 EVO (ArduPilot/ardupilot#33883) → ArduPilot/ardupilot_wiki#8016
- NWBlue Pro H757 (ArduPilot/ardupilot#33349) → ArduPilot/ardupilot_wiki#8017

🤖 Generated with [Claude Code](https://claude.com/claude-code)