### PR TITLE
common: clarify DisplayPort UART DMA note

### DIFF
--- a/common/source/docs/common-displayport.rst
+++ b/common/source/docs/common-displayport.rst
@@ -7,7 +7,7 @@ DisplayPort, is an MSP protocol extension that allows an autopilot to remotely d
 
 HDZero, Walksnail, and DJI with WTF-OSD modifications are capable of DisplayPort operation.
 
-.. note:: on F4 based autopilots, with extremely crowded OSDs (ie many panels), it is possible that if the UART used does not have DMA, that display corruption, artifacts, etc. can occur. In this rare case, move the DisplayPort connection to a UART that does have DMA.
+.. note:: on F4 and F7 based autopilots, with extremely crowded OSDs (ie many panels), it is possible that if the UART used does not have DMA, that display corruption, artifacts, etc. can occur. In this rare case, try moving the DisplayPort connection to a UART that does have DMA. Be aware that this may or may not help: a UART listed as DMA capable will still not use DMA if its DMA channel is shared with another peripheral on that board, and which UARTs this affects varies from board to board. You can check what is actually being used by opening ``@SYS/uarts.txt`` over MAVFtp - a ``*`` immediately after the ``TX`` of a port's line means transmit DMA is in use on that port, and a blank means it is not.
 
 Features
 --------


### PR DESCRIPTION
The DisplayPort note advises moving the connection to a UART that has DMA. That is right as far as it goes, but a UART can have a DMA channel and still not use it: `AP_HAL_ChibiOS/UARTDriver.cpp` disables transmit DMA on any port whose DMA stream is shared with another peripheral when the baudrate is 115200 or below, and DisplayPort is always 115200. Moving the connection to such a UART changes nothing, and there is no way for a user to tell from the hwdef or the parameters which UARTs are affected, since it depends on how the DMA resolver allocated streams for that specific board.

So the note now says the remedy may or may not help, and points at `@SYS/uarts.txt`. That file is generated from `tx_dma_enabled` itself, so it reports the effective state after the shared-stream disable has been applied - a `*` after `TX` means transmit DMA really is in use on that port. That gives the user something to check rather than leaving it to trial and error.

The scope is also widened from F4 to F4 and F7. The hardware USART FIFO that keeps this from biting is gated on `USART_CR1_FIFOEN`, which exists only on H7 and G4; F7 has no FIFO and shares F4's exposure to the same truncation. F7 boards have more DMA streams so they are less likely to run short, but the failure mode is the same.

No change to the underlying advice or to the described symptom.