### PR TITLE
copter: unlink GND_EFFECT_COMP ref to fix build

### DIFF
--- a/copter/source/docs/ground-effect-compensation.rst
+++ b/copter/source/docs/ground-effect-compensation.rst
@@ -11,7 +11,7 @@ If your vehicle is not suffering from the bounce on landing it's best to leave t
 Setup
 =====
 
-Connect to the autopilot using your ground station (i.e. Mission Planner) and set the :ref:`GND_EFFECT_COMP <GND_EFFECT_COMP>` parameter to "1".
+Connect to the autopilot using your ground station (i.e. Mission Planner) and set the ``GND_EFFECT_COMP`` parameter to "1".
 
 Video
 =====


### PR DESCRIPTION
GND_EFFECT_COMP was removed from master by ArduPilot/ardupilot#32472 (merged 2026-09-01), which folds it into the new `GNDEFF_ALT` / `GNDEFF_TMO` parameters. The `:ref:` on the Ground Effect Compensation page no longer resolves and the build errors on it.

This just drops the link to literal markup so the wiki builds again. The page still needs a proper rewrite for the new parameters and the changed default (compensation is now on by default via `GNDEFF_ALT=0.5`) — that is on the 4.8 doc list for the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)