### PR TITLE
common: future wiki changes: drop boards already on the autopilots page

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -221,7 +221,7 @@ Closed Hardware
     Parrot Bebop Autopilot <parrot-bebop-autopilot>
 [/site]
     Parrot C.H.U.C.K <common-CHUCK-overview>
-    PilotGaeaSHV1-bdshot <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md>
+    PilotGaeaSH7V1-bdshot <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/PilotGaeaSH7V1-bdshot/README.md>
     PixFlamingo- F767 <common-pixflamingo-f767>
     PixSurveyA2-IND <common-pixsurveya2-ind>
     RadioLink MiniPix <common-radiolink-minipix>

--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -10,15 +10,8 @@ Will be in future 4.8 release and is currently in master ("latest")
 New Board Support
 =================
 - JPilot-C, see https://github.com/ArduPilot/ardupilot_wiki/pull/7567
-- VUAV-TinyV7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7630
 - SparkNavi Blue , see https://github.com/ArduPilot/ardupilot_wiki/pull/7643
-- PilotGaeaSH7V1-bdshot, see https://github.com/ArduPilot/ardupilot_wiki/pull/7687
 - PrinciploT H7 Pi , see https://github.com/ArduPilot/ardupilot_wiki/pull/7694
-- SkyDroid-S3, see https://github.com/ArduPilot/ardupilot_wiki/pull/7791
-- SaamPixV1_1, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
-- CyberX-v10, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
-- AMOV Flycore, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
-- ORBITH743v2, see https://github.com/ArduPilot/ardupilot_wiki/pull/7872
 - GPILOT P1, see https://github.com/ArduPilot/ardupilot_wiki/pull/7877
 - SIYI UniFC 6 PICO, see https://github.com/ArduPilot/ardupilot_wiki/pull/7877
 - SimpliFly H7, see https://github.com/ArduPilot/ardupilot_wiki/pull/7915


### PR DESCRIPTION
These seven boards now have entries in `common-autopilots.rst` on master, so they are no longer future-only changes and can come off the Future Wiki Changes list:

- VUAV-TinyV7
- PilotGaeaSH7V1-bdshot
- SkyDroid-S3
- SaamPixV1_1
- CyberX-v10
- AMOV Flycore
- ORBITH743v2

The rest of the board list was checked against the autopilots page and left alone. Note CUAV-X25-MEGA and AET-H743-Air stay — the page lists CUAV-X25-EVO and AET-H743-Basic, which are different boards.

Also fixes a typo spotted while checking that list: the autopilots page displayed the PilotGaea board as `PilotGaeaSHV1-bdshot` (missing the `7`). The link target was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
