### PR TITLE
4.8:34097/Tustin MACH

### DIFF
--- a/common/source/docs/common-autopilots.rst
+++ b/common/source/docs/common-autopilots.rst
@@ -265,6 +265,7 @@ Closed Hardware
     ThePeach FCC-K1 <common-thepeach-k1>
     ThePeach FCC-R1 <common-thepeach-r1>
     TmotorH7Mini <common-tmotor-h7-mini>
+    Tustin MACH <https://github.com/ArduPilot/ardupilot/blob/master/libraries/AP_HAL_ChibiOS/hwdef/TUSTIN_MACH/README.md>
     UAV-DEV H7 UM982 <common-uav-dev-fc-um982>
     VR Brain 5 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrain5-detail>
     VR uBrain 5.1 <http://www.virtualrobotix.it/index.php/en/shop/autopilot/vrbrainmicro51-detail>


### PR DESCRIPTION
Add the Tustin MACH flight controller to the Closed Hardware list, linking to its hwdef README.

From ArduPilot/ardupilot#34097 (merged 2026-09-01).