### PR TITLE
common: future-wiki-changes: list Tustin MACH

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -29,6 +29,7 @@ New Board Support
 - Lectron Pi5, see https://github.com/ArduPilot/ardupilot_wiki/pull/7976
 - HGLRC H743 EVO, see https://github.com/ArduPilot/ardupilot_wiki/pull/8016
 - NWBlue Pro H757, see https://github.com/ArduPilot/ardupilot_wiki/pull/8017
+- Tustin MACH, see https://github.com/ArduPilot/ardupilot_wiki/pull/8029
 
 New Peripheral Support
 ======================


### PR DESCRIPTION
Adds Tustin MACH to the New Board Support list, pointing at its board PR #8029 (ArduPilot/ardupilot#34097).