### PR TITLE
html CI check and fix the existing issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,11 @@ repos:
         entry: python scripts/check_raw_images.py
         language: python
         types: [rst]
+
+  - repo: local
+    hooks:
+      - id: check-raw-html
+        name: Check raw html blocks have balanced tags
+        entry: python scripts/check_raw_html.py
+        language: python
+        types: [rst]

--- a/ardupilot/source/index.rst
+++ b/ardupilot/source/index.rst
@@ -4,10 +4,10 @@
     <h1 style="text-align:center;">ArduPilot</h1>
 
     <p style="text-align:center;color:green;"><strong>
-    ArduPilot is open source <u>software</u> that runs on a wide range of <u>hardware</u>.</strong>
+    ArduPilot is open source <u>software</u> that runs on a wide range of <u>hardware</u>.</strong></p>
 
     <p style="text-align:center;color:red;"><strong>
-    Success with ArduPilot requires that the 'First Time Setup' and 'First Flight/Drive and Tuning' sections of the vehicle's documentation be read and followed!</strong>
+    Success with ArduPilot requires that the 'First Time Setup' and 'First Flight/Drive and Tuning' sections of the vehicle's documentation be read and followed!</strong></p>
 
     <p style="text-align:left; color:black;">
 

--- a/blimp/source/docs/building-a-blimp.rst
+++ b/blimp/source/docs/building-a-blimp.rst
@@ -90,6 +90,8 @@ Front fin servo
 
 ..  raw:: html
 
+    </td>
+    </tr>
     <tr>
     <td width="48%">
 

--- a/blimp/source/docs/flight-modes.rst
+++ b/blimp/source/docs/flight-modes.rst
@@ -32,7 +32,7 @@ The table below shows for each flight mode whether it provides altitude or posit
  
     <table border="1" class="docutils">
     <tr><th>Symbol</th><th>Definition</th></tr>
-    <tr><td>m</td><td>Manual control</td><tr>
+    <tr><td>m</td><td>Manual control</td></tr>
     <tr><td>s</td><td>Pilot controls desired position/velocity to controller</td></tr>
     </table>
 

--- a/common/source/docs/common-commercial-support.rst
+++ b/common/source/docs/common-commercial-support.rst
@@ -239,7 +239,7 @@ support for ArduPilot including vehicle design, tuning, log analysis, bug fixes 
             <div class="line">ArduPilot Board and Documentation, <a href="mailto:hwurzburg@yahoo.com?Subject=ArduPilot%20commercial%20support" target="_top">hwurzburg@yahoo.com</a></div>
             <div class="line"><br/></div>
             <div class="line">As ArduPilot Wiki Maintainer and AutoPilot board reviewer</div>
-            <div class="line">I can assist in developing new autopilots and their successful submission.</dev>
+            <div class="line">I can assist in developing new autopilots and their successful submission.</div>
             <div class="line">Services include board system architecture consulting,</div>
             <div class="line">board porting and testing, board documentation, and</div>
             <div class="line">ArduPilot Wiki documentation of any kind</div>

--- a/common/source/docs/common-durandal-overview.rst
+++ b/common/source/docs/common-durandal-overview.rst
@@ -512,10 +512,12 @@ POWER1&2
    <td>VOLTAGE</td>
    <td>up to +3.3V</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>

--- a/common/source/docs/common-greensightultrablue.rst
+++ b/common/source/docs/common-greensightultrablue.rst
@@ -787,7 +787,6 @@ JP12 - AP GPIO (Autopilot GPIOs)
       </tr>
       <tr>
       <td>5</td>
-      </td>
       <td>GPIO 61</td>
       <td>+3.3V</td>
       </tr>

--- a/common/source/docs/common-holybro-ph4mini.rst
+++ b/common/source/docs/common-holybro-ph4mini.rst
@@ -332,10 +332,12 @@ POWER1
    <td>VOLTAGE</td>
    <td>up to +3.3V</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>

--- a/common/source/docs/common-ie24-fuelcell.rst
+++ b/common/source/docs/common-ie24-fuelcell.rst
@@ -102,32 +102,32 @@ Failsafe Low Action Error Code Group
 
    <tr>
    <td>31</td>
-   <td>Start Denied</th>
+   <td>Start Denied</td>
    </tr>
 
    <tr>
    <td>30</td>
-   <td>Pressure Alert</th>
+   <td>Pressure Alert</td>
    </tr>
 
    <tr>
    <td>21</td>
-   <td>Battery Low</th>
+   <td>Battery Low</td>
    </tr>
 
    <tr>
    <td>20</td>
-   <td>Pressure Low</th>
+   <td>Pressure Low</td>
    </tr>
 
    <tr>
    <td>11</td>
-   <td>SPM Lost</th>
+   <td>SPM Lost</td>
    </tr>
 
    <tr>
    <td>10</td>
-   <td>Reduced Power</th>
+   <td>Reduced Power</td>
    </tr>
 
    </tbody>

--- a/common/source/docs/common-ie650-fuelcell.rst
+++ b/common/source/docs/common-ie650-fuelcell.rst
@@ -91,57 +91,57 @@ Failsafe Low Action Error Code Group
 
    <tr>
    <td>0x4000000</td>
-   <td>Fan over current (> 0.25 A)</th>
+   <td>Fan over current (> 0.25 A)</td>
    </tr>
 
    <tr>
    <td>0x100000</td>
-   <td>Fuel cell's internal State is set 'stop' for > 15 s</th>
+   <td>Fuel cell's internal State is set 'stop' for > 15 s</td>
    </tr>
 
    <tr>
    <td>0x20000</td>
-   <td>Tank pressure < 15 barg</th>
+   <td>Tank pressure < 15 barg</td>
    </tr>
 
    <tr>
    <td>0x2000</td>
-   <td>Stack 1 under temperature (< 5 degC)</th>
+   <td>Stack 1 under temperature (< 5 degC)</td>
    </tr>
 
    <tr>
    <td>0x1000</td>
-   <td>Stack 2 under temperature (< 5 degC)</th>
+   <td>Stack 2 under temperature (< 5 degC)</td>
    </tr>
 
    <tr>
    <td>0x800</td>
-   <td>Battery under voltage warning (21.6 V)</th>
+   <td>Battery under voltage warning (21.6 V)</td>
    </tr>
 
    <tr>
    <td>0x200</td>
-   <td>Fan pulse aborted</th>
+   <td>Fan pulse aborted</td>
    </tr>
 
    <tr>
    <td>0x100</td>
-   <td>Stack under voltage (650 W < 17.4V, 800 W < 21.13 V)</th>
+   <td>Stack under voltage (650 W < 17.4V, 800 W < 21.13 V)</td>
    </tr>
 
    <tr>
    <td>0x80</td>
-   <td>Stack under voltage and battery power below threshold (< -200 W)</th>
+   <td>Stack under voltage and battery power below threshold (< -200 W)</td>
    </tr>
 
    <tr>
    <td>0x10</td>
-   <td>Battery charger fault</th>
+   <td>Battery charger fault</td>
    </tr>
 
    <tr>
    <td>0x8</td>
-   <td>Battery undertemperature (< -15 degC)</th>
+   <td>Battery undertemperature (< -15 degC)</td>
    </tr>
 
    </tbody>

--- a/common/source/docs/common-makeflyeasy-PixSurveyA1-IND.rst
+++ b/common/source/docs/common-makeflyeasy-PixSurveyA1-IND.rst
@@ -185,6 +185,7 @@ Safety and LED port
    <th>PIN</th>
    <th>SIGNAL</th>
    <th>VOLT</th>
+   </tr>
    <tr>
    <td>1</td>
    <td>VCC</td>

--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -480,6 +480,7 @@ These parameters are not supported by Copter.
    <td>Acc radius</td>
    <td>Acceptance radius in meters (waypoint is complete when the plane is this close to the waypoint location</td>
    </tr>
+   <tr>
    <td><strong>param3</strong></td>
    <td>Pass by</td>
    <td>0 to pass through the WP, if > 0 radius in meters to pass by WP.
@@ -728,7 +729,6 @@ and the mission will move on to the next command immediately.
    <th>Mission Planner Field</th>
    <th>Description</th>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td>param1</td>
    <td></td>
@@ -1036,6 +1036,7 @@ the path in a line between the waypoint centers. =1.
    <td>Radius</td>
    <td>Loiter radius around the waypoint. Units are in meters. Values over 255 will be rounded to units of 10 meters. and values greater than 2550 will be clamped to 2550 m. Negative values indicate counter-clockwise turns. A value of zero will use WP_LOITER_RAD </td>
    </tr>
+   <tr>
    <td><strong>param4</strong></td>
    <td>XTrack Tangent</td>
    <td>Determines which line the aircraft will track after exiting the loiter. If 0, track the line from the center of the circle to the next waypoint. If 1, track the line tangent to the circle to the next waypoint.</td>
@@ -1177,9 +1178,10 @@ tracks the line between the waypoint centers.
    <td>Dir 1=CW</td>
    <td>Loiter direction. Positive is clockwise and negative is counter-clockwise. The magnitude is ignored; radius is set by WP_LOITER_RAD.</td>
    </tr>
+   <tr>
    <td><strong>param4</strong></td>
    <td>XTrack Tangent</td>
-   <td>Determines which line the aircraft will track after exiting the loiter. If 0, track the line from the center of the circle to the next waypoint. If 1, track the line tangent to the circle to the next waypoint.
+   <td>Determines which line the aircraft will track after exiting the loiter. If 0, track the line from the center of the circle to the next waypoint. If 1, track the line tangent to the circle to the next waypoint.</td>
    </tr>
    <tr>
    <td><strong>param5</strong></td>
@@ -1516,7 +1518,6 @@ control the landing is provided in :ref:`LAND flight mode <land-mode>`.
    <tr>
    <td><strong>param1</strong></td>
    <td>Abort Alt</td>
-   </td>
    </tr>
    <tr style="color: #c0c0c0">
    <td>param2</td>
@@ -1544,6 +1545,7 @@ control the landing is provided in :ref:`LAND flight mode <land-mode>`.
    <td>Long</td>
    <td>Longitude</td>
    </tr>
+   <tr>
    <td><strong>param7</strong></td>
    <td>Alt</td>
    <td>Altitude to target for the landing. Unless you are landing at a location different than home, this should be zero</td>
@@ -1938,7 +1940,6 @@ the path in a line between the waypoint centers.
    <th>Mission Planner Field</th>
    <th>Description</th>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param1</strong></td>
    <td></td>
@@ -1949,12 +1950,12 @@ the path in a line between the waypoint centers.
    <td>Radius</td>
    <td>Radius in meters. If positive loiter clockwise, negative counter-clockwise, 0 means no change to standard loiter.</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td>param3</td>
    <td></td>
    <td>Empty</td>
    </tr>
+   <tr>
    <td>param4</td>
    <td>XTrack Tangent</td>
    <td>Determines which line the aircraft will track after exiting the loiter. If 0, track the line from the center of the circle to the next waypoint. If 1, track the line tangent to the circle to the next waypoint.</td>
@@ -2024,7 +2025,6 @@ then occurs. For Copters, they will loiter until then, and Rovers hold position.
    <td>Time in seconds (0-59)</td>
    <td>Delay until this second</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td>param5</td>
    <td></td>
@@ -2086,7 +2086,6 @@ until the time in seconds has elapsed. This is used in a mission to allow a vehi
    <td></td>
    <td>Empty</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td>param6</td>
    <td></td>
@@ -2150,7 +2149,6 @@ This allows the gripper to be commanded to be released, packages replaced, etc.
    <td></td>
    <td>Empty</td>
    </tr>
-   <tr>
    <tr>
    <td><strong>param5</strong></td>
    <td>Lat</td>
@@ -2608,6 +2606,7 @@ regardless of the ``param3`` value).
    If <code>param4=1</code> (relative): The change in heading (in degrees).
    </td>
    </tr>
+   <tr>
    <td><strong>param2</strong></td>
    <td>Speed deg/s</td>
    <td>Speed during yaw change:[deg per second].</td>
@@ -2920,7 +2919,7 @@ vehicle's throttle. If the airspeed option is selected, this changes the :ref:`A
    <tr>
    <td><strong>param2</strong></td>
    <td>Speed (m/s)</td>
-   <td>Target speed (m/s). If airspeed, a value below or above min/max airspeed limits results in no change. a value of -2 uses :ref:`AIRSPEED_CRUISE<AIRSPEED_CRUISE>`</td>
+   <td>Target speed (m/s). If airspeed, a value below or above min/max airspeed limits results in no change. a value of -2 uses AIRSPEED_CRUISE</td>
    </tr>
    <tr>
    <td><strong>param3</strong></td>
@@ -4006,7 +4005,7 @@ in the mission.
    <tr>
    <td><strong>param7</strong></td>
    <td></td>
-   <td>`MAV_MOUNT_MODE <https://mavlink.io/en/messages/common.html#MAV_MOUNT_MODE>`__ enum value.</td>
+   <td><a href="https://mavlink.io/en/messages/common.html#MAV_MOUNT_MODE">MAV_MOUNT_MODE</a> enum value.</td>
    </tr>
    </tbody>
    </table>
@@ -4124,6 +4123,7 @@ To trigger the camera once, immediately after passing the DO command, set param3
    <td></td>
    <td>Empty</td>
    </tr>
+   <tr>
    <td><strong>param3</strong></td>
    <td>?</td>
    <td>Trigger once instantly. One is on, zero is off.</td>
@@ -4638,17 +4638,20 @@ This command can be used to start or stop the ICE before a NAV_VTOL_LAND or afte
    <td>?</td>
    <td>Start/Stop ICE (1: start, 0:stop)</td>
    </tr>
+   <tr>
    <td><strong>param2</strong></td>
    <td></td>
    <td>Cold Start (1: enables choke, currently not implemented)</td>
    </tr>
+   <tr>
    <td><strong>param3</strong></td>
    <td></td>
    <td>Altitude in meters. Altitude at which action is taken.</td>
    </tr>
+   <tr>
    <td><strong>param4</strong></td>
    <td></td>
-   <td>Flags: 1 = allow a single start while disarmed even if :ref:`ICE_OPTIONS<ICE_OPTIONS>` bit 3 is set</td>
+   <td>Flags: 1 = allow a single start while disarmed even if ICE_OPTIONS bit 3 is set</td>
    </tr>
    <tr style="color: #c0c0c0">
    <td>param5</td>

--- a/common/source/docs/common-pixhawk-overview.rst
+++ b/common/source/docs/common-pixhawk-overview.rst
@@ -484,10 +484,12 @@ POWER
    <td>VOLTAGE</td>
    <td>up to +3.3V</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>

--- a/common/source/docs/common-pixsurveya2-ind.rst
+++ b/common/source/docs/common-pixsurveya2-ind.rst
@@ -394,8 +394,8 @@ All PWM outputs can be used as GPIOs (relays, camera, RPM etc). To use them you 
      <tr><td> M4 </td><td> 104 </td> <td> Out4 </td><td>  </td><td> M12 </td><td> 53 </td><td> AuxOut4 </td></tr>
      <tr><td> M5 </td><td> 105 </td> <td> Out5 </td><td>  </td><td> M13 </td><td> 54 </td><td> AuxOut5 </td></tr>
      <tr><td> M6 </td><td> 106 </td> <td> Out6 </td><td>  </td><td> M14 </td><td> 55 </td><td> AuxOut6 </td></tr>
-     <tr><td> M7 </td><td> 107 </td> <td> Out7 </td><td>  </td><td> </td><td>  </td><td>  </td></td></tr>
-     <tr><td> M8 </td><td> 108 </td> <td> Out8 </td><td>  </td><td> </td><td>  </td><td>  </td></td></tr>
+     <tr><td> M7 </td><td> 107 </td> <td> Out7 </td><td>  </td><td> </td><td>  </td><td>  </td></tr>
+     <tr><td> M8 </td><td> 108 </td> <td> Out8 </td><td>  </td><td> </td><td>  </td><td>  </td></tr>
    </table>
 
 Battery Monitor Settings

--- a/common/source/docs/common-serial-options.rst
+++ b/common/source/docs/common-serial-options.rst
@@ -95,6 +95,7 @@ FrSky SPort, see :ref:`FrSky Telemetry <common-frsky-telemetry>`
 .. raw:: html
 
    </td>
+   </tr>
    <tr>
    <td>5</td>
    <td>
@@ -483,6 +484,7 @@ DDS XRCE
 .. raw:: html
 
    </td>
+   </tr>
    <tr>
    <td> 46</td>
    <td>
@@ -492,6 +494,7 @@ IMU Data
 .. raw:: html
 
    </td>
+   </tr>
    <tr>
    <td> 48</td>
    <td>
@@ -501,6 +504,7 @@ PPP
 .. raw:: html
 
    </td>
+   </tr>
    <tr>
    <td> 49</td>
    <td>

--- a/common/source/docs/common-skydrones-airlink.rst
+++ b/common/source/docs/common-skydrones-airlink.rst
@@ -309,6 +309,7 @@ Left side interfaces:
    <td>OUT</td>
    <td>+3.3V</td>
    <td>SBUS output</td>
+   </tr>
    <tr>
    <td>6</td>
    <td>GND</td>
@@ -716,7 +717,6 @@ Front side interfaces:
    <td>IN</td>
    <td>+3.3V</td>
    <td>Safety button</td>
-   </td>
    </tr>
    <tr>
    <td>7</td>
@@ -724,7 +724,6 @@ Front side interfaces:
    <td>OUT</td>
    <td>+3.3V</td>
    <td>Safety LED</td>
-   </td>
    </tr>
    <tr>
    <td>8</td>
@@ -732,7 +731,6 @@ Front side interfaces:
    <td>OUT</td>
    <td>+3.3V</td>
    <td>3.3V output</td>
-   </td>
    </tr>
    <tr>
    <td>9</td>
@@ -740,7 +738,6 @@ Front side interfaces:
    <td>OUT</td>
    <td>+5V</td>
    <td>Buzzer output</td>
-   </td>
    </tr>
    <tr>
    <td>10</td>

--- a/common/source/docs/common-thecube-overview.rst
+++ b/common/source/docs/common-thecube-overview.rst
@@ -349,10 +349,12 @@ This section details the pin assignments of the standard carrier board of The Cu
    <td>VOLTAGE</td>
    <td>up to +3.3V,pin 2</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>
@@ -391,10 +393,12 @@ This section details the pin assignments of the standard carrier board of The Cu
    <td>VOLTAGE</td>
    <td>up to +3.3V,pin 13</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>

--- a/common/source/docs/common-thecubeorange-overview.rst
+++ b/common/source/docs/common-thecubeorange-overview.rst
@@ -371,10 +371,12 @@ The Cube connector pin assignments
    <td>VOLTAGE</td>
    <td>up to +3.3V,pin 14</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>
@@ -413,10 +415,12 @@ The Cube connector pin assignments
    <td>VOLTAGE</td>
    <td>up to +3.3V,pin 13</td>
    </tr>
+   <tr>
    <td>5 (blk)</td>
    <td>GND</td>
    <td>GND</td>
    </tr>
+   <tr>
    <td>6 (blk)</td>
    <td>GND</td>
    <td>GND</td>

--- a/copter/source/docs/flight-modes.rst
+++ b/copter/source/docs/flight-modes.rst
@@ -56,8 +56,8 @@ The table below shows for each flight mode whether it provides altitude or posit
 
    <table border="1" class="docutils">
    <tr><th>Symbol</th><th>Definition</th></tr>
-   <tr><td>-</td><td>Manual control</td><tr>
-   <tr><td>+</td><td>Manual control with limits & self-level</td><tr>
+   <tr><td>-</td><td>Manual control</td></tr>
+   <tr><td>+</td><td>Manual control with limits & self-level</td></tr>
    <tr><td>s</td><td>Pilot controls rate of changes</td></tr>
    <tr><td>A</td><td>Automatic control</td></tr>
    </table>

--- a/copter/source/index.rst
+++ b/copter/source/index.rst
@@ -7,7 +7,7 @@ ArduPilot Copter
 ..  raw:: html
     
     <p style="text-align:center;color:red;"><strong>
-    Success with Copter requires that the 'First Time Setup' and 'First Flight and Tuning' sections of this documentation be read and followed!</strong>
+    Success with Copter requires that the 'First Time Setup' and 'First Flight and Tuning' sections of this documentation be read and followed!</strong></p>
     <br></br>
 
 .. image:: /images/home_copter.jpg

--- a/dev/source/docs/copter-commands-in-guided-mode.rst
+++ b/dev/source/docs/copter-commands-in-guided-mode.rst
@@ -348,7 +348,6 @@ When providing Pos, Vel and/or Accel all 3 axis must be provided.  At least one 
    <tr>
    <td><strong>afx</strong></td>
    <td>X acceleration in m/s/s (positive is North)</td>
-   </td>
    </tr>
    <tr>
    <td><strong>afy</strong></td>

--- a/dev/source/docs/mavlink-get-set-flightmode.rst
+++ b/dev/source/docs/mavlink-get-set-flightmode.rst
@@ -133,7 +133,6 @@ The flight mode may be changed on some vehicle types to Loiter, RTL or Land by s
    <td><strong>command</strong></td>
    <td>uint16_t</td>
    <td>MAV_CMD_NAV_LOITER_UNLIM=17, MAV_CMD_NAV_RETURN_TO_LAUNCH=20, MAV_CMD_NAV_LAND=21 or MAV_CMD_NAV_VTOL_LAND=85</td>
-   </td>
    </tr>
    <tr style="color: #c0c0c0">
    <td><strong>confirmation</strong></td>

--- a/dev/source/docs/mavlink-get-set-home-and-origin.rst
+++ b/dev/source/docs/mavlink-get-set-home-and-origin.rst
@@ -68,7 +68,6 @@ Set the home location by sending a `COMMAND_INT <https://mavlink.io/en/messages/
    <td>float</td>
    <td>1=use current location, 0=use specified location</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
    <td>float</td>
@@ -84,14 +83,17 @@ Set the home location by sending a `COMMAND_INT <https://mavlink.io/en/messages/
    <td>float</td>
    <td>not used</td>
    </tr>
+   <tr>
    <td><strong>param5</strong></td>
    <td>int32_t</td>
    <td>Latitude in degrees * 10^7</td>
    </tr>
+   <tr>
    <td><strong>param6</strong></td>
    <td>int32_t</td>
    <td>Longitude in degrees * 10^7</td>
    </tr>
+   <tr>
    <td><strong>param7</strong></td>
    <td>float</td>
    <td>Altitude in meters</td>
@@ -150,7 +152,6 @@ Set the home location by sending a `COMMAND_LONG <https://mavlink.io/en/messages
    <td>float</td>
    <td>1=use current location, 0=use specified location</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
    <td>float</td>
@@ -166,14 +167,17 @@ Set the home location by sending a `COMMAND_LONG <https://mavlink.io/en/messages
    <td>float</td>
    <td>not used</td>
    </tr>
+   <tr>
    <td><strong>param5</strong></td>
    <td>float</td>
    <td>Latitude in degrees</td>
    </tr>
+   <tr>
    <td><strong>param6</strong></td>
    <td>float</td>
    <td>Longitude in degrees</td>
    </tr>
+   <tr>
    <td><strong>param7</strong></td>
    <td>float</td>
    <td>Altitude in meters</td>

--- a/dev/source/docs/mavlink-gimbal-mount.rst
+++ b/dev/source/docs/mavlink-gimbal-mount.rst
@@ -361,7 +361,6 @@ Valid options are:
    <td>float</td>
    <td>Gimbal device id (unused)</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
    <td>float</td>
@@ -372,7 +371,6 @@ Valid options are:
    <td>float</td>
    <td>not used</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param4</strong></td>
    <td>float</td>
@@ -459,7 +457,6 @@ The gimbal ROI can be stopped (e.g. the gimbal will switch to its default mode h
    <td>float</td>
    <td>Gimbal device id (unused)</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>param2</strong></td>
    <td>float</td>

--- a/dev/source/docs/mavlink-nongps-position-estimation.rst
+++ b/dev/source/docs/mavlink-nongps-position-estimation.rst
@@ -116,12 +116,10 @@ The preferred method is to send an `ODOMETRY <https://mavlink.io/en/messages/com
    <td>Yaw angular speed in rad/s (clockwise is positive)</td>
    </tr>
    <tr>
-   <tr>
    <td><strong>pos_covariance</strong></td>
    <td>float[21]</td>
    <td>elements 0, 6 and 11 are x, y and z-axis position error. 15, 18, 20 are roll, pitch and yaw angle error. Ignored if NaN</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>velocity_covariance</strong></td>
    <td>float[21]</td>
@@ -132,7 +130,6 @@ The preferred method is to send an `ODOMETRY <https://mavlink.io/en/messages/com
    <td>uint8_t</td>
    <td>External estimator reset counter.  This should be incremented when the estimate resets position, velocity, attitude or angular speed</td>
    </tr>
-   <tr>
    <tr style="color: #c0c0c0">
    <td><strong>estimator_type</strong></td>
    <td>uint8_t</td>

--- a/dev/source/docs/mavlink-precision-landing.rst
+++ b/dev/source/docs/mavlink-precision-landing.rst
@@ -95,6 +95,7 @@ If only the body-frame angle to the target is known then "angle_x" and "angle_y"
    <td>uint8_t</td>
    <td>not used</td>
    </tr>
+   <tr>
    <td><strong>position_valid</strong></td>
    <td>uint8_t</td>
    <td>0 if angle_x, angle_y should be used.  1 if x, y, z fields contain position information</td>

--- a/dev/source/docs/mavlink-rover-commands.rst
+++ b/dev/source/docs/mavlink-rover-commands.rst
@@ -305,7 +305,6 @@ When providing position or velocity both X and Y axis must be provided.  At leas
    <tr style="color: #c0c0c0">
    <td><strong>afx</strong></td>
    <td>X acceleration in m/s/s (positive is North)</td>
-   </td>
    </tr>
    <tr style="color: #c0c0c0">
    <td><strong>afy</strong></td>

--- a/dev/source/docs/ros2-interfaces.rst
+++ b/dev/source/docs/ros2-interfaces.rst
@@ -264,7 +264,6 @@ For more information on the coordinate systems used, review `ROS REP-105 <https:
    <td>tf2_msgs/msg/TFMessage</td> 
    <td>Receive the odometry dynamic transform on the normal tf2 dynamic transform topic.</td>
    </tr>
-   <tr>
    </tbody>
    </table>
 

--- a/plane/source/docs/flight-modes.rst
+++ b/plane/source/docs/flight-modes.rst
@@ -46,16 +46,16 @@ of functionality available.
    <tr><td>GUIDED</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Circles user defined point from GCS</td></tr>
    <tr><td>Return To Launch (RTL)</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Returns to and circles home or rally point</td></tr>
    <tr><td>TAKEOFF</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Automatic takeoff to specific altitude, and loiter at distance from takeoff until mode is changed</td></tr>
-   <tr><td>THERMAL</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Mode entered to search for thermal lift by SOARING feature or manually if lift is encountered. See :ref:`THERMAL Mode <thermal-mode>`</td></tr>
-   <tr><td>AUTOLAND</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Fixed wing Autoland See :ref:`AUTOLAND Mode <mode_autoland>`</td></tr>
+   <tr><td>THERMAL</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Mode entered to search for thermal lift by SOARING feature or manually if lift is encountered. See <a href="thermal-mode.html">THERMAL Mode</a></td></tr>
+   <tr><td>AUTOLAND</td><td>A</td><td>A</td><td>A</td><td>Y</td><td></td><td>Fixed wing Autoland See <a href="mode_autoland.html">AUTOLAND Mode</a></td></tr>
    </table>
 
 .. raw:: html
 
    <table border="1" class="docutils">
    <tr><th>Symbol</th><th>Definition</th></tr>
-   <tr><td>-</td><td>Full manual control of flight surfaces</td><tr>
-   <tr><td>+</td><td>Manual control with stabilized limits or assistance</td><tr>
+   <tr><td>-</td><td>Full manual control of flight surfaces</td></tr>
+   <tr><td>+</td><td>Manual control with stabilized limits or assistance</td></tr>
    <tr><td>s</td><td>Stabilized control with limits</td></tr>
    <tr><td>A</td><td>Automatic control</td></tr>
    <tr><td>SPD</td><td>Controls speed</td></tr>

--- a/plane/source/docs/guide-elevon-plane.rst
+++ b/plane/source/docs/guide-elevon-plane.rst
@@ -61,8 +61,8 @@ PROVIDING RC INPUT is:
 
    <table border="1" class="docutils">
    <tr><th>Input</th><th>Action</th></tr>
-   <tr><td>Roll right</td><td>Left elevon goes up and right elevon goes down</td><tr>
-   <tr><td>Roll left</td><td>Right elevon goes up and left elevon goes down</td><tr>
+   <tr><td>Roll right</td><td>Left elevon goes up and right elevon goes down</td></tr>
+   <tr><td>Roll left</td><td>Right elevon goes up and left elevon goes down</td></tr>
    <tr><td>Pitch down</td><td>Both elevons go up</td></tr>
    <tr><td>Pitch up</td><td>Both elevons go down</td></tr>
    </table>

--- a/plane/source/docs/guide-four-channel-plane.rst
+++ b/plane/source/docs/guide-four-channel-plane.rst
@@ -68,8 +68,8 @@ and coordinate its turns.
 
    <table border="1" class="docutils">
    <tr><th>Movement</th><th>Action</th></tr>
-   <tr><td>Roll Plane Right</td><td>Left aileron moves up and right aileron moves down</td><tr>
-   <tr><td>Roll Plane Left</td><td>Left aileron moves down and right aileron moves up</td><tr>
+   <tr><td>Roll Plane Right</td><td>Left aileron moves up and right aileron moves down</td></tr>
+   <tr><td>Roll Plane Left</td><td>Left aileron moves down and right aileron moves up</td></tr>
    <tr><td>Pitch plane up</td><td>Elevator moves down</td></tr>
    <tr><td>Pitch plane down</td><td>Elevator moves up</td></tr>
    <tr><td>Roll Plane Right</td><td>Rudder moves left</td></tr>
@@ -93,12 +93,12 @@ Keep the plane level in FBWA mode and command the following inputs by moving the
          
    <table border="1" class="docutils">
    <tr><th>Input</th><th>Action</th></tr>
-   <tr><td>Roll Right</td><td>Right aileron moves up and left aileron moves down</td><tr>
-   <tr><td>Roll Left</td><td>Left aileron moves up and right aileron moves down</td><tr>
-   <tr><td>Pitch up</td><td>Elevator moves up</td><tr>
-   <tr><td>Pitch down</td><td>Elevator moves down</td><tr>
-   <tr><td>Yaw right</td><td>Rudder moves right</td><tr>
-   <tr><td>Yaw left</td><td>Rudder moves left</td><tr>
+   <tr><td>Roll Right</td><td>Right aileron moves up and left aileron moves down</td></tr>
+   <tr><td>Roll Left</td><td>Left aileron moves up and right aileron moves down</td></tr>
+   <tr><td>Pitch up</td><td>Elevator moves up</td></tr>
+   <tr><td>Pitch down</td><td>Elevator moves down</td></tr>
+   <tr><td>Yaw right</td><td>Rudder moves right</td></tr>
+   <tr><td>Yaw left</td><td>Rudder moves left</td></tr>
    </table>
 
 If the control surfaces do not respond correctly, change the RCn_reversed

--- a/plane/source/docs/guide-tilt-rotor.rst
+++ b/plane/source/docs/guide-tilt-rotor.rst
@@ -55,7 +55,7 @@ hovering. Currently supported tilt-rotor frame classes are:
 .. raw:: html
 
    <table border="1" class="docutils">
-   <tr><th>Frame Class</th><th>Q_FRAME_CLASS</th></th></tr>
+   <tr><th>Frame Class</th><th>Q_FRAME_CLASS</th></tr>
    <tr><td>Quadcopter</td><td>1</td></tr>
    <tr><td>Hexacopter</td><td>2</td></tr>
    <tr><td>Octacopter</td><td>3</td></tr>

--- a/plane/source/docs/guide-vtail-plane.rst
+++ b/plane/source/docs/guide-vtail-plane.rst
@@ -62,8 +62,8 @@ should move its control surfaces to level itself.
 
    <table border="1" class="docutils">
    <tr><th>Movement</th><th>Action</th></tr>
-   <tr><td>Roll Plane Right</td><td>Left aileron moves up and right aileron moves down</td><tr>
-   <tr><td>Roll Plane Left</td><td>Left aileron moves down and right aileron moves up</td><tr>
+   <tr><td>Roll Plane Right</td><td>Left aileron moves up and right aileron moves down</td></tr>
+   <tr><td>Roll Plane Left</td><td>Left aileron moves down and right aileron moves up</td></tr>
    <tr><td>Pitch plane up</td><td>Both tail surfaces move down</td></tr>
    <tr><td>Pitch plane down</td><td>Both tail surfaces move up</td></tr>
    <tr><td>Roll Plane Right</td><td>Both tail surfaces move left</td></tr>
@@ -81,8 +81,8 @@ at a time to avoid confusion.
 
    <table border="1" class="docutils">
    <tr><th>Control Surface Response</th><th>Corrective Action</th></tr>
-   <tr><td>Correct for 1 movement (pitch or roll), but not the other</td><td>Change the function (from 79 to 80; or 80 to 79)</td><tr>
-   <tr><td>Incorrect for both movements (pitch and roll)</td><td>Change the reversal of that channel</td><tr>
+   <tr><td>Correct for 1 movement (pitch or roll), but not the other</td><td>Change the function (from 79 to 80; or 80 to 79)</td></tr>
+   <tr><td>Incorrect for both movements (pitch and roll)</td><td>Change the reversal of that channel</td></tr>
    </table>
 
 .. note:: :ref:`KFF_RDDRMIX<KFF_RDDRMIX>` must not be set to 0 for rudder setup. If the 
@@ -101,12 +101,12 @@ Keep the plane level in FBWA mode and command the following inputs:
          
    <table border="1" class="docutils">
    <tr><th>Input</th><th>Action</th></tr>
-   <tr><td>Roll Right</td><td>Right aileron moves up and left aileron moves down</td><tr>
-   <tr><td>Roll Left</td><td>Left aileron moves up and right aileron moves down</td><tr>
-   <tr><td>Pitch up</td><td>Both tail surfaces moveup</td><tr>
-   <tr><td>Pitch down</td><td>Both tail surfaces move down</td><tr>
-   <tr><td>Yaw right</td><td>Both tail surfaces move right</td><tr>
-   <tr><td>Yaw left</td><td>Both tail surfaces move left</td><tr>
+   <tr><td>Roll Right</td><td>Right aileron moves up and left aileron moves down</td></tr>
+   <tr><td>Roll Left</td><td>Left aileron moves up and right aileron moves down</td></tr>
+   <tr><td>Pitch up</td><td>Both tail surfaces moveup</td></tr>
+   <tr><td>Pitch down</td><td>Both tail surfaces move down</td></tr>
+   <tr><td>Yaw right</td><td>Both tail surfaces move right</td></tr>
+   <tr><td>Yaw left</td><td>Both tail surfaces move left</td></tr>
    </table>
 
 Double check MANUAL mode for the inputs as well. If everything is setup correctly, 

--- a/plane/source/docs/quadplane-support.rst
+++ b/plane/source/docs/quadplane-support.rst
@@ -10,7 +10,7 @@ multicopter aircraft, also known as a "QuadPlane".
 ..  raw:: html
 
     <p style="text-align:center;color:red;"><strong>
-    Since a Quadplane also functions as a conventional fixed wing Plane, success with ArduPilot requires that not only the 'First Time Setup' and 'First Flight/Drive and Tuning' sections below be read and followed, but also those same sections for a conventional Plane!</strong>
+    Since a Quadplane also functions as a conventional fixed wing Plane, success with ArduPilot requires that not only the 'First Time Setup' and 'First Flight/Drive and Tuning' sections below be read and followed, but also those same sections for a conventional Plane!</strong></p>
 
  
 

--- a/plane/source/index.rst
+++ b/plane/source/index.rst
@@ -7,7 +7,7 @@ ArduPilot Plane
 ..  raw:: html
     
     <p style="text-align:center;color:red;"><strong>
-    Success with Plane requires that the 'First Time Setup' and 'First Flight and Tuning' sections of this documentation be read and followed!</strong>
+    Success with Plane requires that the 'First Time Setup' and 'First Flight and Tuning' sections of this documentation be read and followed!</strong></p>
     <br></br>
 
 

--- a/rover/source/index.rst
+++ b/rover/source/index.rst
@@ -7,7 +7,7 @@ ArduPilot Rover
 ..  raw:: html
  
     <p style="text-align:center;color:red;"><strong>
-    Success with Rover requires that the 'First Time Setup' and 'First Drive and Tuning' sections of this documentation be read and followed!</strong>
+    Success with Rover requires that the 'First Time Setup' and 'First Drive and Tuning' sections of this documentation be read and followed!</strong></p>
     <br></br>
 
 .. image:: /images/home_rover.jpg

--- a/scripts/check_raw_html.py
+++ b/scripts/check_raw_html.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Check that the HTML inside ``.. raw:: html`` blocks has balanced tags.
+
+Browsers repair a mismatched or missing closing tag, so a page can look
+fine while its markup is broken. Anything that parses the built page
+strictly, like an epub reader, rejects the whole page instead. The check
+walks every raw html block of a file in order, since a table is often
+opened in one block and closed in a later one, and reports:
+
+- a closing tag with no open tag to match, such as ``</tr>`` twice
+- a closing tag that skips over a still open one, such as ``<td>`` closed by ``</th>``
+- a tag still open at the end of the file
+- a tag that is not an HTML element, which usually means a literal ``<``
+  in text, such as ``<PARAM_NAME>``, that needs to be written ``&lt;``
+
+Raw blocks shown as examples inside a literal or code block are skipped.
+"""
+
+import argparse
+import pathlib
+import re
+import sys
+from html.parser import HTMLParser
+
+# Case-insensitive, and the substitution form renders too.
+RAW_HTML_RE = re.compile(r"^(\s*)\.\.\s+(?:\|[^|]+\|\s+)?raw::\s+html\s*$",
+                         re.IGNORECASE)
+CODE_RE = re.compile(r"^\.\.\s+(?:code|code-block|parsed-literal)::")
+DIRECTIVE_RE = re.compile(r"^\.\.\s+(?:\|[^|]+\|\s+)?[\w.-]+::")
+
+# Elements that never take a closing tag.
+VOID = {"area", "base", "br", "col", "embed", "hr", "img", "input", "link",
+        "meta", "param", "source", "track", "wbr"}
+
+# Every element of the HTML living standard plus the few obsolete ones the wiki uses.
+ELEMENTS = VOID | set("""
+a abbr address article aside audio b bdi bdo blockquote body button canvas
+caption center cite code colgroup data datalist dd del details dfn dialog div
+dl dt em fieldset figcaption figure font footer form h1 h2 h3 h4 h5 h6 head
+header hgroup html i iframe ins kbd label legend li main map mark menu meter
+nav noscript object ol optgroup option output p picture pre progress q rp rt
+ruby s samp script search section select slot small span strike strong style
+sub summary sup table tbody td template textarea tfoot th thead time title tr
+tt u ul var video
+""".split())
+
+
+def indent_of(line: str) -> int:
+    return len(line) - len(line.lstrip())
+
+
+def opens_literal(line: str) -> bool:
+    """A block whose body never reaches the built page: a code directive or
+    a true comment. Other directives still build, nested raw included."""
+    text = line.strip()
+    if text == "..":
+        return True
+    if text.startswith(".. "):
+        if CODE_RE.match(text):
+            return True
+        # No directive marker makes it a comment; a directive's body builds.
+        return not DIRECTIVE_RE.match(text)
+    return text.endswith("::")
+
+
+def raw_blocks(path: pathlib.Path):
+    """Yield (first line number, text) for every raw html block that builds."""
+    skip = None   # indent of the literal or code block being skipped
+    raw = None    # indent of the raw html block being gathered
+    start = 0
+    held = []
+
+    for number, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        blank = not line.strip()
+        if skip is not None:
+            if blank or indent_of(line) > skip:
+                continue
+            skip = None
+        if raw is not None:
+            if blank or indent_of(line) > raw:
+                if not held:
+                    start = number
+                held.append(line)
+                continue
+            yield start, "\n".join(held)
+            raw, held = None, []
+        match = RAW_HTML_RE.match(line)
+        if match:
+            raw = len(match.group(1))
+        elif opens_literal(line):
+            skip = indent_of(line)
+    if raw is not None and held:
+        yield start, "\n".join(held)
+
+
+class TagBalance(HTMLParser):
+    """Track open tags across everything fed in and record each mismatch."""
+
+    def __init__(self):
+        super().__init__()
+        self.stack = []     # (tag, parser line) for every open element
+        self.errors = []    # (parser line, message)
+
+    def handle_starttag(self, tag, attrs):
+        if tag not in ELEMENTS:
+            self.errors.append((self.getpos()[0], f"<{tag}> is not an HTML tag; write a literal < as &lt;"))
+            return
+        if tag not in VOID:
+            self.stack.append((tag, self.getpos()[0]))
+
+    def handle_startendtag(self, tag, attrs):
+        if tag not in ELEMENTS:
+            self.handle_starttag(tag, attrs)
+
+    def handle_endtag(self, tag):
+        line = self.getpos()[0]
+        if tag in VOID:
+            return
+        if not any(open_tag == tag for open_tag, _ in self.stack):
+            self.errors.append((line, f"</{tag}> closes nothing"))
+            return
+        while self.stack[-1][0] != tag:
+            open_tag, opened = self.stack.pop()
+            self.errors.append((opened, f"<{open_tag}> is still open when </{tag}> closes it"))
+        self.stack.pop()
+
+    def finish(self):
+        self.close()
+        for open_tag, opened in self.stack:
+            self.errors.append((opened, f"<{open_tag}> is never closed"))
+
+
+def problems(path: pathlib.Path):
+    """Yield (line number, message) for every tag problem in the file's raw html."""
+    parser = TagBalance()
+    lines = []      # parser line index -> file line number
+    for start, text in raw_blocks(path):
+        lines.extend(range(start, start + text.count("\n") + 1))
+        parser.feed(text + "\n")
+    if not lines:
+        return
+    parser.finish()
+    for index, message in sorted(parser.errors):
+        yield lines[min(index, len(lines)) - 1], message
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("files", nargs="+", type=pathlib.Path)
+    args = parser.parse_args()
+
+    failures = 0
+    for path in args.files:
+        for number, message in problems(path):
+            failures += 1
+            print(f"{path}:{number}: {message}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This PR fixes and enforces correct HTML syntax, as found and requested by
https://github.com/ArduPilot/ardupilot_wiki/pull/8018/changes#r3947735498

As part of making the offline wiki, it was found that the HTML was not syntactically valid and this was a widespread issue.
There were 158 invalid HTML tags across 35 pages. They have now been resolved.