### PR TITLE
4.8:34271/ARK FPV

### DIFF
--- a/common/source/docs/common-ark-fpv.rst
+++ b/common/source/docs/common-ark-fpv.rst
@@ -15,7 +15,7 @@ Features
 * 480MHz
 * 2MB Flash
 * 1MB RAM
-* Invensense IIM-42653 Industrial IMU with heater resistor
+* Invensense IIM-42653 (hardware rev 0) or ST LSM6DSV32X (hardware rev 1) IMU with heater resistor
 * Bosch BMP390 Barometer
 * ST IIS2MDC Magnetometer
 * 9x PWM  Bidirectional-DSHOT capable


### PR DESCRIPTION
Documents ArduPilot/ardupilot#34271, which adds an ST LSM6DSV32X probe on the same SPI1 bus and CS as the IIM-42653 so a single firmware image supports both ARK FPV hardware revisions — rev 0 carries the IIM-42653, rev 1 the LSM6DSV32X.

Updates the IMU line in the Features list accordingly. No other section of the page is affected: the hwdef change adds no connector, UART, PWM group, relay or battery change, and the accompanying `AP_InertialSensor_LSM6DSV` change (publishing temperature at loop rate so the IMU heater loop is fed fast enough) is driver-internal.

Note: #7929 also touches this page, in the POWER AUX / VTX sections — different hunks, so the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)