### PR TITLE
plane: fix stale Q_P_JERK_XY/Z names in QuadPlane tuning list

### DIFF
--- a/plane/source/docs/quadplane-vtol-tuning-process.rst
+++ b/plane/source/docs/quadplane-vtol-tuning-process.rst
@@ -485,8 +485,8 @@ The full list of input shaping parameters are:
 - :ref:`Q_A_RATE_R_MAX <Q_A_RATE_R_MAX>`
 - :ref:`Q_A_RATE_Y_MAX <Q_A_RATE_Y_MAX>`
 - :ref:`Q_A_RATE_WPY_MAX<Q_A_RATE_WPY_MAX>`
-- ``Q_P_JERK_XY``
-- ``Q_P_JERK_Z``
+- :ref:`Q_P_NE_JERK<Q_P_NE_JERK>`
+- :ref:`Q_P_D_JERK<Q_P_D_JERK>`
 - :ref:`Q_LOIT_ACC_MAX_M<Q_LOIT_ACC_MAX_M>`
 - :ref:`Q_LOIT_ANG_MAX <Q_LOIT_ANG_MAX>`
 - :ref:`Q_LOIT_BRK_ACC_M<Q_LOIT_BRK_ACC_M>`


### PR DESCRIPTION
ArduPilot/ardupilot#33843 renamed `PSC_JERK_NE`/`PSC_JERK_D` to `PSC_NE_JERK`/`PSC_D_JERK` (and the QuadPlane `Q_P_` equivalents). The rename is in the `ArduPilot-4.7` branch as well as master, so no delay-merge is needed.

The input shaping list in `quadplane-vtol-tuning-process.rst` was still using the pre-4.7 names `Q_P_JERK_XY` / `Q_P_JERK_Z`, written as literals rather than links. `Q_P_NE_JERK` and `Q_P_D_JERK` both have anchors in the plane parameter reference, so they are now `:ref:` links like every other entry in that list.

`common-param-name-changes.rst` already lists `PSC_JERK_XY → PSC_NE_JERK` and `PSC_JERK_Z → PSC_D_JERK` under 4.6 → 4.7, which matches what the 4.7 branch ships — no change needed there. No other wiki page referenced the old names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)