### PR TITLE
common: RTL mission command continues the mission when RTL_ALT_FINAL_M > 0

### DIFF
--- a/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
+++ b/common/source/docs/common-mavlink-mission-command-messages-mav_cmd.rst
@@ -1219,7 +1219,8 @@ if the vehicle configuration allows this).
 Copter
 ~~~~~~
 
-Return to the *home location* (or the nearest :ref:`Rally Point <common-rally-points>` if closer) and then land. The home
+Return to the *home location* (or the nearest :ref:`Rally Point <common-rally-points>` if closer) and then land or
+hover above home, depending on :ref:`RTL_ALT_FINAL_M<RTL_ALT_FINAL_M>`. The home
 location is where the vehicle was last armed (or when it first gets GPS
 lock after arming if the vehicle configuration allows this).
 
@@ -1228,8 +1229,12 @@ first climb to the
 :ref:`RTL_ALT_M<RTL_ALT_M>`
 parameter's specified altitude (default is 15m) before returning home.
 
-This command takes no parameters and generally should be the last
-command in the mission.
+:ref:`RTL_ALT_FINAL_M<RTL_ALT_FINAL_M>` determines what happens once home is reached.  If it is
+zero (the default) the vehicle lands, so this command should be the last command in the
+mission.  If it is non-zero the vehicle stops and hovers at that altitude above home, the
+command completes, and the mission continues with the next command.
+
+This command takes no parameters.
 
 **Command parameters**
 


### PR DESCRIPTION
ArduPilot/ardupilot#33797 fixed Auto mode's `verify_RTL()`: it used to require the motors to reach `GROUND_IDLE` before a `NAV_RETURN_TO_LAUNCH` item was considered complete, which never happens when :ref:`RTL_ALT_FINAL_M<RTL_ALT_FINAL_M>` is non-zero, so the mission stalled at that item. Now `FINAL_DESCENT` completes on its own and only `LAND` waits for spool-down.

The Copter section of `MAV_CMD_NAV_RETURN_TO_LAUNCH` documented only the landing case ("and then land", "generally should be the last command in the mission"). Updated to describe both: `RTL_ALT_FINAL_M` = 0 (the default) lands and ends the mission; non-zero hovers above home and the mission continues with the next command.

Copter section only — the plane and rover sections of the same command are untouched. The fix is in the `ArduPilot-4.7` branch as well as master, so no delay-merge label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)