### PR TITLE
common: flywoof405hd: list BMP280 alongside DPS-310 and SPL06

### DIFF
--- a/common/source/docs/common-flywoof405hd.rst
+++ b/common/source/docs/common-flywoof405hd.rst
@@ -28,7 +28,7 @@ Specifications
 -  **Sensors**
 
    -  ICM-42688P IMU or MPU6000(accel, gyro)
-   -  DPS-310 or SPL06 barometer
+   -  BMP280, DPS-310 or SPL06 barometer
    -  Voltage & 180A current sensor
 
 


### PR DESCRIPTION
ArduPilot/ardupilot#33779 enabled the SPL06 driver and reworked the barometer block in `FlywooF405S-AIO/hwdef.dat`, which `FlywooF405HD-AIOv2/hwdef.dat` includes. The board now probes BMP280, DPS310 and SPL06 at `I2C:0:0x76`.

`common-flywoof405hd.rst` is the only wiki page affected — `FlywooF405S-AIO` itself has no wiki page or `common-autopilots.rst` entry, and no other Flywoo hwdef includes it. That page has listed "DPS-310 or SPL06" since it was written in 2024, from the vendor spec, ahead of the firmware actually supporting SPL06; the remaining gap is BMP280, which is also probed. Added.

The change is in the `ArduPilot-4.7` branch as well as master, so no delay-merge label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)