### PR TITLE
common: flywoof405pro: correct barometer to DPS310

### DIFF
--- a/common/source/docs/common-flywoof405pro.rst
+++ b/common/source/docs/common-flywoof405pro.rst
@@ -14,7 +14,7 @@ Specifications
 
    -  STM32F405 ARM microcontroller
    -  ICM42688 IMU (Gyro and Accelerometers)
-   -  BMP280 Barometer
+   -  DPS310 Barometer
    -  AT7456E OSD
    -  16Mbytes logging flash
 


### PR DESCRIPTION
`common-flywoof405pro.rst` has listed a **BMP280 Barometer** since the page was added in 2023 (`88bc0e4a4`), but `libraries/AP_HAL_ChibiOS/hwdef/FlywooF405Pro/hwdef.dat` declares only:

```
BARO DPS310 I2C:0:0x76
```

That is the case on `master` and on the `ArduPilot-4.7` branch, and the hwdef has no `include` that could add another barometer. No BMP280 is probed, so anyone comparing `BARO1_DEVID` against the wiki gets a mismatch.

Spotted while working on #8045 (Flywoo F405HD barometer list). Unrelated board, unrelated cause — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)