### PR TITLE
4.8:23578/FLIP_RATE parameter

### DIFF
--- a/copter/source/docs/flip-mode.rst
+++ b/copter/source/docs/flip-mode.rst
@@ -19,3 +19,13 @@ The mode may be entered either by an :ref:`Auxiliary Switch <common-auxiliary-fu
 - You may abort the flip by moving the pitch or roll stick as if to command near full stick in that axis. The Flip will immediately halt **at whatever attitude it is currently at** and return to the previous flight mode at the pilot's throttle stick input.
 - As the flip is completing, it will briefly increase throttle to try to recover any lost altitude. Again, this is an approximation. Once completed (entry attitude re-attained), the previous flight mode is returned to (if not entered by an AUX switch). It will not flip again until the Aux Switch is lowered and raised again, if used, or FLIP flight mode re-entered. If entered via a flight mode switch, you will need to change mode out of FLIP, to another mode, and then back again if another flip is desired,
 
+Flip Rotation Rate
+==================
+
+The rate at which the vehicle rotates during the flip is set by :ref:`FLIP_RATE<FLIP_RATE>`, in deg/s. It defaults to 400 deg/s and is constrained to the range 60 to 1000 deg/s.
+
+Lower rates give a slower, gentler flip, which is usually required on larger vehicles and on traditional helicopters, since they cannot reach the default rate.
+
+The flip's timeout is derived from this parameter: the flip is abandoned if it has not completed within twice the time a full 360 deg rotation would take at :ref:`FLIP_RATE<FLIP_RATE>`, i.e. 720/:ref:`FLIP_RATE<FLIP_RATE>` seconds, which is 1.8s at the default rate.
+
+.. warning:: Set a rate the vehicle can actually achieve. Requesting a rate the vehicle cannot deliver both shortens the timeout and leaves the rotation slower than requested, so the flip is likely to be abandoned part way around, returning to the previous flight mode at whatever attitude it had reached.


### PR DESCRIPTION
Documents ArduPilot/ardupilot#23578, which replaces Flip mode's hard-coded 400 deg/s rotation rate with the new `FLIP_RATE` parameter (default 400 deg/s, internally constrained to 60..1000 deg/s).

The flip timeout is no longer the fixed 2.5s: it is now twice the time one 360 deg rotation would take at `FLIP_RATE`, i.e. 720/`FLIP_RATE` seconds (1.8s at the default). Since an unachievable rate both shortens the timeout and slows the actual rotation, the page warns that setting a rate above what the vehicle can deliver makes the flip likely to be abandoned part way around.

Added as a new section at the end of flip-mode.rst rather than editing existing text, so it does not conflict with #7759, which rewrites the earlier part of the same page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
