### PR TITLE
common: future-wiki-changes: list FLIP_RATE

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -52,6 +52,7 @@ New Features
 - MAV_CMD_DO_SET_ROI_WPNEXT_OFFSET mission command (point gimbal at next waypoint with an offset), see https://github.com/ArduPilot/ardupilot_wiki/pull/7920
 - Simple/Super Simple mode fix: rotation now correctly applied in more flight modes, including Drift mode and during Precision Landing reposition, see https://github.com/ArduPilot/ardupilot_wiki/pull/7967
 - Tradheli: DDFP tail rotor moved to the RSC controller with independent H_TAIL_RAMP_TIME, see https://github.com/ArduPilot/ardupilot_wiki/pull/7979
+- Flip mode rotation rate is now set by FLIP_RATE, with the flip timeout derived from it, see https://github.com/ArduPilot/ardupilot_wiki/pull/8049
 [/site]
 [site wiki="rover"]
 


### PR DESCRIPTION
Lists ArduPilot/ardupilot#23578 (Flip mode rotation rate parameterized as FLIP_RATE, flip timeout derived from it) in the copter section of the master-only changes page, pointing at #8049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)