### PR TITLE
4.8:29762/MAVn_DEVID

### DIFF
--- a/common/source/docs/common-mavlink-configuration.rst
+++ b/common/source/docs/common-mavlink-configuration.rst
@@ -9,6 +9,12 @@ MAVLink Advanced Configuration
 
 If a serial port protocol is set to MAVLink (``SERIALx_PROTOCOL`` == 1 or 2), then advance configuration options can be set. The first serial port to have the protocol uses the ``MAV1_`` parameters (often the USB port on ``SERIAL0``), the second port will be ``MAV2_``. etc.
 
+DEVICE ID
+=========
+Because the ``MAVx_`` groups are assigned in the order the MAVLink ports are found, which group belongs to which port is not always obvious, and can change if another port's protocol is changed. Each channel therefore reports the device it is attached to in a read-only parameter: :ref:`MAV1_DEVID<MAV1_DEVID>` for the first channel, ``MAV2_DEVID`` for the second, and so on.
+
+The value is an encoded device id, whose meanings are listed with the parameter: the serial ports (``SERIAL0`` through ``SERIAL9``), the :ref:`network ports <common-network>` (``NET_P1`` through ``NET_P4``), the DroneCAN serial tunnel ports (``CAN_D1_UC_S1``, etc.), and the :ref:`scripting <common-lua-scripts>` simulated serial devices (``SCR_SDEV1``, etc.). Zero means no device has been assigned to the channel.
+
 STREAM RATES
 ============
 The following stream rate parameters can be set for each instance of a MAVLink using serial port to determine how fast data is sent over the port(SERIAL1 will be used in the following as an example)


### PR DESCRIPTION
Documents ArduPilot/ardupilot#29762, which adds the read-only `MAVn_DEVID` parameter so a user can work backwards from a `MAVn_` parameter group to the port actually using it — useful because the groups are numbered in port-discovery order, which is not obvious and can shift when another port's protocol changes.

Adds a short "DEVICE ID" section to the MAVLink Advanced Configuration page, right after the paragraph that explains that ordering. The encoded values themselves are already listed in the parameter's own `@Values` metadata (SERIAL0-9, NET_P1-4, CAN UART-over-CAN ports, SCR_SDEV scripting devices), so the page points at that rather than duplicating the table.

The PR's other user-visible change, a `-M`/`--mavlink` option for `Tools/scripts/decode_devid.py`, is not covered: that script is not documented anywhere in the wiki.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
