### PR TITLE
common: future-wiki-changes: list MAVn_DEVID

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -41,6 +41,7 @@ New Features
 - Accel and gyro consistency pre-arm checks now run concurrently, see https://github.com/ArduPilot/ardupilot_wiki/pull/7921
 - EK3_OPTIONS bits for optical flow (terrain alt above rangefinder range, AGL Kalman filter for flow scaling), see https://github.com/ArduPilot/ardupilot_wiki/pull/7962
 - MAV_CMD_DO_SET_MISSION_CURRENT can now reset DO_JUMP repeat counters without changing the current mission item, see https://github.com/ArduPilot/ardupilot_wiki/pull/7982
+- Read-only MAVn_DEVID parameter identifying which port each MAVLink channel's parameter group belongs to, see https://github.com/ArduPilot/ardupilot_wiki/pull/8051
 
 [site wiki="plane"]
 - Rangefinder engagement distance, see https://github.com/ArduPilot/ardupilot_wiki/pull/7559


### PR DESCRIPTION
Lists ArduPilot/ardupilot#29762 (read-only MAVn_DEVID parameter identifying the port each MAVn_ parameter group belongs to) in the all-vehicles New Features list, pointing at #8051.

🤖 Generated with [Claude Code](https://claude.com/claude-code)