### PR TITLE
4.8:33609/Sub Guided PosVelAccel

### DIFF
--- a/sub/source/docs/modes.rst
+++ b/sub/source/docs/modes.rst
@@ -25,6 +25,20 @@ SURFTRAK        Hold distance above seafloor while stabilizing      R
 
 See :ref:`Pilot Control <pilot-control>` for more details on modes.
 
+GUIDED Mode Targets
+===================
+
+In GUIDED mode the vehicle is commanded by a GCS, companion computer or Lua script. Position, velocity and acceleration targets are sent using `SET_POSITION_TARGET_LOCAL_NED <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_LOCAL_NED>`__ or `SET_POSITION_TARGET_GLOBAL_INT <https://mavlink.io/en/messages/common.html#SET_POSITION_TARGET_GLOBAL_INT>`__, with the ``type_mask`` field selecting which of the three are being supplied. The accepted combinations are:
+
+- position only
+- velocity only
+- position and velocity
+- position, velocity and acceleration
+
+Acceleration is used only when it is accompanied by both position and velocity; it is ignored in any other combination. The supplied acceleration is fed forward into the position controller, which lets an external controller or script command a smoothly changing trajectory instead of a series of steps.
+
+Lua scripts can send the same targets with ``vehicle:set_target_posvelaccel_NED()``, and can offset the vehicle's current target using the ``poscontrol`` bindings, ``poscontrol:set_posvelaccel_offset()`` and ``poscontrol:get_posvelaccel_offset()``. The ``guided_above_terrain_posvelaccel_sub.lua`` example script uses these to swim at a constant forward speed while holding a set height above the seafloor.
+
 Mode Specific Parameters
 ========================
 


### PR DESCRIPTION
Documents ArduPilot/ardupilot#33609, which turns ArduSub's `Guided_PosVel` into `Guided_PosVelAccel`: a `SET_POSITION_TARGET_LOCAL_NED` / `SET_POSITION_TARGET_GLOBAL_INT` carrying position + velocity now also accepts an acceleration, which is fed forward into the position controller. Acceleration is used only alongside both position and velocity; every other combination still requires the acceleration bits to be ignored.

The same PR makes the `poscontrol` singleton (`set_posvelaccel_offset` / `get_posvelaccel_offset`) available on Sub and adds the `guided_above_terrain_posvelaccel_sub.lua` example, which holds a constant forward speed while following the seafloor.

The Sub wiki has no Guided-mode page (no `sub-commands-in-guided-mode.rst` equivalent of the Copter/Plane dev-wiki pages), so this adds a short "GUIDED Mode Targets" section to `sub/source/docs/modes.rst`, listing the accepted target combinations and pointing at the scripting route. Happy to spin it out into a proper page instead if you'd rather.

Not covered: the GUIP log message gains aX/aY/aZ and now logs position/velocity in m and m/s as its units always claimed — the Sub log-message page is generated from the source metadata, so it picks that up on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
