### PR TITLE
common: future-wiki-changes: list Sub GUIDED acceleration target

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -58,4 +58,5 @@ New Features
 [/site]
 [site wiki="sub"]
 - Remote (MAVLink) leak detection, see https://github.com/ArduPilot/ardupilot_wiki/pull/7593
+- GUIDED mode accepts an acceleration target alongside position and velocity, see https://github.com/ArduPilot/ardupilot_wiki/pull/8053
 [/site]


### PR DESCRIPTION
Lists ArduPilot/ardupilot#33609 (ArduSub Guided_PosVel becomes Guided_PosVelAccel) in the sub section of the master-only changes page, pointing at #8053.

🤖 Generated with [Claude Code](https://claude.com/claude-code)