### PR TITLE
common: future-wiki-changes: list 4.8 rangefinder, airspeed, quadplane and flap changes

### DIFF
--- a/common/source/docs/common-future-wiki-changes.rst
+++ b/common/source/docs/common-future-wiki-changes.rst
@@ -42,10 +42,15 @@ New Features
 - EK3_OPTIONS bits for optical flow (terrain alt above rangefinder range, AGL Kalman filter for flow scaling), see https://github.com/ArduPilot/ardupilot_wiki/pull/7962
 - MAV_CMD_DO_SET_MISSION_CURRENT can now reset DO_JUMP repeat counters without changing the current mission item, see https://github.com/ArduPilot/ardupilot_wiki/pull/7982
 - Read-only MAVn_DEVID parameter identifying which port each MAVLink channel's parameter group belongs to, see https://github.com/ArduPilot/ardupilot_wiki/pull/8051
+- I2C TFmini Plus lidar can now be powered down above the RNGFNDx_PWRRNG height above terrain, see https://github.com/ArduPilot/ardupilot_wiki/pull/8055
+- ARSPD_TYPE = 20 allows a LUA script to provide the airspeed or differential pressure, see https://github.com/ArduPilot/ardupilot_wiki/pull/8057
 
 [site wiki="plane"]
 - Rangefinder engagement distance, see https://github.com/ArduPilot/ardupilot_wiki/pull/7559
 - QRTL approach now descends gradually to RTL_ALTITUDE instead of stepping down to it, see https://github.com/ArduPilot/ardupilot_wiki/pull/8031
+- Weathervaning is now active while navigating between VTOL waypoints in AUTO, see https://github.com/ArduPilot/ardupilot_wiki/pull/8058
+- Q_RTL_PAUSE_TIME pauses above the landing point before the final VTOL descent, defaulting to 5s on tailsitters, see https://github.com/ArduPilot/ardupilot_wiki/pull/8059
+- Automatic flap speed schedule reworked: target airspeed is used without needing an airspeed sensor, with AIRSPEED_CRUISE as the fallback, see https://github.com/ArduPilot/ardupilot_wiki/pull/8060
 [/site]
 [site wiki="copter"]
 - Ability to abort flip using aux switch low, see https://github.com/ArduPilot/ardupilot_wiki/pull/7759


### PR DESCRIPTION
Adds the Upcoming Features entries for:

- ArduPilot/ardupilot#33712 (I2C TFmini Plus power down above RNGFNDx_PWRRNG) -> #8055
- ArduPilot/ardupilot#33812 (ARSPD_TYPE = 20 scripting backend) -> #8057
- ArduPilot/ardupilot#33836 (weathervaning on VTOL waypoint legs in AUTO, plane section) -> #8058
- ArduPilot/ardupilot#33842 (Q_RTL_PAUSE_TIME landing pause, plane section) -> #8059
- ArduPilot/ardupilot#33995 (flap speed schedule rework, plane section) -> #8060

🤖 Generated with [Claude Code](https://claude.com/claude-code)