### PR TITLE
4.8:33995/Plane flap speed

### DIFF
--- a/plane/source/docs/automatic-flaps.rst
+++ b/plane/source/docs/automatic-flaps.rst
@@ -22,10 +22,21 @@ The target speed can be commanded by changing the value of cruise_speed
 in the parameter interface, by using the Do_Set_Speed command in a
 mission, or by the throttle stick position in FBW-B.
 
+An airspeed sensor is not required: the target speed is used whether or
+not one is fitted. If the current mode does not set a target speed, then
+:ref:`AIRSPEED_CRUISE<AIRSPEED_CRUISE>` is used instead.
+
 :ref:`FLIGHT_OPTIONS<FLIGHT_OPTIONS>` bit 15 set
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-- In manual throttle modes actual airspeed (or estimate) is used for flaps activation
-- In auto-throttle modes the minimum of target airspeed and actual airspeed is used
+- In manual throttle modes the measured airspeed is used for flaps activation
+- In auto-throttle modes the minimum of target airspeed and measured airspeed is used
+
+Using the measured airspeed requires that airspeed is actually in use for
+control, ie an airspeed sensor is fitted and enabled with
+:ref:`ARSPD_USE<ARSPD_USE>` = 1, or synthetic airspeed is enabled. If it is
+not, the flap schedule falls back to the target speed, or to
+:ref:`AIRSPEED_CRUISE<AIRSPEED_CRUISE>` in modes which do not set one, exactly
+as it does with bit 15 clear.
 
 This allows for auto flaps in manual throttle modes, and when speed drops in an un-commanded fashion in auto-throttle modes. This needs to be used with caution and carefully tested on an aircraft as it could result in an oscillation, as adding flaps can change the airspeed.
 


### PR DESCRIPTION
Updates the automatic flaps page for the flap speed rework in ArduPilot/ardupilot#33995 (master / 4.8 only).

The page described behaviour that no longer holds:

- the target speed is now used whether or not an airspeed sensor is fitted, and modes with no target fall back to AIRSPEED_CRUISE (previously the cruise throttle percentage was compared against the flap speeds)
- with FLIGHT_OPTIONS bit 15 set, the measured airspeed is only used when airspeed is in use for control (ARSPD_USE = 1, or synthetic airspeed); otherwise the schedule falls back to the target speed or AIRSPEED_CRUISE

🤖 Generated with [Claude Code](https://claude.com/claude-code)