### PR TITLE
4.8:33891/33937/Follow retarget

### DIFF
--- a/copter/source/docs/follow-mode.rst
+++ b/copter/source/docs/follow-mode.rst
@@ -16,7 +16,7 @@ The altitude is maintained with the altitude hold controller so the vehicle will
 The following parameters can be used to tune Follow Mode's performance:
 
 -  :ref:`FOLL_ENABLE <FOLL_ENABLE>`: set to 1 to enable follow mode and refresh parameters
--  :ref:`FOLL_SYSID <FOLL_SYSID>`: MAVLink system id of lead vehicle ("0" means follow the first vehicle "seen")
+-  :ref:`FOLL_SYSID <FOLL_SYSID>`: MAVLink system id of the lead vehicle. This must be set explicitly; "0" means no lead vehicle has been selected and Follow is inactive
 -  :ref:`FOLL_DIST_MAX <FOLL_DIST_MAX>`: if lead vehicle is more than this many meters away, give up on following and hold position
 -  :ref:`FOLL_OFS_X <FOLL_OFS_X>`, :ref:`FOLL_OFS_Y <FOLL_OFS_Y>`, :ref:`FOLL_OFS_Z <FOLL_OFS_Z>`: 3D offset (in meters) from the lead vehicle
 -  :ref:`FOLL_OFS_TYPE <FOLL_OFS_TYPE>`: set to 0 if offsets are North-East-Down, 1 if offsets are relative to lead vehicle's heading
@@ -52,3 +52,12 @@ an unexpected height.
    mismatch between the two vehicles' home altitudes. If the follower consistently flies too
    high or too low by roughly the difference in take-off elevations, "relative" is the wrong
    choice for that setup.
+
+Changing the Lead Vehicle
+=========================
+
+:ref:`FOLL_SYSID<FOLL_SYSID>` may be changed while flying, for example by a Lua script switching between two beacons. The position, velocity and heading held for the previous lead vehicle are discarded as soon as the parameter changes, so the follower has no target and holds its current position until the newly selected vehicle is heard from. Tracking then restarts from that vehicle's position, rather than being smoothed across from the old one.
+
+The type of position message in use is also reset by the change, so if the previous lead vehicle was sending ``FOLLOW_TARGET``, ``GLOBAL_POSITION_INT`` from the new lead vehicle is accepted immediately.
+
+Setting :ref:`FOLL_SYSID<FOLL_SYSID>` to "0" deselects the lead vehicle altogether, and nothing is followed until a non-zero system id is set. Earlier firmware treated "0" as "follow the first vehicle seen" and wrote that vehicle's system id into the parameter; it no longer does either, so the lead vehicle must always be selected explicitly.

--- a/rover/source/docs/follow-mode.rst
+++ b/rover/source/docs/follow-mode.rst
@@ -29,11 +29,20 @@ If using QGroundControl ensure the Application setting under the General tab ``S
 The following parameters can be used to tune Follow mode's performance:
 
 -  :ref:`FOLL_ENABLE <FOLL_ENABLE>`: set to 1 to enable follow mode and refresh parameters.
--  :ref:`FOLL_SYSID <FOLL_SYSID>`: MAVLink system id of lead vehicle ("0" means follow the first vehicle "seen").
+-  :ref:`FOLL_SYSID <FOLL_SYSID>`: MAVLink system id of the lead vehicle. This must be set explicitly; "0" means no lead vehicle has been selected and Follow is inactive.
 -  :ref:`FOLL_DIST_MAX <FOLL_DIST_MAX>`: if lead vehicle is more than this many meters away, give up on following and hold position (loiter if boat, stop if ground vehicle).
 -  :ref:`FOLL_OFS_X <FOLL_OFS_X>`, :ref:`FOLL_OFS_Y <FOLL_OFS_Y>`, :ref:`FOLL_OFS_Z <FOLL_OFS_Z>` (not used in Rover) : 3D offset (in meters) from the lead vehicle. If they are zero, then the current vehicle's offset from the follow target at time of mode entry is used every time. These offsets can be altered via Mavlink and will take effect immediately. However, if they were originally zero and changed during FOLLOW MODE rather than during another mode, they will be reset to zero for the next entry into FOLLOW mode, until a reboot occurs and then the changed offsets will be restored. 
 -  :ref:`FOLL_OFS_TYPE <FOLL_OFS_TYPE>`: set to 0 if offsets are North-East (NED), 1 if offsets are relative to lead vehicle's heading, see diagrams below.
 -  :ref:`FOLL_POS_P <FOLL_POS_P>`: gain which controls how aggressively this vehicle moves towards lead vehicle (limited by :ref:`WP_SPD<WP_SPD>`)
+
+Changing the Lead Vehicle
+=========================
+
+:ref:`FOLL_SYSID<FOLL_SYSID>` may be changed while driving. The position, velocity and heading held for the previous lead vehicle are discarded as soon as the parameter changes, so the follower has no target and stops until the newly selected vehicle is heard from. Tracking then restarts from that vehicle's position, rather than being smoothed across from the old one.
+
+The type of position message in use is also reset by the change, so if the previous lead vehicle was sending ``FOLLOW_TARGET``, ``GLOBAL_POSITION_INT`` from the new lead vehicle is accepted immediately.
+
+Setting :ref:`FOLL_SYSID<FOLL_SYSID>` to "0" deselects the lead vehicle altogether, and nothing is followed until a non-zero system id is set. Earlier firmware treated "0" as "follow the first vehicle seen" and wrote that vehicle's system id into the parameter; it no longer does either, so the lead vehicle must always be selected explicitly.
 
 .. image:: ../images/FollowMode.jpg
    :target: ../_images/FollowMode.jpg


### PR DESCRIPTION
Documents two merged AP_Follow changes on the Copter and Rover Follow mode pages.

ArduPilot/ardupilot#33891 (AP_Follow: discard target state when FOLL_SYSID changes):
- changing `FOLL_SYSID` now discards the position, velocity and heading held for the previous lead vehicle, so following pauses (Copter holds position, Rover stops) until the newly selected vehicle transmits, and tracking then restarts from that vehicle's position instead of being smoothed across the change
- the `FOLLOW_TARGET` preference is also cleared, so `GLOBAL_POSITION_INT` from the new lead vehicle is accepted immediately

ArduPilot/ardupilot#33937 (AP_Follow: remove auto sysid):
- `FOLL_SYSID` = 0 no longer means "follow the first vehicle seen", and the parameter is no longer overwritten with an adopted system id, so the lead vehicle must be selected explicitly. The old wording was still on both pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
